### PR TITLE
fix(tests): restore 2 more clusters + 7 production bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -264,3 +264,6 @@ alembic/logs/
 /.mcp.json
 
 prompt.txt
+
+# Notification reporting service runtime output
+/reports/

--- a/backend/core/service_registry.py
+++ b/backend/core/service_registry.py
@@ -31,13 +31,26 @@ from backend.core.service_lifecycle import (
 
 
 class ServiceStatus(Enum):
-    """Service lifecycle status."""
+    """Service lifecycle status.
+
+    Lifecycle order during a normal run:
+        PENDING -> STARTING -> HEALTHY (-> DEGRADED) -> STOPPED
+    Failure paths transition to FAILED at any step.
+
+    STOPPED is used both pre-startup (initial state for services that
+    have been registered but not yet brought up) and post-shutdown
+    (after _shutdown_service successfully tears a service down). The
+    enum's previous omission of STOPPED meant services kept their last
+    runtime status forever after shutdown, which broke any caller that
+    needed to distinguish 'still running' from 'cleanly stopped'.
+    """
 
     PENDING = "PENDING"
     STARTING = "STARTING"
     HEALTHY = "HEALTHY"
     DEGRADED = "DEGRADED"
     FAILED = "FAILED"
+    STOPPED = "STOPPED"
 
 
 class ServiceRegistry:
@@ -200,7 +213,17 @@ class ServiceRegistry:
             await self._shutdown_service(service_name)
 
     async def _shutdown_service(self, name: str):
-        """Shutdown individual service."""
+        """Shutdown individual service.
+
+        Sets the registry's tracked status to STOPPED on success so callers
+        can distinguish 'still running' from 'cleanly stopped'. Without
+        this, services kept their last runtime status (HEALTHY, DEGRADED,
+        etc.) forever after shutdown, which broke any caller that needed
+        to make lifecycle decisions post-teardown.
+
+        On failure the status is left as FAILED -- a partial-shutdown
+        state is itself a failure mode worth surfacing.
+        """
         try:
             service = self._services.get(name)
             if service and hasattr(service, "shutdown"):
@@ -208,8 +231,13 @@ class ServiceRegistry:
                     await service.shutdown()
                 else:
                     service.shutdown()
+            # Mark stopped after a successful shutdown call (or trivial
+            # no-op for services without a shutdown method, which is fine).
+            if name in self._service_status:
+                self._service_status[name] = ServiceStatus.STOPPED
         except Exception:
-            pass
+            if name in self._service_status:
+                self._service_status[name] = ServiceStatus.FAILED
 
     async def _emergency_cleanup(self):
         """Emergency cleanup of partially initialized services."""

--- a/backend/integrations/notifications/channels/webhook.py
+++ b/backend/integrations/notifications/channels/webhook.py
@@ -70,6 +70,19 @@ class WebhookAuthConfig(BaseModel):
         return v
 
 
+# HTTP status code class boundaries used by the retry-decision logic
+# below. Named so the conditions read as intent rather than as magic
+# numbers (also satisfies ruff PLR2004).
+_HTTP_CLIENT_ERROR_MIN = 400  # Inclusive lower bound of the 4xx range
+_HTTP_SERVER_ERROR_MIN = 500  # Inclusive lower bound of the 5xx range
+
+# Maximum response-body length kept on the WebhookDeliveryResult before
+# truncation. Webhook responses are usually short, but a misconfigured
+# endpoint can return arbitrarily large payloads (HTML error pages, etc.)
+# that we don't want to keep in memory or write to logs.
+_RESPONSE_BODY_MAX_BYTES = 1000
+
+
 class WebhookTarget(BaseModel):
     """Configuration for a webhook target endpoint."""
 
@@ -367,8 +380,8 @@ class WebhookNotificationChannel:
                 response_body = await response.text()
 
                 # Truncate long responses
-                if len(response_body) > 1000:
-                    response_body = response_body[:1000] + "... (truncated)"
+                if len(response_body) > _RESPONSE_BODY_MAX_BYTES:
+                    response_body = response_body[:_RESPONSE_BODY_MAX_BYTES] + "... (truncated)"
 
                 duration_ms = (time.time() - start_time) * 1000
 
@@ -433,11 +446,8 @@ class WebhookNotificationChannel:
         if status_code is None:
             # Network error / timeout -- transient, retry.
             return True
-        if 400 <= status_code < 500:
-            # 4xx client error -- not transient, don't retry.
-            return False
-        # 5xx server error (or anything else non-2xx) -- retry.
-        return True
+        # 4xx (client error) -- don't retry; anything else (5xx etc.) -- retry.
+        return not _HTTP_CLIENT_ERROR_MIN <= status_code < _HTTP_SERVER_ERROR_MIN
 
     async def send_notification(self, notification: NotificationPayload) -> bool:
         """
@@ -502,9 +512,11 @@ class WebhookNotificationChannel:
                 result = await self._deliver_to_target(notification, target)
 
                 self.logger.info(
-                    f"Webhook delivery to {target_name}: "
-                    f"{'SUCCESS' if result.success else 'FAILED'} "
-                    f"(status: {result.status_code}, duration: {result.duration_ms:.1f}ms)"
+                    "Webhook delivery to %s: %s (status: %s, duration: %.1fms)",
+                    target_name,
+                    "SUCCESS" if result.success else "FAILED",
+                    result.status_code,
+                    result.duration_ms,
                 )
 
                 if result.success:
@@ -517,16 +529,20 @@ class WebhookNotificationChannel:
                 # already rejected -- retrying just wastes attempts.
                 if not self._should_retry_status(result.status_code):
                     self.logger.info(
-                        f"Webhook delivery to {target_name} failed with non-retryable "
-                        f"status {result.status_code}; no further attempts."
+                        "Webhook delivery to %s failed with non-retryable status %s; "
+                        "no further attempts.",
+                        target_name,
+                        result.status_code,
                     )
                     break
 
                 if attempt == max_attempts - 1:
                     # Final attempt failed
                     self.logger.error(
-                        f"Webhook delivery to {target_name} failed after {max_attempts} attempts: "
-                        f"{result.error_message}"
+                        "Webhook delivery to %s failed after %s attempts: %s",
+                        target_name,
+                        max_attempts,
+                        result.error_message,
                     )
 
             # Per-target outcome roll-up.

--- a/backend/integrations/notifications/channels/webhook.py
+++ b/backend/integrations/notifications/channels/webhook.py
@@ -27,7 +27,7 @@ import hmac
 import json
 import logging
 import time
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 
 import aiohttp
@@ -91,7 +91,12 @@ class WebhookTarget(BaseModel):
 
     # Retry configuration
     max_retries: int = Field(3, description="Maximum retry attempts")
-    retry_delay: int = Field(1, description="Initial retry delay in seconds")
+    # retry_delay accepts fractional seconds so callers can request sub-second
+    # backoff for testing / local-dev. Production CAN-bus politeness still
+    # benefits from longer real-world delays, but locking the type to int
+    # forced a 1s minimum that made test iteration painful and offered no
+    # real safety guarantee.
+    retry_delay: float = Field(1.0, description="Initial retry delay in seconds")
     retry_exponential: bool = Field(True, description="Use exponential backoff")
 
     # Security
@@ -367,15 +372,13 @@ class WebhookNotificationChannel:
 
                 duration_ms = (time.time() - start_time) * 1000
 
-                # Check if successful
+                # Check if successful. We deliberately DO NOT update stats
+                # here -- _deliver_to_target is per-attempt, but stats counters
+                # (successful_requests / failed_requests / last_*) are
+                # per-notification semantics, owned by send_notification's
+                # outer loop. Mixing the two led to double-counting on every
+                # retried failure.
                 success = 200 <= response.status < 300
-
-                if success:
-                    self.stats["successful_requests"] += 1
-                    self.stats["last_success"] = datetime.utcnow()
-                else:
-                    self.stats["failed_requests"] += 1
-                    self.stats["last_failure"] = datetime.utcnow()
 
                 return WebhookDeliveryResult(
                     success=success,
@@ -388,8 +391,6 @@ class WebhookNotificationChannel:
 
         except TimeoutError:
             duration_ms = (time.time() - start_time) * 1000
-            self.stats["failed_requests"] += 1
-            self.stats["last_failure"] = datetime.utcnow()
 
             return WebhookDeliveryResult(
                 success=False,
@@ -402,8 +403,6 @@ class WebhookNotificationChannel:
 
         except Exception as e:
             duration_ms = (time.time() - start_time) * 1000
-            self.stats["failed_requests"] += 1
-            self.stats["last_failure"] = datetime.utcnow()
 
             return WebhookDeliveryResult(
                 success=False,
@@ -413,6 +412,32 @@ class WebhookNotificationChannel:
                 duration_ms=duration_ms,
                 attempt_number=notification.retry_count + 1,
             )
+
+    @staticmethod
+    def _should_retry_status(status_code: int | None) -> bool:
+        """Decide whether a delivery attempt should trigger a retry.
+
+        Industry-standard webhook delivery (Stripe, GitHub, etc.) only
+        retries on transient failures:
+        - 5xx server errors (server might recover)
+        - Network errors / timeouts (status_code is None)
+
+        4xx client errors are NOT retried because the server has told us
+        the request itself is wrong (auth failure, malformed payload,
+        unknown endpoint, etc.) -- retrying wastes attempts and adds load
+        without ever succeeding. Production was previously retrying every
+        failure type, which surfaced as the test_failed_delivery_4xx
+        regression: a 4xx response would consume max_retries+1 attempts
+        and inflate failed_requests beyond the per-notification count.
+        """
+        if status_code is None:
+            # Network error / timeout -- transient, retry.
+            return True
+        if 400 <= status_code < 500:
+            # 4xx client error -- not transient, don't retry.
+            return False
+        # 5xx server error (or anything else non-2xx) -- retry.
+        return True
 
     async def send_notification(self, notification: NotificationPayload) -> bool:
         """
@@ -441,6 +466,15 @@ class WebhookNotificationChannel:
         successful_deliveries = 0
         total_targets = 0
 
+        # Track whether ANY target succeeded and whether ANY target failed,
+        # independently. This supports per-notification stats with
+        # partial-success semantics: a notification can simultaneously bump
+        # successful_requests (at least one target succeeded -> the operator
+        # was reached) AND failed_requests (at least one target failed ->
+        # an operator may want to investigate the broken endpoint).
+        any_target_succeeded = False
+        any_target_failed = False
+
         # Deliver to all applicable targets
         for target_name, target in self.targets.items():
             if not self._should_deliver_to_target(notification, target):
@@ -448,6 +482,7 @@ class WebhookNotificationChannel:
 
             total_targets += 1
             max_attempts = target.max_retries + 1
+            target_succeeded = False
 
             for attempt in range(max_attempts):
                 if attempt > 0:
@@ -474,13 +509,47 @@ class WebhookNotificationChannel:
 
                 if result.success:
                     successful_deliveries += 1
+                    target_succeeded = True
                     break  # Success, no need to retry
+
+                # Decide whether to retry. 4xx responses are not retried
+                # because they indicate a client-side error the server has
+                # already rejected -- retrying just wastes attempts.
+                if not self._should_retry_status(result.status_code):
+                    self.logger.info(
+                        f"Webhook delivery to {target_name} failed with non-retryable "
+                        f"status {result.status_code}; no further attempts."
+                    )
+                    break
+
                 if attempt == max_attempts - 1:
                     # Final attempt failed
                     self.logger.error(
                         f"Webhook delivery to {target_name} failed after {max_attempts} attempts: "
                         f"{result.error_message}"
                     )
+
+            # Per-target outcome roll-up.
+            if target_succeeded:
+                any_target_succeeded = True
+            else:
+                any_target_failed = True
+
+        # Update per-notification stat counters once. successful_requests
+        # and failed_requests are independent: a partial-success
+        # notification (one target OK, another not) bumps BOTH counters,
+        # because the operator dashboard cares about both "did the
+        # message get out at all?" (successful_requests) and "is some
+        # endpoint broken?" (failed_requests). last_success / last_failure
+        # track the most recent notification with that outcome type, not
+        # the most recent attempt.
+        now = datetime.now(UTC)
+        if any_target_succeeded:
+            self.stats["successful_requests"] += 1
+            self.stats["last_success"] = now
+        if any_target_failed:
+            self.stats["failed_requests"] += 1
+            self.stats["last_failure"] = now
 
         # Return True if at least one delivery succeeded
         return successful_deliveries > 0

--- a/backend/repositories/persistence_repository.py
+++ b/backend/repositories/persistence_repository.py
@@ -261,7 +261,12 @@ class PersistenceRepository(MonitoredRepository):
         if not backup_dir.exists():
             return 0
 
-        cutoff_date = datetime.now() - timedelta(days=self._backup_retention_days)
+        # cutoff is offset-aware (UTC) to match modified_at, which uses
+        # tz=UTC below. Mixing naive and aware datetimes raises TypeError
+        # at comparison time -- which used to silently fail this method
+        # before the fromtimestamp(tz=UTC) hardening landed. Both sides
+        # must be timezone-aware for the < comparison to work.
+        cutoff_date = datetime.now(UTC) - timedelta(days=self._backup_retention_days)
         deleted_count = 0
 
         for backup_file in backup_dir.glob("*.db"):
@@ -272,7 +277,7 @@ class PersistenceRepository(MonitoredRepository):
                     deleted_count += 1
                     logger.debug(f"Deleted old backup: {backup_file}")
             except Exception as e:
-                logger.warning(f"Failed to delete backup {backup_file}: {e}")
+                logger.warning("Failed to delete backup %s: %s", backup_file, e)
 
         if deleted_count > 0:
             logger.info(f"Cleaned up {deleted_count} old backups")

--- a/backend/services/notification_analytics_service.py
+++ b/backend/services/notification_analytics_service.py
@@ -82,9 +82,17 @@ class NotificationAnalyticsService:
             flush_interval=30.0,
         )
 
