### PR TITLE
chore(prompts): add 4 subagent prompts for follow-up test-restoration work

### DIFF
--- a/.github/prompts/notification-analytics-architecture.prompt.md
+++ b/.github/prompts/notification-analytics-architecture.prompt.md
@@ -1,0 +1,262 @@
+# Subagent task: restore tests/test_notification_analytics.py
+
+You are picking up work mid-stream on `fix/test-suite-restoration-2`,
+which is branched off the latest `main` of the
+[carpenike/coachiq](https://github.com/carpenike/coachiq) repo. PR #89
+("restore test suite — 8 clusters, +194 passing tests") was merged
+recently. This task is the deep architectural work that I peeled out
+of that PR because it's much larger than a normal "fix one test
+cluster" job.
+
+## Read first
+
+These three repo-memory files set the framing — start here, in this
+order. Don't drift from the architectural framing on the first one in
+particular:
+
+1. `/memories/repo/coachiq-architecture.md` — pins what CoachIQ IS and
+   IS NOT. CoachIQ is a CAN-bus orchestration layer that talks to a
+   Firefly MIRA panel, **not** a safety-critical system. Calibrate
+   code-quality decisions to "good consumer-grade backend service",
+   not aerospace.
+2. `/memories/repo/coachiq-state.md` — repo state snapshot.
+3. `/memories/repo/handoff-2026-05-11.md` — handoff from the PR #89
+   work, including the methodology that worked and house rules.
+
+After you've read those, also skim `.github/copilot-instructions.md`
+if you haven't worked in this repo before.
+
+## The job
+
+Restore `tests/test_notification_analytics.py` from
+**4 passed / 12 failed / 0 errors** to **16/0/0** without skipping
+any tests, and fix the underlying production architecture drift the
+test failures are pointing at.
+
+The test file is the spec. Tests describe the contract that production
+code should honour. Where tests look stale (poking at private impl
+details that have moved), update the tests to assert against the
+public API. Where production code is genuinely broken or incomplete,
+fix the production code. Per the handoff house rules: **call out every
+production bug you find in your commit messages** -- they're real wins.
+
+## Current state (already committed on this branch)
+
+Commit `2510827` on `fix/test-suite-restoration-2` already fixes one
+production bug:
+
+- `NotificationAnalyticsService.__init__` was constructing
+  `NotificationReportingService` with `(self._repository,
+  performance_monitor, database_manager)` (3 args) but the constructor
+  only accepts `(database_manager, analytics_service)` (2). Every
+  construction of the analytics service was raising `TypeError`,
+  which broke every analytics REST endpoint at startup. Fixed.
+
+That fix took the cluster from 16 errors → 12 failures + 4 passes.
+The remaining 12 failures expose deeper drift, summarised below.
+
+## What's broken (the 12 remaining failures, grouped)
+
+### Group A: missing query methods on NotificationReportingService
+
+`NotificationAnalyticsService.get_channel_metrics() /
+get_aggregated_metrics() / analyze_errors() / get_queue_health()` all
+delegate to `self._reporting_service.<same_method>()` -- but those
+methods **don't exist** on `NotificationReportingService`. Production
+callers blow up with `AttributeError`:
+
+- `backend/api/routers/notification_analytics.py` (the REST endpoints
+  for `/api/notifications/analytics/*`) calls all four of these.
+- `backend/services/notification_reporting_service_full.py` (a 950-line
+  variant that's currently unreferenced -- **decide whether to delete
+  it or wire it back in** as part of this work).
+
+The repository layer (`NotificationAnalyticsRepository`) has the right
+primitives:
+
+- `get_channel_statistics(channel, start_date, end_date) -> list[dict]`
+- `get_metric_aggregates(...) -> ...`
+- `get_error_patterns(start_date, end_date, min_occurrences) -> list[dict]`
+- `get_queue_statistics(since) -> dict`
+
+What's missing is the **dict→typed-model conversion layer** that
+converts those rows into `ChannelMetrics`, `NotificationMetric`,
+`NotificationErrorAnalysis`, and `NotificationQueueHealth` (all defined
+in `backend/models/notification_analytics.py`).
+
+Decision needed: Do those conversions live on the **reporting service**
+(matching what the tests' fixture wires up:
+`NotificationReportingService(db_manager, analytics_service)` -- so
+the reporting service holds the analytics-service back-reference and
+calls the repository directly), or on the **analytics service**
+itself (with the reporting service handling only the report-template /
+schedule / file-format concerns)?
+
+Both are defensible. Look at the test expectations in
+`tests/test_notification_analytics.py::TestNotificationAnalyticsService`
+(lines ~170-290) and
+`tests/test_notification_analytics.py::TestNotificationReportingService`
+(lines ~290-525) and pick whichever placement keeps both classes'
+contracts coherent. The test calls `analytics_service.get_*()` and
+`reporting_service.generate_report()`, so the public API is clear; the
+implementation split is the part that needs your judgement.
+
+### Group B: legacy buffer attribute names
+
+Tests poke at:
+
+- `analytics_service._metric_buffer` (a `list`)
+- `analytics_service._buffer_size_limit` (an `int`)
+- `analytics_service._flush_buffer()` (a method)
+
+These were on the **old** `NotificationAnalyticsService`. The new
+orchestrator moved buffering to `NotificationIngestionService` as an
+`asyncio.Queue` (totally different shape: no `len()`, no auto-flush
+on size threshold, no public `_metric_buffer` attribute).
+
+Decision needed: either
+1. **Restore the legacy attrs** as compatibility shims on the
+   orchestrator that proxy to the ingestion service / repository
+   buffer (the repository at
+   `NotificationAnalyticsRepository` does still have a list-shaped
+   `_metric_buffer` with `add_to_buffer` / `flush_buffer` methods --
+   these may be the right thing to expose), OR
+2. **Rewrite the tests** to match the new ingestion-queue model and
+   assert against the queue's behaviour instead.
+
+Option 1 is the smaller change and preserves the tests as the spec.
+Option 2 is the cleaner long-term architecture but rewrites the tests
+substantially. Use your judgement; document the decision in the
+commit message.
+
+### Group C: column name mismatch
+
+Tests construct `NotificationDeliveryLog(metadata={...})` and read
+`log.metadata`. The SQLAlchemy model uses **`delivery_metadata`**
+(see `backend/models/notification_analytics.py` line 145). Either:
+
+1. Add a property alias `metadata` → `delivery_metadata` on the
+   model (cleanest; matches what tests expect; doesn't risk a DB
+   migration).
+2. Migrate the column to `metadata` (requires Alembic migration;
+   `metadata` is a SQLAlchemy reserved attribute name on `Base` so
+   you'll likely hit collision warnings -- this is *probably* why
+   it was renamed in the first place).
+
+Lean toward option 1. There's the same `metric_metadata` pattern on
+`NotificationMetricAggregate`, suggesting deliberate avoidance of
+the reserved name.
+
+### Group D: test_dispatcher_analytics_integration & test_end_to_end_analytics_flow
+
+These integration-style tests likely surface as derivative failures of
+groups A-C. Re-check them after you've done A-C; they may pass
+without further changes, or there may be a small additional fixture
+issue.
+
+## The unreferenced file
+
+`backend/services/notification_reporting_service_full.py` (~950 lines,
+imports `matplotlib`, `pandas`, `reportlab`) is **not referenced
+anywhere in the codebase** (verified via `grep -r`). It looks like an
+abandoned variant from a previous refactor. Three options:
+
+1. **Delete it.** Cleanest. If those export formats are wanted
+   later, they'll be brought back per a real spec.
+2. **Move it to `_deprecated/`.** But `_deprecated/` was already
+   purged from the repo on 2026-05-11, so this would re-introduce
+   the directory.
+3. **Leave it.** Risk: someone confuses it for the real
+   reporting service.
+
+Recommend option 1, but flag it in the commit message and let the
+human review. Don't surprise the reviewer.
+
+## Methodology (proven on PR #89 — follow this)
+
+For each cluster of failures:
+
+1. Run the cluster, look at the FIRST failure with `--tb=short`
+   (or `--tb=long` if cryptic).
+2. Decide: API drift (test stale), real bug, or test infra issue.
+3. If test stale: update the test to match current API.
+4. If real bug: fix production code, then verify the test now passes.
+5. If test infra: fix the fixture.
+6. Re-run the cluster, repeat until clean.
+7. **Always run a wider sanity check** at the end to confirm no
+   regressions in earlier-fixed clusters. Use this command:
+
+   ```bash
+   nix develop --command bash -c 'poetry run pytest \
+     tests/test_rvc_decoder_comprehensive.py \
+     tests/integration/test_canbus_decoder_integration.py \
+     tests/integrations/rvc/test_phase1_improvements.py \
+     backend/integrations/can/tests/test_tx_rate_limiter.py \
+     tests/services/test_notification_queue.py \
+     tests/services/test_async_notification_dispatcher.py \
+     tests/services/test_persistence_service.py \
+     tests/services/test_vector_service.py \
+     tests/services/test_docs_service.py \
+     tests/services/test_config_service.py \
+     tests/api/test_safety_pin_endpoints.py \
+     tests/test_pin_security.py \
+     tests/test_notification_analytics.py \
+     --no-cov -q --tb=line 2>&1 | tail -5'
+   ```
+8. **Commit per logical change** with a detailed message that lists
+   production bugs found and design decisions made (especially the
+   "decision needed" points above).
+
+## House rules
+
+- Never skip tests — fix them. Per the user: "don't be lazy."
+- Commit messages explain WHY + HOW, not just WHAT.
+- **Production bugs caught by tests are wins** — call them out
+  explicitly in commit messages. The previous PR found 14; the
+  orchestrator constructor fix is #15; you may find more.
+- Don't add new `# nosec` / `# noqa` / `# type: ignore` without an
+  inline rationale comment.
+- Architectural framing: **consumer-grade backend, NOT
+  safety-critical**. The `safety_*` names in the codebase refer to
+  API guardrails, not vehicle safety (Firefly owns that).
+- CI is now properly diff-aware (`scripts/ruff_diff_check.py` runs
+  ruff lint with line-level filtering); only NEW issues on lines you
+  touch will block. Whole-file pre-commit hooks (ruff-format,
+  bandit) still run on the changed file set.
+- Pre-push hook: use `git push --no-verify` to bypass it during
+  iterative work; the gate runs in CI anyway.
+- The user's shell is fish — bash arithmetic / heredocs need a
+  `bash -lc "..."` wrapper.
+
+## Files NOT to touch without asking
+
+- `wip/security-rpi-hardening-2025` branch (preserved sprint).
+- `config/2021_Entegra_Aspire_44R.yml` (real coach mapping).
+- The 3 notification managers (`notification_manager.py`,
+  `safe_notification_manager.py`, `notification_lightweight.py`) —
+  they look like duplicates but are intentional safety/perf tiers.
+
+## What "done" looks like
+
+- `tests/test_notification_analytics.py`: 16/16 passing.
+- The wider sanity check above shows zero regressions.
+- A focused PR (squash-merge) onto `main` with one or more commits
+  whose messages explain:
+  - What production bugs were found and how they were fixed
+  - Each "decision needed" call you made and why
+  - Whether you deleted/kept `notification_reporting_service_full.py`
+- `./scripts/ci-quality-gate.sh` passes locally (it's the same gate
+  CI runs).
+
+## Branch / PR convention
+
+Work on a fresh branch off the **latest `main`** (NOT off
+`fix/test-suite-restoration-2` -- that branch will likely have moved
+on with the safety-integration cluster work that's running in
+parallel). Name it something like
+`fix/notification-analytics-architecture` or similar. Open a PR that
+explicitly references this prompt and the orchestrator fix in commit
+`2510827` (which will already be on main by the time you start).
+
+Good luck. The codebase rewards careful reading; the test file *is*
+the spec for the contract you're trying to honour.

--- a/.github/prompts/notification-integration-test-restoration.prompt.md
+++ b/.github/prompts/notification-integration-test-restoration.prompt.md
@@ -1,0 +1,127 @@
+# Subagent task: restore tests/integration/test_notification_integration.py
+
+You are picking up work on the test-suite restoration project for
+[carpenike/coachiq](https://github.com/carpenike/coachiq), branched
+off the latest `main`.
+
+## Read first
+
+1. `/memories/repo/coachiq-architecture.md` — pins what CoachIQ IS
+   and IS NOT.
+2. `/memories/repo/coachiq-state.md` — repo state snapshot.
+3. `/memories/repo/handoff-2026-05-11.md` — methodology + house rules.
+
+## The job
+
+Restore `tests/integration/test_notification_integration.py` from
+**3 passed / 5 failed / 1 skipped / 8 errors** to all-green without
+skipping any tests, and fix any production drift the failures point
+at.
+
+## What's broken (categorised)
+
+### Group A: Pydantic v2 extra-field strictness on routing rules
+
+`TestNotificationRoutingIntegration::test_user_preference_routing` and
+`test_custom_routing_rules` fail with errors like:
+
+```
+debounce_minutes
+  Extra inputs are not permitted [type=extra_forbidden, input_value=1, ...]
+```
+
+Either the routing rule model has tightened `model_config = ConfigDict(extra="forbid")`
+without adding the fields tests expect, or the tests are passing
+fields that genuinely no longer exist. Audit the model in
+`backend/services/notification_routing.py` (or similar) against the
+test's expectations.
+
+### Group B: TestEmailTemplateIntegration ERRORS
+
+3 tests in `TestEmailTemplateIntegration` error out at setup. Likely
+a fixture issue or a template-engine constructor signature drift.
+Investigate `--tb=long` on the first error.
+
+### Group C: TestSafeNotificationManagerIntegration ERRORS
+
+3 tests error at setup. `SafeNotificationManager` has its own complex
+API surface. Likely fixture drift around the constructor or its
+dependencies.
+
+### Group D: Performance test ERRORS
+
+`TestNotificationSystemPerformance::test_high_volume_notification_processing`
+and `test_rate_limiting_under_load` error at setup. May be downstream
+of B or C, or a separate fixture issue.
+
+### Group E: Queue persistence + retry/DLQ failures
+
+`TestNotificationQueueIntegration::test_queue_persistence_across_restarts`
+and `test_queue_retry_and_dlq` fail with `assert 0 == 1`. Tests
+expect the queue to recover state across simulated restarts; verify
+the persistence layer and DLQ wiring are intact.
+
+### Group F: Mock-based dispatcher test
+
+`TestMockedServiceIntegration::test_dispatcher_processing_with_mocks`
+fails with `assert 0 >= 1`. Likely the dispatcher isn't being
+triggered, or the mocks don't simulate the right surface.
+
+## Methodology
+
+1. Run cluster with `--tb=line` to get the full failure list
+2. For each, run with `--tb=short` or `--tb=long` to get traceback
+3. Decide: API drift (test stale), real bug, or fixture issue
+4. Fix and re-run
+5. Sanity-check across all 14 fixed clusters before each commit
+
+## House rules (same as previous prompts)
+
+- Never skip tests
+- Production bugs caught by tests are wins; call them out in commits
+- The branch `fix/test-suite-restoration-2` already accumulated 7+
+  production-bug fixes via this restoration sweep; keep counting
+- No new noqa/nosec/type:ignore without inline rationale
+- Architectural framing: consumer-grade backend, NOT safety-critical
+- Stage-1 CI gate is line-level diff-aware; only NEW issues block
+
+## Files NOT to touch without asking
+
+- `wip/security-rpi-hardening-2025` branch
+- `config/2021_Entegra_Aspire_44R.yml`
+- The 3 notification managers (notification_manager.py,
+  safe_notification_manager.py, notification_lightweight.py) —
+  intentional safety/perf tiers, NOT duplicates. You will likely
+  need to MODIFY safe_notification_manager.py for the ERROR tests
+  in Group C, but don't attempt to consolidate the three managers.
+
+## Sanity-check command
+
+```bash
+nix develop --command bash -c 'poetry run pytest \
+  tests/test_rvc_decoder_comprehensive.py \
+  tests/integration/test_canbus_decoder_integration.py \
+  tests/integrations/rvc/test_phase1_improvements.py \
+  backend/integrations/can/tests/test_tx_rate_limiter.py \
+  tests/services/test_notification_queue.py \
+  tests/services/test_async_notification_dispatcher.py \
+  tests/services/test_persistence_service.py \
+  tests/services/test_vector_service.py \
+  tests/services/test_docs_service.py \
+  tests/services/test_config_service.py \
+  tests/api/test_safety_pin_endpoints.py \
+  tests/test_pin_security.py \
+  tests/test_webhook_channel.py \
+  tests/integration/test_notification_integration.py \
+  --no-cov -q --tb=line 2>&1 | tail -5'
+```
+
+The known pre-existing failure
+`test_async_notification_dispatcher::test_force_queue_processing`
+(passes in isolation, fails in full-suite due to test pollution)
+should be ignored.
+
+## Branch / PR convention
+
+Cut a fresh branch off `main` (after PR for `fix/test-suite-restoration-2`
+merges). Name something like `fix/notification-integration-test-restoration`.

--- a/.github/prompts/pin-manager-db-test-restoration.prompt.md
+++ b/.github/prompts/pin-manager-db-test-restoration.prompt.md
@@ -1,0 +1,200 @@
+# Subagent task: restore tests/services/test_pin_manager_db.py
+
+You are picking up work on the test-suite restoration project for
+[carpenike/coachiq](https://github.com/carpenike/coachiq). This task
+follows commit `0474815` on `fix/test-suite-restoration-2`, which
+added three missing public-API methods (`create_pin`, `rotate_pin`,
+`deactivate_pin`) to `PINManager`.
+
+## Read first
+
+These three repo-memory files set the framing — read in order:
+
+1. `/memories/repo/coachiq-architecture.md` — pins what CoachIQ IS
+   and IS NOT (CAN-bus orchestration layer, NOT safety-critical).
+   Realistic threats are API-side (auth bypass, session leak, etc.).
+   PIN management directly serves the auth threat model.
+2. `/memories/repo/coachiq-state.md` — repo state snapshot.
+3. `/memories/repo/handoff-2026-05-11.md` — handoff from PR #89,
+   methodology, house rules.
+
+## The job
+
+Restore `tests/services/test_pin_manager_db.py` from
+**5 passed / 7 failed / 1 error** to **12+/0/0** without skipping
+any tests, and fix any production drift the failures point at.
+
+## Current state (already on the branch)
+
+Commit `0474815` added three operator-facing methods to PINManager:
+
+- `create_pin(user_id, pin, pin_type, description=None)` — wrapper
+  over `set_pin` with arg order matching `validate_pin` and a clearer
+  verb name. The method works; 5 tests now pass (PIN creation /
+  duplicate / multiple types).
+- `rotate_pin(user_id, pin_type, old_pin, new_pin)` — verifies old
+  PIN, revokes the verification session, sets new PIN.
+- `deactivate_pin(user_id, pin_type)` — soft-deletes via
+  `is_active = False`.
+
+The tests for `rotate_pin` and `deactivate_pin` themselves still
+fail because they're downstream of the `validate_pin` API drift
+described below.
+
+## The remaining 7 failures + 1 error: validate_pin return-type drift
+
+Every remaining failure traces to one root cause: `PINManager.validate_pin`
+returns a **`PINValidationResult` Pydantic model** (defined in
+`backend/services/pin_manager.py:81`) with these fields:
+
+```python
+class PINValidationResult(BaseModel):
+    success: bool
+    session_id: str | None = None      # populated only when success=True
+    error_message: str | None = None
+    lockout_until: datetime | None = None
+```
+
+The tests treat the return value as a **bare `session_id: str | None`**:
+
+```python
+session_id = await pin_manager_with_db.validate_pin(...)
+assert session_id is not None        # success case
+assert session_id is None            # failure case (wrong PIN, lockout, etc.)
+```
+
+There are 12 sites in `tests/services/test_pin_manager_db.py` that
+need this pattern updated. The minimal-change rewrite is:
+
+```python
+result = await pin_manager_with_db.validate_pin(...)
+session_id = result.session_id  # already None on failure (line 442/453/476/489 in pin_manager.py)
+assert session_id is not None  # or `is None`
+```
+
+OR equivalently:
+
+```python
+result = await pin_manager_with_db.validate_pin(...)
+assert result.success            # success case
+assert not result.success        # failure case
+```
+
+The latter is more readable but requires fixing more lines in each
+test. Use your judgement; document the convention you pick in a
+brief module-level comment.
+
+The 12 call sites are at lines: 150, 201, 233, 296, 304, 351, 374
+(closure return -> needs different handling), 408, 455, 472, 480,
+504. (Run `grep -n "validate_pin" tests/services/test_pin_manager_db.py`
+to confirm if drift since.)
+
+The closure case at line 374 (`return await pin_manager_with_db.validate_pin(...)`)
+returns a list of `PINValidationResult` objects; the assertion below
+is `assert all(sid is not None for sid in session_ids)` which needs
+to become `assert all(r.success for r in results)`.
+
+## The 1 ERROR (TestConcurrentOperations::test_concurrent_session_creation)
+
+The pytest output shows this is an ERROR, not just a FAILED, which
+usually means it failed during setup or teardown rather than during
+the test body. Diagnose with `--tb=long` first; it may be related to
+the SAWarning seen in the output (`Session.add() within flush
+process`) which suggests a real concurrency issue in `_create_session`.
+If it IS a real concurrency bug, fix it -- this is exactly the kind
+of API guardrail issue the project's threat model cares about.
+
+## Other failures to investigate
+
+After fixing the validate_pin return-type drift, re-run the cluster.
+If `test_lockout_after_failed_attempts` or other tests still fail,
+check the `lockout_until` field handling — the production code
+likely returns success=False with lockout_until set, but the tests
+may be expecting an exception or a different shape.
+
+Also `test_rotate_pin` and `test_deactivate_pin` -- these will
+exercise the new methods I added in `0474815`. Verify the implementations
+work correctly end-to-end (the methods compiled fine but I didn't
+test them past unit construction; the `rotate_pin` validate-then-
+revoke flow especially should be verified against the test
+expectations).
+
+## Methodology
+
+For each test:
+
+1. Run with `--tb=short`, identify root cause.
+2. Decide: API drift (test stale), real bug, or fixture issue.
+3. If stale: update the test.
+4. If real bug: **fix production code** and call it out in the
+   commit message.
+5. Re-run, repeat until clean.
+6. **Sanity check** before each commit:
+
+   ```bash
+   nix develop --command bash -c 'poetry run pytest \
+     tests/test_rvc_decoder_comprehensive.py \
+     tests/integration/test_canbus_decoder_integration.py \
+     tests/integrations/rvc/test_phase1_improvements.py \
+     backend/integrations/can/tests/test_tx_rate_limiter.py \
+     tests/services/test_notification_queue.py \
+     tests/services/test_async_notification_dispatcher.py \
+     tests/services/test_persistence_service.py \
+     tests/services/test_vector_service.py \
+     tests/services/test_docs_service.py \
+     tests/services/test_config_service.py \
+     tests/api/test_safety_pin_endpoints.py \
+     tests/test_pin_security.py \
+     tests/test_webhook_channel.py \
+     tests/services/test_pin_manager_db.py \
+     --no-cov -q --tb=line 2>&1 | tail -5'
+   ```
+
+## House rules
+
+- Never skip tests — fix them. User: "don't be lazy."
+- Commit messages explain WHY + HOW.
+- **Production bugs caught by tests are wins** -- call them out
+  explicitly. PR #89 found 14, this branch has added 7+ more so far
+  (NotificationReportingService constructor wiring; ServiceStatus.STOPPED
+  + _shutdown_service status update; persistence backup cleanup
+  datetime tz; webhook retry_delay int->float; webhook per-attempt
+  vs per-notification stat semantics; webhook 4xx no-retry; webhook
+  partial-success counter logic). Keep counting.
+- No new `# nosec` / `# noqa` / `# type: ignore` without inline
+  rationale.
+- Architectural framing: consumer-grade backend, NOT safety-critical.
+- The CI gate's Stage-1 ruff check is line-level diff-aware
+  (`scripts/ruff_diff_check.py`); only NEW issues on changed lines
+  block. Whole-file pre-commit hooks (ruff-format, bandit) still
+  run on the changed file set.
+- Pre-push hook runs the gate locally; use `--no-verify` to bypass
+  during iteration.
+- User's shell is fish — wrap heredocs in `bash -lc "..."`.
+
+## Files NOT to touch without asking
+
+- `wip/security-rpi-hardening-2025` branch.
+- `config/2021_Entegra_Aspire_44R.yml` (real coach mapping).
+- The 3 notification managers — intentional safety/perf tiers.
+
+## What "done" looks like
+
+- `tests/services/test_pin_manager_db.py`: all 12 tests passing
+  (12+/0/0).
+- The wider sanity check shows zero regressions (the
+  `test_async_notification_dispatcher::test_force_queue_processing`
+  pollution failure is a known pre-existing issue per handoff memory;
+  ignore it).
+- `./scripts/ci-quality-gate.sh` passes locally.
+- A focused PR commit with a message that explains the validate_pin
+  return-type drift decision, calls out any production bugs found
+  in the rotate_pin / deactivate_pin verification, and addresses
+  the concurrency error.
+
+## Branch / PR convention
+
+Either keep working on `fix/test-suite-restoration-2` (where the
+0474815 PINManager work already lives), or wait until that branch
+merges to main and cut a fresh branch. Reference commit `0474815`
+in your PR description as the prerequisite.

--- a/.github/prompts/safety-integration-test-restoration.prompt.md
+++ b/.github/prompts/safety-integration-test-restoration.prompt.md
@@ -1,0 +1,237 @@
+# Subagent task: restore tests/test_safety_integration.py
+
+You are picking up work mid-stream on `fix/test-suite-restoration-2`,
+which is branched off the latest `main` of the
+[carpenike/coachiq](https://github.com/carpenike/coachiq) repo.
+
+## Read first
+
+These three repo-memory files set the framing — start here, in this
+order:
+
+1. `/memories/repo/coachiq-architecture.md` — pins what CoachIQ IS and
+   IS NOT. CoachIQ is a CAN-bus orchestration layer that talks to a
+   Firefly MIRA panel, **not** a safety-critical system in the
+   aerospace / DO-178C sense. The `safety_*` names in this codebase
+   are API guardrails, not vehicle safety (Firefly owns that).
+2. `/memories/repo/coachiq-state.md` — repo state snapshot.
+3. `/memories/repo/handoff-2026-05-11.md` — handoff from PR #89,
+   including methodology and house rules.
+
+## The job
+
+Restore `tests/test_safety_integration.py` from
+**0 passed / 14 errors / 0 failed** to **14/0/0** without skipping
+any tests, and fix any production drift the failures point at.
+
+## Current state (already committed on this branch)
+
+Two commits on `fix/test-suite-restoration-2` already addressed
+production gaps surfaced by this cluster's triage; you don't need to
+redo them:
+
+- `2510827` — `NotificationAnalyticsService` constructor wiring fix
+  (unrelated cluster, but on the same branch).
+- `664bac5` — added `ServiceStatus.STOPPED` to the enum, made
+  `_shutdown_service` actually update status post-shutdown, and fixed
+  a silent bug in `persistence_repository._cleanup_old_backups`
+  (offset-naive vs offset-aware datetime comparison).
+
+After those, the cluster still fails 14/14 with a new error:
+
+```
+TypeError: EnhancedServiceRegistry.register_service() got an
+unexpected keyword argument 'service'
+```
+
+## What's broken (the 14 remaining errors)
+
+All 14 errors trace back to the `integrated_system` fixture at
+`tests/test_safety_integration.py:235-269`. The fixture calls:
+
+```python
+service_registry.register_service(
+    name=name,
+    service=service,                         # WRONG: kwarg doesn't exist
+    dependencies=config.get("depends_on", []),
+    is_critical=config.get(...) in [...],    # WRONG: kwarg doesn't exist
+)
+```
+
+But `EnhancedServiceRegistry.register_service` (in
+`backend/core/service_registry.py:316-350`) actually accepts:
+
+```python
+def register_service(
+    self,
+    name: str,
+    init_func: Callable[[], Any],          # NOT 'service'
+    dependencies: list[str | ServiceDependency] | None = None,
+    tags: set[str] | None = None,          # NOT 'is_critical'
+    description: str | None = None,
+    health_check: Callable[[], bool] | None = None,
+) -> None: ...
+```
+
+Two more drift points the fixture hits later:
+
+- Tests call `await service_registry.startup()` -- but on
+  `EnhancedServiceRegistry`, that hits the base-class method which
+  iterates the (empty for ESR) `_startup_stages` list and does
+  nothing. The actual startup method on ESR is `startup_all()` (line
+  369). The base class's `startup()` is for a different (legacy)
+  registration model where you call `register_startup_stage()`
+  instead of `register_service()`.
+- The fixture builds pre-instantiated `RealWorldService` objects and
+  expects the registry to call `service.startup()` on them.
+  `EnhancedServiceRegistry._start_service_with_di_and_metrics`
+  (line ~485) **does** call `service.startup()` after
+  `init_func()` returns -- but only if `init_func` returned a
+  fully-built service instance. The fixture currently passes the
+  instance directly via `service=`; you need to wrap it in a
+  trivial callable.
+
+## Suggested fixture rewrite
+
+```python
+@pytest.fixture
+def integrated_system(rv_system_config):
+    """Create integrated RV system for testing."""
+    service_registry = EnhancedServiceRegistry()
+
+    services = {}
+    for name, config in rv_system_config.items():
+        service = RealWorldService(
+            name=name,
+            safety_classification=config.get("safety_classification", "operational"),
+        )
+        service.enabled = config.get("enabled", True)
+        services[name] = service
+
+        # `init_func` must be a callable that returns the service
+        # instance. Use a default-arg lambda so each iteration captures
+        # its own `service` (avoids the classic late-binding closure bug).
+        # Use a tag set instead of the legacy `is_critical=` kwarg.
+        tags = set()
+        if config.get("safety_classification") in ["critical", "safety_related"]:
+            tags.add("critical")
+
+        service_registry.register_service(
+            name=name,
+            init_func=lambda s=service: s,
+            dependencies=config.get("depends_on", []),
+            tags=tags,
+        )
+
+    safety_service = SafetyService(
+        service_registry=service_registry,
+        health_check_interval=0.1,
+        watchdog_timeout=2.0,
+    )
+
+    return {
+        "service_registry": service_registry,
+        "safety_service": safety_service,
+        "services": services,
+    }
+```
+
+Then update every `await service_registry.startup()` in the test
+bodies to `await service_registry.startup_all()` (use grep --
+there are several occurrences).
+
+## What to expect downstream
+
+After the fixture is fixed, you'll likely surface a second wave of
+issues in the test bodies themselves. Audit:
+
+- `service_registry.get_service_status(name)` — verify it exists on
+  EnhancedServiceRegistry and returns a `ServiceStatus`.
+- `service_registry.check_system_health()` — verify it exists.
+- `safety_service.trigger_emergency_stop(reason)` /
+  `reset_emergency_stop(authorization)` /
+  `_emergency_stop_active` / `get_safety_status()` /
+  `get_audit_log()` / `start_monitoring()` — these mostly exist
+  per `grep` (see `backend/services/safety_service.py`), but
+  signatures may have drifted.
+
+## Methodology
+
+For each failure:
+
+1. Run the test, look at FIRST failure with `--tb=short`.
+2. Decide: API drift (test stale), real bug, or fixture issue.
+3. If stale: update the test.
+4. If real bug: **fix production code** and call it out in the commit
+   message. The previous PR #89 found 14 production bugs; commits
+   `2510827` and `664bac5` on this branch found 3 more (#15-17). Keep
+   counting.
+5. Re-run cluster, repeat until clean.
+6. **Always run the wider sanity check** before committing:
+
+   ```bash
+   nix develop --command bash -c 'poetry run pytest \
+     tests/test_rvc_decoder_comprehensive.py \
+     tests/integration/test_canbus_decoder_integration.py \
+     tests/integrations/rvc/test_phase1_improvements.py \
+     backend/integrations/can/tests/test_tx_rate_limiter.py \
+     tests/services/test_notification_queue.py \
+     tests/services/test_async_notification_dispatcher.py \
+     tests/services/test_persistence_service.py \
+     tests/services/test_vector_service.py \
+     tests/services/test_docs_service.py \
+     tests/services/test_config_service.py \
+     tests/api/test_safety_pin_endpoints.py \
+     tests/test_pin_security.py \
+     tests/test_safety_integration.py \
+     --no-cov -q --tb=line 2>&1 | tail -5'
+   ```
+
+## House rules (non-negotiable)
+
+- Never skip tests — fix them. The user explicitly said "don't be lazy."
+- Commit messages explain WHY + HOW, not just WHAT.
+- **Production bugs caught by tests are wins** — call them out
+  explicitly with a line like "Production bug found and fixed: ...".
+- No new `# nosec` / `# noqa` / `# type: ignore` without inline
+  rationale.
+- Architectural framing: consumer-grade backend, NOT safety-critical.
+- The Stage-1 CI gate is line-level diff-aware
+  (`scripts/ruff_diff_check.py`), so only NEW issues on lines you
+  touch will block. Whole-file pre-commit hooks (ruff-format, bandit)
+  still run on the changed file set.
+- User's shell is fish — `bash -lc "..."` wrapper for any
+  bash arithmetic / heredocs.
+- Pre-push hook runs CI locally; use `--no-verify` to bypass it
+  during iteration. CI will catch issues anyway.
+
+## Files NOT to touch without asking
+
+- `wip/security-rpi-hardening-2025` branch.
+- `config/2021_Entegra_Aspire_44R.yml` (real coach mapping).
+- The 3 notification managers (notification_manager.py,
+  safe_notification_manager.py, notification_lightweight.py) —
+  intentional safety/perf tiers, not duplicates.
+
+## What "done" looks like
+
+- `tests/test_safety_integration.py`: 14/14 passing.
+- The wider sanity check shows zero regressions (the
+  test_async_notification_dispatcher::test_force_queue_processing
+  pollution failure is a known pre-existing issue per handoff
+  memory; ignore that one if you see it).
+- A focused PR onto `main` with one or more commits whose messages
+  explain each design decision and call out every production bug
+  found.
+- `./scripts/ci-quality-gate.sh` passes locally.
+
+## Branch / PR convention
+
+Either keep working on `fix/test-suite-restoration-2` and add this
+work to PR-X (whatever number that branch becomes), or cut a fresh
+branch off the latest `main` (after `fix/test-suite-restoration-2`
+merges) named something like `fix/safety-integration-test-restoration`.
+
+If you fork a separate branch, reference commits `2510827` and
+`664bac5` in your PR description as prerequisites — those will
+already be on main by the time you start.


### PR DESCRIPTION
## Summary

Adds four `.github/prompts/` files for the deeper architectural work surfaced while triaging clusters during PR #89 follow-up (PR #90). Each prompt is self-contained: the subagent reads the prompt + the three repo-memory files (`coachiq-architecture.md`, `coachiq-state.md`, `handoff-2026-05-11.md`) and has everything needed to do the work.

## Prompts

1. **`notification-analytics-architecture.prompt.md`** — restoring `tests/test_notification_analytics.py` (12 failures after the orchestrator-constructor fix in PR #90 `2510827`). Decisions needed: where to place the dict→typed-model conversion layer (analytics service vs reporting service), and whether to restore legacy `_metric_buffer` attrs as compat shims or rewrite tests against the new asyncio.Queue ingestion model.

2. **`safety-integration-test-restoration.prompt.md`** — `tests/test_safety_integration.py` (14 errors after the `ServiceStatus.STOPPED` fix in PR #90 `664bac5`). Fixture rewrite: `register_service(service=, is_critical=)` no longer matches production's `register_service(init_func=, tags=)`, plus `startup()` vs `startup_all()` on `EnhancedServiceRegistry`.

3. **`pin-manager-db-test-restoration.prompt.md`** — finishing the cluster started in PR #90. After the 3 new PINManager methods landed, 7 failures remain that all trace to `validate_pin` returning `PINValidationResult` (rich) vs tests treating it as bare session_id (12 sites to update). Plus 1 ERROR in concurrent-session test that may surface a real concurrency bug.

4. **`notification-integration-test-restoration.prompt.md`** — `tests/integration/test_notification_integration.py` (5 failed / 8 errors). Multi-group failures: Pydantic v2 extra-field strictness on routing rules, `SafeNotificationManager` fixture drift, queue persistence gaps, mock-dispatcher wiring.

## Why separate from the test-fix PR

These prompts describe substantial work (~2-4 hours each); merging them on a separate PR keeps PR #90's review focused on the actual production-bug fixes and test restoration, while making the prompts immediately discoverable to anyone (or any agent) picking up the next slice of the backlog.