### PR TITLE
Fix default CAN bitrate

### DIFF
--- a/backend/can/feature.py
+++ b/backend/can/feature.py
@@ -53,7 +53,7 @@ class CANBusFeature(Feature):
         self.config = {
             "interfaces": config_dict.get("interfaces", ["vcan0"]),
             "bustype": config_dict.get("bustype", "socketcan"),
-            "bitrate": config_dict.get("bitrate", 250000),
+            "bitrate": config_dict.get("bitrate", 500000),
             "poll_interval": config_dict.get("poll_interval", 0.1),  # seconds
             "simulate": config_dict.get("simulate", False),
         }

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -26,7 +26,7 @@ class CANBusSettings(BaseModel):
 
     bustype: str = Field(default="socketcan")
     channels: list[str] = Field(default=["vcan0"])
-    bitrate: int = Field(default=250000)
+    bitrate: int = Field(default=500000)
 
     @field_validator("channels", mode="before")
     @classmethod


### PR DESCRIPTION
## Summary
- use 500000 as the default CAN bitrate in app settings and CAN feature

## Testing
- `pytest tests/core/test_config.py::TestSettings::test_can_configuration_defaults -q`
- `pytest -q` *(fails: 14 failed, 363 passed, 1 skipped, 3 warnings, 12 errors)*

------
https://chatgpt.com/codex/tasks/task_e_683f5fdbc61483288710893e11ac94f6