-        self._reporting_service = NotificationReportingService(
-            self._repository, performance_monitor, database_manager
-        )
+        # The reporting service needs the analytics-service public API
+        # (get_channel_metrics, get_aggregated_metrics, analyze_errors,
+        # get_queue_health) because every report template invokes those
+        # methods. We hand it `self` so it can call back; this is a
+        # normal orchestrator-with-helpers composition, not a leak. The
+        # previous wiring passed `(self._repository, performance_monitor,
+        # database_manager)` -- a stale signature from an earlier refactor
+        # that no longer matches NotificationReportingService.__init__,
+        # raising `TypeError: takes 3 positional arguments but 4 were
+        # given` on every analytics-service construction.
+        self._reporting_service = NotificationReportingService(database_manager, self)
 
         # Background task management
         self._task_manager = BackgroundTaskManager()

--- a/backend/services/pin_manager.py
+++ b/backend/services/pin_manager.py
@@ -275,13 +275,12 @@ class PINManager:
         # immediately so we don't leave a side-effect from the rotation
         # flow. validate_pin returns a PINValidationResult with .success
         # and .session_id; .session_id is None on failure.
-        validation = await self.validate_pin(
-            user_id=user_id, pin=old_pin, pin_type=pin_type
-        )
-        if not validation.success or validation.session_id is None:
+        validation = await self.validate_pin(user_id=user_id, pin=old_pin, pin_type=pin_type)
+        if validation.session_id is None or not validation.success:
             logger.warning(
-                f"PIN rotation rejected for user {user_id} type {pin_type}: "
-                f"old PIN verification failed"
+                "PIN rotation rejected for user %s type %s: old PIN verification failed",
+                user_id,
+                pin_type,
             )
             return False
 
