### PR TITLE
Fix CAN bus listener start flag

### DIFF
--- a/backend/can/feature.py
+++ b/backend/can/feature.py
@@ -104,6 +104,9 @@ class CANBusFeature(Feature):
         This method is called automatically by the FeatureManager.
         """
         logger.info("Starting CAN bus feature")
+        # Mark the feature as running before spawning listener/simulation tasks
+        # so that they don't exit immediately when checking this flag.
+        self._is_running = True
 
         # Load RVC decoder configuration
         try:
@@ -218,7 +221,6 @@ class CANBusFeature(Feature):
                 logger.error(f"Failed to start CAN bus listeners: {e}", exc_info=True)
                 return
 
-        self._is_running = True
 
     async def _setup_can_listeners(self) -> None:
         """Set up CAN message listeners for all active interfaces using python-can's asyncio support."""


### PR DESCRIPTION
## Summary
- fix CANBusFeature startup ordering so listeners/simulation run

## Testing
- `pytest -q` *(fails: usage: pytest [options] [file_or_dir] [file_or_dir] [...])*

------
https://chatgpt.com/codex/tasks/task_e_6845137c0bf483288fd2c5257d89d91f