@@ -322,7 +321,7 @@ class PINManager:
         pin.is_active = False
         pin.updated_at = datetime.now(UTC)
         await self.db_session.commit()
-        logger.info(f"PIN deactivated for user {user_id} type {pin_type}")
+        logger.info("PIN deactivated for user %s type %s", user_id, pin_type)
         return True
 
     def _validate_pin_format(self, pin: str) -> bool:

--- a/backend/services/pin_manager.py
+++ b/backend/services/pin_manager.py
@@ -227,6 +227,104 @@ class PINManager:
         )
         return True
 
+    async def create_pin(
+        self,
+        user_id: str,
+        pin: str,
+        pin_type: str,
+        description: str | None = None,
+    ) -> bool:
+        """
+        Create a new PIN (or update if one of the same type exists).
+
+        This is the operator-facing public API: callers spell their intent
+        ("I'm creating a PIN") and the audit log records that, even though
+        the underlying storage operation is the same set-or-update as
+        ``set_pin``. The argument order (``user_id, pin, pin_type, ...``)
+        matches the convention used by ``validate_pin`` and the broader
+        PIN-management surface; ``set_pin`` predates this and uses
+        ``(user_id, pin_type, pin, ...)`` for historical reasons.
+        """
+        return await self.set_pin(
+            user_id=user_id, pin_type=pin_type, pin=pin, description=description
+        )
+
+    async def rotate_pin(
+        self,
+        user_id: str,
+        pin_type: str,
+        old_pin: str,
+        new_pin: str,
+    ) -> bool:
+        """
+        Rotate a PIN: verify the current PIN, then replace it with a new one.
+
+        Verifying the old PIN before accepting the rotation prevents an
+        attacker who only has session-level access (but not the current
+        PIN) from silently changing it. This is the standard contract for
+        end-user-driven credential rotation.
+
+        Returns True on success, False if old_pin verification fails.
+        """
+        if not self.db_session:
+            msg = "Database session not available"
+            raise RuntimeError(msg)
+
+        # Verify the current PIN by attempting to validate it. If validation
+        # succeeds, the PIN was correct; revoke that throwaway session
+        # immediately so we don't leave a side-effect from the rotation
+        # flow. validate_pin returns a PINValidationResult with .success
+        # and .session_id; .session_id is None on failure.
+        validation = await self.validate_pin(
+            user_id=user_id, pin=old_pin, pin_type=pin_type
+        )
+        if not validation.success or validation.session_id is None:
+            logger.warning(
+                f"PIN rotation rejected for user {user_id} type {pin_type}: "
+                f"old PIN verification failed"
+            )
+            return False
+
+        await self.revoke_session(validation.session_id)
+
+        # Set the new PIN via the same set-or-update path used by create_pin.
+        return await self.set_pin(user_id=user_id, pin_type=pin_type, pin=new_pin)
+
+    async def deactivate_pin(self, user_id: str, pin_type: str) -> bool:
+        """
+        Deactivate (soft-delete) a PIN by clearing its is_active flag.
+
+        Soft-deletion preserves the audit trail (the PIN row stays in the
+        database with its hash and creation history) while ensuring
+        ``validate_pin`` refuses to mint a session for it. Hard deletion
+        would lose the audit signal.
+
+        Returns True if a matching active PIN was found and deactivated,
+        False if no active PIN of that type existed.
+        """
+        if not self.db_session:
+            msg = "Database session not available"
+            raise RuntimeError(msg)
+
+        result = await self.db_session.execute(
+            select(UserPIN).where(
+                and_(
+                    UserPIN.user_id == user_id,
+                    UserPIN.pin_type == pin_type,
+                    UserPIN.is_active.is_(True),
+                )
+            )
+        )
+        pin = result.scalar_one_or_none()
+        if pin is None:
+            return False
+
+        pin.is_active = False
+        pin.updated_at = datetime.now(UTC)
+        await self.db_session.commit()
+        logger.info(f"PIN deactivated for user {user_id} type {pin_type}")
+        return True
+
     def _validate_pin_format(self, pin: str) -> bool:
         """Validate PIN format requirements."""
         if len(pin) < self.config.min_pin_length or len(pin) > self.config.max_pin_length:

--- a/tests/test_webhook_channel.py
+++ b/tests/test_webhook_channel.py
@@ -122,8 +122,19 @@ class TestWebhookNotificationChannel:
 
     @pytest.fixture
     def channel(self):
-        """Create webhook channel for testing."""
-        return WebhookNotificationChannel()
+        """Create webhook channel for testing.
+
+        WebhookChannelConfig.enabled defaults to False (production opt-in
+        security default; webhook notifications shouldn't fire unless an
+        operator explicitly enables them via
+        COACHIQ_NOTIFICATIONS__WEBHOOK__ENABLED=true). Tests in this class
+        need the channel enabled to exercise the delivery paths, so flip
+        the flag after construction rather than mutating the global
+        settings object.
+        """
+        ch = WebhookNotificationChannel()
+        ch.enabled = True
+        return ch
 
     @pytest.fixture
     def test_target(self):
@@ -151,7 +162,10 @@ class TestWebhookNotificationChannel:
     def test_channel_initialization(self, channel):
         """Test channel initialization."""
         assert channel.channel == NotificationChannel.WEBHOOK
-        assert channel.enabled is True  # Default from config
+        # The fixture explicitly enables the channel; the production default
+        # is False (opt-in security default). Asserting True here just
+        # confirms the fixture's flip took effect.
+        assert channel.enabled is True
         assert channel.targets == {}
         assert channel.stats["total_requests"] == 0
 
@@ -358,8 +372,12 @@ class TestWebhookDelivery:
 
     @pytest.fixture
     def channel(self):
-        """Create webhook channel for testing."""
-        return WebhookNotificationChannel()
+        """Create webhook channel for testing. See
+        TestWebhookNotificationChannel.channel for the rationale on
+        flipping `enabled` after construction."""
+        ch = WebhookNotificationChannel()
+        ch.enabled = True
+        return ch
 
     @pytest.fixture
     def test_target(self):
@@ -607,6 +625,10 @@ class TestWebhookIntegration:
     async def test_real_webhook_delivery(self):
         """Test delivery to a real webhook endpoint (httpbin.org)."""
         channel = WebhookNotificationChannel()
+        # Production default is `enabled=False` (security opt-in); flip it
+        # for the test scenario. See TestWebhookNotificationChannel.channel
+        # fixture for the rationale.
+        channel.enabled = True
         target = WebhookTarget(
             name="httpbin-test",
             url="https://httpbin.org/post",
@@ -635,6 +657,8 @@ class TestWebhookIntegration:
     async def test_unreachable_endpoint(self):
         """Test delivery to unreachable endpoint."""
         channel = WebhookNotificationChannel()
+        # See test_real_webhook_delivery for rationale on flipping `enabled`.
+        channel.enabled = True
         target = WebhookTarget(
             name="unreachable",
             url="https://unreachable.example.invalid/webhook",


### PR DESCRIPTION
## Summary

Continues the test-suite restoration work from PR #89. This PR restores **2 more test clusters** (`test_webhook_channel` from 12-fail to 44/44, partial progress on `test_pin_manager_db` from 0/12 to 5/12) and lands **7 new production bug fixes** surfaced by the failing tests.

## Production bugs fixed

1. **`NotificationAnalyticsService.__init__`** was constructing `NotificationReportingService` with the wrong arg signature → broke every analytics REST endpoint at startup. (commit `2510827`)
2. **`ServiceStatus` enum was missing `STOPPED`** + `_shutdown_service` never updated status post-shutdown → services kept their last runtime status forever after teardown. (commit `664bac5`)
3. **`persistence_repository._cleanup_old_backups`** had silent broken backup cleanup since PR #89 — `datetime.fromtimestamp(tz=UTC)` (offset-aware) being compared to `datetime.now()` (offset-naive) raised `TypeError` that was silently caught. Backups would have accumulated forever. (commit `664bac5`)
4. **`WebhookChannelConfig.retry_delay`** typed as `int` → forced 1s minimum retry delay; no callers can request sub-second backoff. Changed to `float`. (commit `3fd70ca`)
5. **`WebhookNotificationChannel` stat counters were per-attempt** but `total_requests` was per-notification — three counters with incoherent semantics. Refactored `_deliver_to_target` to be pure data; per-notification stat updates now happen once at end of `send_notification`. (commit `3fd70ca`)
6. **Webhook retry loop retried 4xx responses** — server explicitly told us the request itself is wrong; retrying wastes attempts. Added `_should_retry_status()` helper following Stripe/GitHub webhook contract (only retry 5xx + network errors). (commit `3fd70ca`)
7. **Webhook partial-success notifications under-counted** — when one target succeeded and another failed, only `successful_requests` bumped. Operator dashboard needs both signals. Reworked roll-up so the two counters are independent. (commit `3fd70ca`)

Plus 3 new public-API methods on PINManager (`create_pin`, `rotate_pin`, `deactivate_pin`) — operator-facing wrappers + new functionality (rotation requires old-PIN verification; deactivation soft-deletes for audit preservation). (commit `0474815`)

## Test cluster status

- `test_webhook_channel`: 12 failed / 32 passed → **44/44 passing**
- `test_pin_manager_db`: 0/12 passed → **5/12 passed** (remaining 7 failures all trace to one root cause documented in follow-up prompt)
- All 13 earlier-fixed clusters from PR #89: **306/307 passing** (the 1 known pre-existing pollution failure is documented in handoff memory)

## Follow-up work

Three subagent prompts have been written for the deeper architectural work that surfaced during this triage but didn't fit a single PR:

- `notification-analytics-architecture` — restoring `test_notification_analytics` (12 failures from architectural drift)
- `safety-integration-test-restoration` — fixture rewrite for `test_safety_integration` (14 errors from `register_service` signature change)
- `pin-manager-db-test-restoration` — finishing the cluster started in this PR (12 `validate_pin` call sites need updating for the richer `PINValidationResult` return type)
- `notification-integration-test-restoration` — multi-group failures in `test_notification_integration`

These live on a separate branch `chore/prompt-notification-analytics-followup` (PR follows).

## Local CI

`./scripts/ci-quality-gate.sh` passes all stages locally. The line-level diff-aware ruff filter from PR #89 means only NEW issues on changed lines block.