### PR TITLE
fix(tests): restore test_pin_manager_db cluster (12/12) + 4 production bugs

### DIFF
--- a/backend/services/pin_manager.py
+++ b/backend/services/pin_manager.py
@@ -10,12 +10,13 @@ Provides PIN-based authorization for safety-critical operations including:
 For RV deployment security with internet connectivity.
 """
 
+import asyncio
 import hashlib
 import logging
 import secrets
 import uuid
 from datetime import UTC, datetime, timedelta
-from typing import Optional
+from typing import Any, overload
 
 from pydantic import BaseModel, Field
 from sqlalchemy import and_, func, select
@@ -28,28 +29,67 @@ from backend.models.auth import UserPIN
 logger = logging.getLogger(__name__)
 
 
+def _ensure_utc_aware(dt: datetime | None) -> datetime | None:
+    """Coerce a datetime read back from the database to UTC-aware.
+
+    SQLite has no native ``TIMESTAMP WITH TIME ZONE`` type. SQLAlchemy's
+    ``DateTime(timezone=True)`` declaration is honoured by Postgres but
+    silently degraded by the SQLite dialect: writes that go in tz-aware
+    come back tz-naive. CoachIQ's reference deployment uses SQLite, so
+    every Python-side comparison between ``datetime.now(UTC)`` and a
+    value loaded from the DB is a latent ``TypeError: can't compare
+    offset-naive and offset-aware datetimes`` waiting to fire.
+
+    Treat naive datetimes as UTC (which is how the writer intended them)
+    so authorization checks and lockout windows work identically on
+    SQLite and Postgres. Returns ``None`` unchanged so callers can keep
+    using nullable columns; the overload narrows the return type so
+    non-nullable callers don't need a redundant ``assert``.
+    """
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=UTC)
+    return dt
+
+
+@overload
+def _coerce_utc_aware(dt: datetime) -> datetime: ...
+@overload
+def _coerce_utc_aware(dt: None) -> None: ...
+def _coerce_utc_aware(dt: datetime | None) -> datetime | None:
+    """Non-nullable-narrowing wrapper around ``_ensure_utc_aware``."""
+    return _ensure_utc_aware(dt)
+
+
 class PINConfig(BaseModel):
     """PIN system configuration."""
 
     # PIN Requirements
-    min_pin_length: int = Field(4, description="Minimum PIN length")
-    max_pin_length: int = Field(8, description="Maximum PIN length")
-    require_numeric_only: bool = Field(True, description="Require numeric PINs only")
+    min_pin_length: int = Field(default=4, description="Minimum PIN length")
+    max_pin_length: int = Field(default=8, description="Maximum PIN length")
+    require_numeric_only: bool = Field(default=True, description="Require numeric PINs only")
 
     # Authorization Settings
-    emergency_pin_expires_minutes: int = Field(5, description="Emergency PIN session timeout")
-    max_failed_attempts: int = Field(3, description="Max failed PIN attempts before lockout")
-    lockout_duration_minutes: int = Field(15, description="Lockout duration after max failures")
+    emergency_pin_expires_minutes: int = Field(
+        default=5, description="Emergency PIN session timeout"
+    )
+    max_failed_attempts: int = Field(
+        default=3, description="Max failed PIN attempts before lockout"
+    )
+    lockout_duration_minutes: int = Field(
+        default=15, description="Lockout duration after max failures"
+    )
 
     # Session Management
-    session_timeout_minutes: int = Field(30, description="General PIN session timeout")
-    max_concurrent_sessions: int = Field(2, description="Max concurrent PIN sessions")
+    session_timeout_minutes: int = Field(default=30, description="General PIN session timeout")
+    max_concurrent_sessions: int = Field(default=2, description="Max concurrent PIN sessions")
 
     # Security Features
-    enable_pin_rotation: bool = Field(True, description="Enable automatic PIN rotation")
-    pin_rotation_days: int = Field(30, description="Days between PIN rotation")
+    enable_pin_rotation: bool = Field(default=True, description="Enable automatic PIN rotation")
+    pin_rotation_days: int = Field(default=30, description="Days between PIN rotation")
     require_pin_confirmation: bool = Field(
-        True, description="Require PIN confirmation for critical ops"
+        default=True, description="Require PIN confirmation for critical ops"
     )
 
 
@@ -61,31 +101,31 @@ class PINSessionData(BaseModel):
     pin_type: str = Field(..., description="Type of PIN: emergency, override, maintenance")
     created_at: datetime = Field(..., description="Session creation timestamp")
     expires_at: datetime = Field(..., description="Session expiration timestamp")
-    operations_used: int = Field(0, description="Number of operations performed")
-    max_operations: int | None = Field(None, description="Maximum operations allowed")
-    is_active: bool = Field(True, description="Whether session is active")
+    operations_used: int = Field(default=0, description="Number of operations performed")
+    max_operations: int | None = Field(default=None, description="Maximum operations allowed")
+    is_active: bool = Field(default=True, description="Whether session is active")
 
 
 class PINAttemptData(BaseModel):
     """PIN attempt data for API responses."""
 
-    user_id: str | None = Field(None, description="User attempting PIN validation")
+    user_id: str | None = Field(default=None, description="User attempting PIN validation")
     pin_type: str = Field(..., description="Type of PIN attempted")
     timestamp: datetime = Field(..., description="Attempt timestamp")
     success: bool = Field(..., description="Whether attempt was successful")
-    ip_address: str | None = Field(None, description="Source IP address")
-    session_id: str | None = Field(None, description="Created session ID if successful")
-    failure_reason: str | None = Field(None, description="Reason for failure")
+    ip_address: str | None = Field(default=None, description="Source IP address")
+    session_id: str | None = Field(default=None, description="Created session ID if successful")
+    failure_reason: str | None = Field(default=None, description="Reason for failure")
 
 
 class PINValidationResult(BaseModel):
     """Result of PIN validation."""
 
     success: bool = Field(..., description="Whether validation was successful")
-    session_id: str | None = Field(None, description="Created session ID if successful")
-    error_message: str | None = Field(None, description="Error message if failed")
+    session_id: str | None = Field(default=None, description="Created session ID if successful")
+    error_message: str | None = Field(default=None, description="Error message if failed")
     lockout_until: datetime | None = Field(
-        None, description="Lockout expiration if user is locked out"
+        default=None, description="Lockout expiration if user is locked out"
     )
 
 
@@ -107,6 +147,18 @@ class PINManager:
         """
         self.config = config or PINConfig()
         self.db_session = db_session
+        # SQLAlchemy AsyncSession is NOT safe for concurrent use: a flush in
+        # one task colliding with a Session.add()/execute() in another task
+        # produces "Session.add() within flush process" warnings and can
+        # leave the session in an inconsistent state. The PIN flow on a real
+        # request is single-threaded, but this manager can be exercised from
+        # parallel WebSocket / API calls that share a request-scoped session
+        # (and the test suite explicitly drives concurrent validate_pin /
+        # authorize_operation calls). Serialise all DB-mutating public
+        # methods through a per-instance lock to keep the threat model
+        # honest: brute-force or burst-style PIN attempts must not corrupt
+        # auth state.
+        self._db_lock: asyncio.Lock = asyncio.Lock()
 
         logger.info("PIN Manager initialized with database persistence for RV safety operations")
 
@@ -186,46 +238,49 @@ class PINManager:
         if not self._validate_pin_format(pin):
             raise ValueError("PIN doesn't meet format requirements")
 
-        # Generate salt and hash PIN
-        salt = self._generate_salt()
-        pin_hash = self._hash_pin(pin, salt)
+        async with self._db_lock:
+            # Generate salt and hash PIN
+            salt = self._generate_salt()
+            pin_hash = self._hash_pin(pin, salt)
 
-        # Check if PIN already exists for this user and type
-        existing_pin = await self.db_session.execute(
-            select(UserPIN).where(and_(UserPIN.user_id == user_id, UserPIN.pin_type == pin_type))
-        )
-        existing = existing_pin.scalar_one_or_none()
-
-        if existing:
-            # Update existing PIN
-            existing.pin_hash = pin_hash
-            existing.salt = salt
-            existing.updated_at = datetime.now(UTC)
-            if description:
-                existing.description = description
-        else:
-            # Create new PIN
-            new_pin = UserPIN(
-                id=str(uuid.uuid4()),
-                user_id=user_id,
-                pin_type=pin_type,
-                pin_hash=pin_hash,
-                salt=salt,
-                description=description,
-                is_active=True,
-                use_count=0,
-                lockout_after_failures=self.config.max_failed_attempts,
-                lockout_duration_minutes=self.config.lockout_duration_minutes,
-                created_at=datetime.now(UTC),
-                updated_at=datetime.now(UTC),
+            # Check if PIN already exists for this user and type
+            existing_pin = await self.db_session.execute(
+                select(UserPIN).where(
+                    and_(UserPIN.user_id == user_id, UserPIN.pin_type == pin_type)
+                )
             )
-            self.db_session.add(new_pin)
+            existing = existing_pin.scalar_one_or_none()
 
-        await self.db_session.commit()
-        logger.info(
-            f"PIN {'updated' if existing else 'created'} for user {user_id}, type: {pin_type}"
-        )
-        return True
+            if existing:
+                # Update existing PIN
+                existing.pin_hash = pin_hash
+                existing.salt = salt
+                existing.updated_at = datetime.now(UTC)
+                if description:
+                    existing.description = description
+            else:
+                # Create new PIN
+                new_pin = UserPIN(
+                    id=str(uuid.uuid4()),
+                    user_id=user_id,
+                    pin_type=pin_type,
+                    pin_hash=pin_hash,
+                    salt=salt,
+                    description=description,
+                    is_active=True,
+                    use_count=0,
+                    lockout_after_failures=self.config.max_failed_attempts,
+                    lockout_duration_minutes=self.config.lockout_duration_minutes,
+                    created_at=datetime.now(UTC),
+                    updated_at=datetime.now(UTC),
+                )
+                self.db_session.add(new_pin)
+
+            await self.db_session.commit()
+            logger.info(
+                f"PIN {'updated' if existing else 'created'} for user {user_id}, type: {pin_type}"
+            )
+            return True
 
     async def create_pin(
         self,
@@ -305,24 +360,25 @@ class PINManager:
             msg = "Database session not available"
             raise RuntimeError(msg)
 
-        result = await self.db_session.execute(
-            select(UserPIN).where(
-                and_(
-                    UserPIN.user_id == user_id,
-                    UserPIN.pin_type == pin_type,
-                    UserPIN.is_active.is_(True),
+        async with self._db_lock:
+            result = await self.db_session.execute(
+                select(UserPIN).where(
+                    and_(
+                        UserPIN.user_id == user_id,
+                        UserPIN.pin_type == pin_type,
+                        UserPIN.is_active.is_(True),
+                    )
                 )
             )
-        )
-        pin = result.scalar_one_or_none()
-        if pin is None:
-            return False
+            pin = result.scalar_one_or_none()
+            if pin is None:
+                return False
 
-        pin.is_active = False
-        pin.updated_at = datetime.now(UTC)
-        await self.db_session.commit()
-        logger.info("PIN deactivated for user %s type %s", user_id, pin_type)
-        return True
+            pin.is_active = False
+            pin.updated_at = datetime.now(UTC)
+            await self.db_session.commit()
+            logger.info("PIN deactivated for user %s type %s", user_id, pin_type)
+            return True
 
     def _validate_pin_format(self, pin: str) -> bool:
         """Validate PIN format requirements."""
@@ -377,6 +433,7 @@ class PINManager:
 
             last_attempt_time = last_attempt.scalar()
             if last_attempt_time:
+                last_attempt_time = _coerce_utc_aware(last_attempt_time)
                 lockout_until = last_attempt_time + timedelta(
                     minutes=self.config.lockout_duration_minutes
                 )
@@ -436,76 +493,98 @@ class PINManager:
             PINValidationResult: Validation result with session info or error
         """
         if not self.db_session:
+            # No DB session: nothing to serialize, but still record the attempt
+            # via the (no-op) recorder for symmetry with the rest of the flow.
             await self._record_attempt(
                 user_id, pin_type, False, ip_address, user_agent, "Database unavailable"
             )
             return PINValidationResult(success=False, error_message="Database service unavailable")
 
-        # Check if user is locked out
-        lockout_until = await self._is_user_locked_out(user_id, pin_type)
-        if lockout_until:
-            logger.warning(
-                f"PIN attempt blocked - user {user_id} is locked out until {lockout_until}"
-            )
-            await self._record_attempt(
-                user_id, pin_type, False, ip_address, user_agent, "User locked out"
-            )
-            return PINValidationResult(
-                success=False,
-                error_message="User is locked out due to failed attempts",
-                lockout_until=lockout_until,
-            )
+        async with self._db_lock:
+            # Check if user is locked out
+            lockout_until = await self._is_user_locked_out(user_id, pin_type)
+            if lockout_until:
+                logger.warning(
+                    f"PIN attempt blocked - user {user_id} is locked out until {lockout_until}"
+                )
+                await self._record_attempt(
+                    user_id, pin_type, False, ip_address, user_agent, "User locked out"
+                )
+                return PINValidationResult(
+                    success=False,
+                    error_message="User is locked out due to failed attempts",
+                    lockout_until=lockout_until,
+                )
 
-        # Get PIN from database
-        user_pin = await self.db_session.execute(
-            select(UserPIN).where(
-                and_(
-                    UserPIN.user_id == user_id,
-                    UserPIN.pin_type == pin_type,
-                    UserPIN.is_active == True,
+            # Get PIN from database
+            user_pin = await self.db_session.execute(
+                select(UserPIN).where(
+                    and_(
+                        UserPIN.user_id == user_id,
+                        UserPIN.pin_type == pin_type,
+                        UserPIN.is_active == True,
+                    )
                 )
             )
-        )
-        pin_record = user_pin.scalar_one_or_none()
+            pin_record = user_pin.scalar_one_or_none()
 
-        if not pin_record:
-            logger.warning(f"No active PIN found for user {user_id}, type {pin_type}")
+            if not pin_record:
+                logger.warning(f"No active PIN found for user {user_id}, type {pin_type}")
+                await self._record_attempt(
+                    user_id, pin_type, False, ip_address, user_agent, "PIN not found"
+                )
+                return PINValidationResult(
+                    success=False, error_message="PIN not configured or inactive"
+                )
+
+            # Validate PIN
+            hashed_pin = self._hash_pin(pin, pin_record.salt)
+            is_valid = hashed_pin == pin_record.pin_hash
+
+            if not is_valid:
+                logger.warning(f"Invalid PIN attempt by user {user_id} for type {pin_type}")
+                await self._record_attempt(
+                    user_id, pin_type, False, ip_address, user_agent, "Invalid PIN"
+                )
+                return PINValidationResult(success=False, error_message="Invalid PIN")
+
+            # PIN is valid - create session
+            session_id = await self._create_session(
+                user_id, pin_type, pin_record, ip_address=ip_address, user_agent=user_agent
+            )
+
+            # Update PIN usage count
+            pin_record.use_count += 1
+            pin_record.last_used_at = datetime.now(UTC)
+            await self.db_session.commit()
+
+            # Record successful attempt
             await self._record_attempt(
-                user_id, pin_type, False, ip_address, user_agent, "PIN not found"
-            )
-            return PINValidationResult(
-                success=False, error_message="PIN not configured or inactive"
+                user_id, pin_type, True, ip_address, user_agent, session_id=session_id
             )
 
-        # Validate PIN
-        hashed_pin = self._hash_pin(pin, pin_record.salt)
-        is_valid = hashed_pin == pin_record.pin_hash
+            logger.info(f"PIN validation successful for user {user_id}, type {pin_type}")
+            return PINValidationResult(success=True, session_id=session_id)
 
-        if not is_valid:
-            logger.warning(f"Invalid PIN attempt by user {user_id} for type {pin_type}")
-            await self._record_attempt(
-                user_id, pin_type, False, ip_address, user_agent, "Invalid PIN"
-            )
-            return PINValidationResult(success=False, error_message="Invalid PIN")
+    async def _create_session(
+        self,
+        user_id: str,
+        pin_type: str,
+        user_pin: UserPIN,
+        ip_address: str | None = None,
+        user_agent: str | None = None,
+    ) -> str:
+        """Create a new PIN authorization session in the database.
 
-        # PIN is valid - create session
-        session_id = await self._create_session(user_id, pin_type, pin_record)
-
-        # Update PIN usage count
-        pin_record.use_count += 1
-        pin_record.last_used_at = datetime.now(UTC)
-        await self.db_session.commit()
-
-        # Record successful attempt
-        await self._record_attempt(
-            user_id, pin_type, True, ip_address, user_agent, session_id=session_id
-        )
-
-        logger.info(f"PIN validation successful for user {user_id}, type {pin_type}")
-        return PINValidationResult(success=True, session_id=session_id)
-
-    async def _create_session(self, user_id: str, pin_type: str, user_pin: UserPIN) -> str:
-        """Create a new PIN authorization session in the database."""
+        ``ip_address`` / ``user_agent`` are propagated from the originating
+        request so the audit trail on ``PINSession`` matches the audit
+        trail on ``PINAttempt``. Earlier revisions accepted these on
+        ``validate_pin`` but silently dropped them here, leaving the
+        session row with NULL audit fields even when the caller supplied
+        them — a real audit-completeness bug for the realistic threat
+        model (see ``coachiq-architecture.md``: API-side abuse is the
+        threat we actually defend against).
+        """
         if not self.db_session:
             raise RuntimeError("Database session not available")
 
@@ -562,6 +641,8 @@ class PINManager:
             user_pin_id=user_pin.id,
             session_id=session_id,
             created_by_user_id=user_id,
+            ip_address=ip_address,
+            user_agent=user_agent,
             max_duration_minutes=self.config.session_timeout_minutes,
             max_operations=max_operations,
             operation_count=0,
@@ -595,52 +676,55 @@ class PINManager:
             logger.error("Database session not available for operation authorization")
             return False
 
-        # Get session from database
-        session_query = await self.db_session.execute(
-            select(DBPINSession).where(
-                and_(DBPINSession.session_id == session_id, DBPINSession.is_active == True)
+        async with self._db_lock:
+            # Get session from database
+            session_query = await self.db_session.execute(
+                select(DBPINSession).where(
+                    and_(DBPINSession.session_id == session_id, DBPINSession.is_active == True)
+                )
             )
-        )
-        session = session_query.scalar_one_or_none()
+            session = session_query.scalar_one_or_none()
 
-        if not session:
-            logger.warning(f"Unknown or inactive session ID: {session_id}")
-            return False
+            if not session:
+                logger.warning(f"Unknown or inactive session ID: {session_id}")
+                return False
 
-        # Check session expiration
-        if datetime.now(UTC) > session.expires_at:
-            logger.warning(f"Expired session used: {session_id}")
-            session.is_active = False
-            session.terminated_at = datetime.now(UTC)
+            # Check session expiration
+            if datetime.now(UTC) > _coerce_utc_aware(session.expires_at):
+                logger.warning(f"Expired session used: {session_id}")
+                session.is_active = False
+                session.terminated_at = datetime.now(UTC)
+                await self.db_session.commit()
+                return False
+
+            # Check user matches (if provided)
+            if user_id and session.created_by_user_id != user_id:
+                logger.warning(
+                    f"Session user mismatch: {session.created_by_user_id} != {user_id}"
+                )
+                return False
+
+            # Check usage limits
+            if session.max_operations and session.operation_count >= session.max_operations:
+                logger.warning(f"Session {session_id} usage limit exceeded")
+                session.is_active = False
+                session.terminated_at = datetime.now(UTC)
+                await self.db_session.commit()
+                return False
+
+            # Authorize operation
+            session.operation_count += 1
+            session.last_used_at = datetime.now(UTC)
+
+            # Terminate session if single-use
+            if session.max_operations == 1:
+                session.is_active = False
+                session.terminated_at = datetime.now(UTC)
+                logger.info(f"Terminated single-use session {session_id}")
+
             await self.db_session.commit()
-            return False
-
-        # Check user matches (if provided)
-        if user_id and session.created_by_user_id != user_id:
-            logger.warning(f"Session user mismatch: {session.created_by_user_id} != {user_id}")
-            return False
-
-        # Check usage limits
-        if session.max_operations and session.operation_count >= session.max_operations:
-            logger.warning(f"Session {session_id} usage limit exceeded")
-            session.is_active = False
-            session.terminated_at = datetime.now(UTC)
-            await self.db_session.commit()
-            return False
-
-        # Authorize operation
-        session.operation_count += 1
-        session.last_used_at = datetime.now(UTC)
-
-        # Terminate session if single-use
-        if session.max_operations == 1:
-            session.is_active = False
-            session.terminated_at = datetime.now(UTC)
-            logger.info(f"Terminated single-use session {session_id}")
-
-        await self.db_session.commit()
-        logger.info(f"Authorized operation {operation} for session {session_id}")
-        return True
+            logger.info(f"Authorized operation {operation} for session {session_id}")
+            return True
 
     async def revoke_session(self, session_id: str) -> bool:
         """
@@ -655,21 +739,24 @@ class PINManager:
         if not self.db_session:
             return False
 
-        session_query = await self.db_session.execute(
-            select(DBPINSession).where(
-                and_(DBPINSession.session_id == session_id, DBPINSession.is_active == True)
+        async with self._db_lock:
+            session_query = await self.db_session.execute(
+                select(DBPINSession).where(
+                    and_(DBPINSession.session_id == session_id, DBPINSession.is_active == True)
+                )
             )
-        )
-        session = session_query.scalar_one_or_none()
+            session = session_query.scalar_one_or_none()
 
-        if session:
-            session.is_active = False
-            session.terminated_at = datetime.now(UTC)
-            await self.db_session.commit()
-            logger.info(f"Revoked PIN session {session_id} for user {session.created_by_user_id}")
-            return True
+            if session:
+                session.is_active = False
+                session.terminated_at = datetime.now(UTC)
+                await self.db_session.commit()
+                logger.info(
+                    f"Revoked PIN session {session_id} for user {session.created_by_user_id}"
+                )
+                return True
 
-        return False
+            return False
 
     async def revoke_all_user_sessions(self, user_id: str) -> int:
         """
@@ -684,26 +771,30 @@ class PINManager:
         if not self.db_session:
             return 0
 
-        # Get all active sessions for user
-        active_sessions = await self.db_session.execute(
-            select(DBPINSession).where(
-                and_(DBPINSession.created_by_user_id == user_id, DBPINSession.is_active == True)
+        async with self._db_lock:
+            # Get all active sessions for user
+            active_sessions = await self.db_session.execute(
+                select(DBPINSession).where(
+                    and_(
+                        DBPINSession.created_by_user_id == user_id,
+                        DBPINSession.is_active == True,
+                    )
+                )
             )
-        )
 
-        sessions = active_sessions.scalars().all()
-        revoked_count = 0
+            sessions = active_sessions.scalars().all()
+            revoked_count = 0
 
-        for session in sessions:
-            session.is_active = False
-            session.terminated_at = datetime.now(UTC)
-            revoked_count += 1
+            for session in sessions:
+                session.is_active = False
+                session.terminated_at = datetime.now(UTC)
+                revoked_count += 1
 
-        if revoked_count > 0:
-            await self.db_session.commit()
-            logger.info(f"Revoked {revoked_count} sessions for user {user_id}")
+            if revoked_count > 0:
+                await self.db_session.commit()
+                logger.info(f"Revoked {revoked_count} sessions for user {user_id}")
 
-        return revoked_count
+            return revoked_count
 
     async def _cleanup_expired_sessions(self) -> None:
         """Clean up expired sessions."""
@@ -753,10 +844,11 @@ class PINManager:
             expires_at=session.expires_at,
             operations_used=session.operation_count,
             max_operations=session.max_operations,
-            is_active=session.is_active and datetime.now(UTC) < session.expires_at,
+            is_active=session.is_active
+            and datetime.now(UTC) < _coerce_utc_aware(session.expires_at),
         )
 
-    async def get_user_status(self, user_id: str) -> dict:
+    async def get_user_status(self, user_id: str) -> dict[str, Any]:
         """Get PIN status for a user."""
         if not self.db_session:
             return {"error": "Database unavailable"}
@@ -801,7 +893,7 @@ class PINManager:
             "can_use_pins": len(lockout_times) == 0,
         }
 
-    async def get_system_status(self) -> dict:
+    async def get_system_status(self) -> dict[str, Any]:
         """Get overall PIN system status."""
         if not self.db_session:
             return {"error": "Database unavailable"}

--- a/backend/services/pin_manager.py
+++ b/backend/services/pin_manager.py
@@ -28,6 +28,9 @@ from backend.models.auth import UserPIN
 
 logger = logging.getLogger(__name__)
 
+# Number of default PINs minted per user (emergency / override / maintenance).
+_DEFAULT_PIN_COUNT = 3
+
 
 def _ensure_utc_aware(dt: datetime | None) -> datetime | None:
     """Coerce a datetime read back from the database to UTC-aware.
@@ -177,21 +180,22 @@ class PINManager:
             dict: Generated PINs by type (for one-time display)
         """
         if not self.db_session:
-            raise RuntimeError("Database session not available")
+            msg = "Database session not available"
+            raise RuntimeError(msg)
 
         # Check if PINs already exist for this user
         existing_pins = await self.db_session.execute(
             select(UserPIN).where(UserPIN.user_id == user_id)
         )
         if existing_pins.scalars().first():
-            logger.info(f"PINs already exist for user {user_id}")
+            logger.info("PINs already exist for user %s", user_id)
             return {}
 
         generated_pins = {}
 
         # Generate unique 4-digit PINs
-        pin_values = set()
-        while len(pin_values) < 3:
+        pin_values: set[str] = set()
+        while len(pin_values) < _DEFAULT_PIN_COUNT:
             pin = secrets.randbelow(9000) + 1000  # 4-digit PIN
             pin_values.add(str(pin))
 
@@ -202,7 +206,7 @@ class PINManager:
             generated_pins[pin_type] = pin_value
             await self.set_pin(user_id, pin_type, pin_value)
 
-        logger.warning(f"Default PINs initialized for user {user_id}")
+        logger.warning("Default PINs initialized for user %s", user_id)
         return generated_pins
 
     def _generate_salt(self) -> str:
@@ -233,10 +237,12 @@ class PINManager:
             RuntimeError: If database session not available
         """
         if not self.db_session:
-            raise RuntimeError("Database session not available")
+            msg = "Database session not available"
+            raise RuntimeError(msg)
 
         if not self._validate_pin_format(pin):
-            raise ValueError("PIN doesn't meet format requirements")
+            msg = "PIN doesn't meet format requirements"
+            raise ValueError(msg)
 
         async with self._db_lock:
             # Generate salt and hash PIN
@@ -278,7 +284,10 @@ class PINManager:
 
             await self.db_session.commit()
             logger.info(
-                f"PIN {'updated' if existing else 'created'} for user {user_id}, type: {pin_type}"
+                "PIN %s for user %s, type: %s",
+                "updated" if existing else "created",
+                user_id,
+                pin_type,
             )
             return True
 
@@ -385,10 +394,7 @@ class PINManager:
         if len(pin) < self.config.min_pin_length or len(pin) > self.config.max_pin_length:
             return False
 
-        if self.config.require_numeric_only and not pin.isdigit():
-            return False
-
-        return True
+        return not (self.config.require_numeric_only and not pin.isdigit())
 
     async def _is_user_locked_out(self, user_id: str, pin_type: str) -> datetime | None:
         """
@@ -408,7 +414,15 @@ class PINManager:
                 and_(
                     DBPINAttempt.attempted_by_user_id == user_id,
                     DBPINAttempt.pin_type == pin_type,
-                    DBPINAttempt.success == False,
+                    # SQLAlchemy boolean negation: `~col` => `NOT col` in SQL.
+                    # Don't use Python `not col` here — that evaluates the
+                    # column object as a Python bool (always truthy) and the
+                    # filter silently degenerates. Don't use `col.is_(False)`
+                    # either: SQLite emits `IS 0`, which mis-evaluates Boolean
+                    # columns in some dialects. ruff E712 nudges toward the
+                    # wrong fixes here; the bitwise form is the correct SQLA
+                    # idiom and survives across dialects.
+                    ~DBPINAttempt.success,
                     DBPINAttempt.attempted_at > cutoff_time,
                 )
             )
@@ -424,7 +438,8 @@ class PINManager:
                     and_(
                         DBPINAttempt.attempted_by_user_id == user_id,
                         DBPINAttempt.pin_type == pin_type,
-                        DBPINAttempt.success == False,
+                        # See note on `~col` vs `not col` above.
+                        ~DBPINAttempt.success,
                     )
                 )
                 .order_by(DBPINAttempt.attempted_at.desc())
@@ -442,7 +457,7 @@ class PINManager:
 
         return None
 
-    async def _record_attempt(
+    async def _record_attempt(  # noqa: PLR0913 - audit trail needs full request context
         self,
         user_id: str | None,
         pin_type: str,
@@ -505,7 +520,9 @@ class PINManager:
             lockout_until = await self._is_user_locked_out(user_id, pin_type)
             if lockout_until:
                 logger.warning(
-                    f"PIN attempt blocked - user {user_id} is locked out until {lockout_until}"
+                    "PIN attempt blocked - user %s is locked out until %s",
+                    user_id,
+                    lockout_until,
                 )
                 await self._record_attempt(
                     user_id, pin_type, False, ip_address, user_agent, "User locked out"
@@ -522,14 +539,14 @@ class PINManager:
                     and_(
                         UserPIN.user_id == user_id,
                         UserPIN.pin_type == pin_type,
-                        UserPIN.is_active == True,
+                        UserPIN.is_active,
                     )
                 )
             )
             pin_record = user_pin.scalar_one_or_none()
 
             if not pin_record:
-                logger.warning(f"No active PIN found for user {user_id}, type {pin_type}")
+                logger.warning("No active PIN found for user %s, type %s", user_id, pin_type)
                 await self._record_attempt(
                     user_id, pin_type, False, ip_address, user_agent, "PIN not found"
                 )
@@ -542,7 +559,7 @@ class PINManager:
             is_valid = hashed_pin == pin_record.pin_hash
 
             if not is_valid:
-                logger.warning(f"Invalid PIN attempt by user {user_id} for type {pin_type}")
+                logger.warning("Invalid PIN attempt by user %s for type %s", user_id, pin_type)
                 await self._record_attempt(
                     user_id, pin_type, False, ip_address, user_agent, "Invalid PIN"
                 )
@@ -563,7 +580,7 @@ class PINManager:
                 user_id, pin_type, True, ip_address, user_agent, session_id=session_id
             )
 
-            logger.info(f"PIN validation successful for user {user_id}, type {pin_type}")
+            logger.info("PIN validation successful for user %s, type %s", user_id, pin_type)
             return PINValidationResult(success=True, session_id=session_id)
 
     async def _create_session(
@@ -586,7 +603,8 @@ class PINManager:
         threat we actually defend against).
         """
         if not self.db_session:
-            raise RuntimeError("Database session not available")
+            msg = "Database session not available"
+            raise RuntimeError(msg)
 
         # Clean up expired sessions first
         await self._cleanup_expired_sessions()
@@ -596,7 +614,7 @@ class PINManager:
             select(func.count(DBPINSession.id)).where(
                 and_(
                     DBPINSession.created_by_user_id == user_id,
-                    DBPINSession.is_active == True,
+                    DBPINSession.is_active,
                     DBPINSession.expires_at > datetime.now(UTC),
                 )
             )
@@ -608,9 +626,7 @@ class PINManager:
             # Remove oldest session
             oldest_session = await self.db_session.execute(
                 select(DBPINSession)
-                .where(
-                    and_(DBPINSession.created_by_user_id == user_id, DBPINSession.is_active == True)
-                )
+                .where(and_(DBPINSession.created_by_user_id == user_id, DBPINSession.is_active))
                 .order_by(DBPINSession.created_at)
                 .limit(1)
             )
@@ -619,7 +635,7 @@ class PINManager:
             if oldest:
                 oldest.is_active = False
                 oldest.terminated_at = datetime.now(UTC)
-                logger.info(f"Removed oldest session for user {user_id} due to limit")
+                logger.info("Removed oldest session for user %s due to limit", user_id)
 
         # Create new session
         session_id = secrets.token_urlsafe(32)
@@ -655,7 +671,7 @@ class PINManager:
         self.db_session.add(new_session)
         await self.db_session.commit()
 
-        logger.info(f"Created PIN session {session_id} for user {user_id}, type {pin_type}")
+        logger.info("Created PIN session %s for user %s, type %s", session_id, user_id, pin_type)
         return session_id
 
     async def authorize_operation(
@@ -680,18 +696,18 @@ class PINManager:
             # Get session from database
             session_query = await self.db_session.execute(
                 select(DBPINSession).where(
-                    and_(DBPINSession.session_id == session_id, DBPINSession.is_active == True)
+                    and_(DBPINSession.session_id == session_id, DBPINSession.is_active)
                 )
             )
             session = session_query.scalar_one_or_none()
 
             if not session:
-                logger.warning(f"Unknown or inactive session ID: {session_id}")
+                logger.warning("Unknown or inactive session ID: %s", session_id)
                 return False
 
             # Check session expiration
             if datetime.now(UTC) > _coerce_utc_aware(session.expires_at):
-                logger.warning(f"Expired session used: {session_id}")
+                logger.warning("Expired session used: %s", session_id)
                 session.is_active = False
                 session.terminated_at = datetime.now(UTC)
                 await self.db_session.commit()
@@ -700,13 +716,15 @@ class PINManager:
             # Check user matches (if provided)
             if user_id and session.created_by_user_id != user_id:
                 logger.warning(
-                    f"Session user mismatch: {session.created_by_user_id} != {user_id}"
+                    "Session user mismatch: %s != %s",
+                    session.created_by_user_id,
+                    user_id,
                 )
                 return False
 
             # Check usage limits
             if session.max_operations and session.operation_count >= session.max_operations:
-                logger.warning(f"Session {session_id} usage limit exceeded")
+                logger.warning("Session %s usage limit exceeded", session_id)
                 session.is_active = False
                 session.terminated_at = datetime.now(UTC)
                 await self.db_session.commit()
@@ -720,10 +738,10 @@ class PINManager:
             if session.max_operations == 1:
                 session.is_active = False
                 session.terminated_at = datetime.now(UTC)
-                logger.info(f"Terminated single-use session {session_id}")
+                logger.info("Terminated single-use session %s", session_id)
 
             await self.db_session.commit()
-            logger.info(f"Authorized operation {operation} for session {session_id}")
+            logger.info("Authorized operation %s for session %s", operation, session_id)
             return True
 
     async def revoke_session(self, session_id: str) -> bool:
@@ -742,7 +760,7 @@ class PINManager:
         async with self._db_lock:
             session_query = await self.db_session.execute(
                 select(DBPINSession).where(
-                    and_(DBPINSession.session_id == session_id, DBPINSession.is_active == True)
+                    and_(DBPINSession.session_id == session_id, DBPINSession.is_active)
                 )
             )
             session = session_query.scalar_one_or_none()
@@ -752,7 +770,9 @@ class PINManager:
                 session.terminated_at = datetime.now(UTC)
                 await self.db_session.commit()
                 logger.info(
-                    f"Revoked PIN session {session_id} for user {session.created_by_user_id}"
+                    "Revoked PIN session %s for user %s",
+                    session_id,
+                    session.created_by_user_id,
                 )
                 return True
 
@@ -777,7 +797,7 @@ class PINManager:
                 select(DBPINSession).where(
                     and_(
                         DBPINSession.created_by_user_id == user_id,
-                        DBPINSession.is_active == True,
+                        DBPINSession.is_active,
                     )
                 )
             )
@@ -792,7 +812,7 @@ class PINManager:
 
             if revoked_count > 0:
                 await self.db_session.commit()
-                logger.info(f"Revoked {revoked_count} sessions for user {user_id}")
+                logger.info("Revoked %s sessions for user %s", revoked_count, user_id)
 
             return revoked_count
 
@@ -804,7 +824,7 @@ class PINManager:
         # Mark expired sessions as inactive
         expired_sessions = await self.db_session.execute(
             select(DBPINSession).where(
-                and_(DBPINSession.is_active == True, DBPINSession.expires_at <= datetime.now(UTC))
+                and_(DBPINSession.is_active, DBPINSession.expires_at <= datetime.now(UTC))
             )
         )
 
@@ -815,7 +835,7 @@ class PINManager:
 
         if sessions:
             await self.db_session.commit()
-            logger.info(f"Cleaned up {len(sessions)} expired sessions")
+            logger.info("Cleaned up %s expired sessions", len(sessions))
 
     async def get_session_info(self, session_id: str) -> PINSessionData | None:
         """Get information about a PIN session."""
@@ -865,7 +885,7 @@ class PINManager:
             select(DBPINSession).where(
                 and_(
                     DBPINSession.created_by_user_id == user_id,
-                    DBPINSession.is_active == True,
+                    DBPINSession.is_active,
                     DBPINSession.expires_at > datetime.now(UTC),
                 )
             )
@@ -904,14 +924,14 @@ class PINManager:
         # Count active sessions
         active_sessions_query = await self.db_session.execute(
             select(func.count(DBPINSession.id)).where(
-                and_(DBPINSession.is_active == True, DBPINSession.expires_at > datetime.now(UTC))
+                and_(DBPINSession.is_active, DBPINSession.expires_at > datetime.now(UTC))
             )
         )
         active_sessions = active_sessions_query.scalar() or 0
 
         # Count configured PINs
         pins_query = await self.db_session.execute(
-            select(func.count(UserPIN.id)).where(UserPIN.is_active == True)
+            select(func.count(UserPIN.id)).where(UserPIN.is_active)
         )
         configured_pins = pins_query.scalar() or 0
 

--- a/scripts/ci-quality-gate.sh
+++ b/scripts/ci-quality-gate.sh
@@ -19,7 +19,7 @@ RESET="\033[0m"
 # gate's job is to stop the count from going UP (a ratchet); fixing actual
 # pyright errors lower the count and the script will print a green message
 # nudging you to update the baseline downward.
-EXPECTED_PYRIGHT_ERRORS=1543  # Resynced 2026-05-11 after long stale period; previous 962 was hit before pyright 1.1.401 + new code accumulated since.
+EXPECTED_PYRIGHT_ERRORS=1533  # Ratcheted 2026-05-11 by PIN-manager fixes (Pydantic Field(default=...) keyword form cleared 10 latent errors).
 EXPECTED_FRONTEND_TS_ERRORS=4  # Resynced 2026-05-11; pre-existing TS debt in DatabaseManagementTab + can-sniffer.
 
 # Determine target branch (for GitHub Actions or local testing)

--- a/tests/services/test_pin_manager_db.py
+++ b/tests/services/test_pin_manager_db.py
@@ -70,15 +70,26 @@ async def test_user(db_session):
 
 @pytest.fixture
 def pin_config():
-    """PIN configuration for testing."""
+    """PIN configuration for testing.
+
+    NOTE: ``PINConfig`` field names are ``min_pin_length`` /
+    ``max_failed_attempts`` etc. — earlier revisions of this fixture used
+    bare names (``min_length`` / ``max_attempts``) that Pydantic v2
+    silently dropped because ``model_config`` allows extras, so the test
+    config wasn't actually overriding production defaults. Fixed.
+
+    ``max_concurrent_sessions`` is bumped to 10 so the concurrent-session
+    test can mint 5 sessions in parallel without the LRU eviction in
+    ``_create_session`` kicking in.
+    """
     return PINConfig(
-        min_length=4,
-        max_length=8,
-        require_numbers=True,
-        require_letters=False,
-        session_duration_minutes=60,
-        max_attempts=3,
+        min_pin_length=4,
+        max_pin_length=8,
+        require_numeric_only=True,
+        session_timeout_minutes=60,
+        max_failed_attempts=3,
         lockout_duration_minutes=15,
+        max_concurrent_sessions=10,
     )
 
 
@@ -146,12 +157,19 @@ class TestPINCreationAndStorage:
         assert len(pins) == 1
         assert pins[0].description == "Updated PIN"
 
-        # Verify new PIN works
-        session_id = await pin_manager_with_db.validate_pin(
+        # Verify new PIN works.
+        # NOTE: ``validate_pin`` returns a ``PINValidationResult`` Pydantic
+        # model (``.success`` / ``.session_id`` / ``.error_message`` /
+        # ``.lockout_until``); ``.session_id`` is None on any failure path.
+        # Tests in this file unwrap to ``session_id`` for compactness; use
+        # ``result.success`` directly when the session id isn't otherwise
+        # needed.
+        result = await pin_manager_with_db.validate_pin(
             user_id=test_user.id,
             pin="5678",
             pin_type="emergency",
         )
+        session_id = result.session_id
         assert session_id is not None
 
     async def test_create_multiple_pin_types(self, pin_manager_with_db, db_session, test_user):
@@ -198,13 +216,14 @@ class TestPINValidationAndSessions:
         )
 
         # Validate PIN
-        session_id = await pin_manager_with_db.validate_pin(
+        result = await pin_manager_with_db.validate_pin(
             user_id=test_user.id,
             pin="1234",
             pin_type="emergency",
             ip_address="127.0.0.1",
             user_agent="Test Agent",
         )
+        session_id = result.session_id
 
         assert session_id is not None
 
@@ -218,7 +237,14 @@ class TestPINValidationAndSessions:
         assert session.is_active is True
         assert session.ip_address == "127.0.0.1"
         assert session.user_agent == "Test Agent"
-        assert session.expires_at > datetime.now(UTC)
+        # SQLite strips tzinfo on round-trip even with DateTime(timezone=True);
+        # production code now coerces back to UTC-aware via _ensure_utc_aware
+        # at every comparison site. Mirror that here so the test matches the
+        # production contract instead of asserting a SQLAlchemy-dialect-quirk.
+        session_expires_at = session.expires_at
+        if session_expires_at.tzinfo is None:
+            session_expires_at = session_expires_at.replace(tzinfo=UTC)
+        assert session_expires_at > datetime.now(UTC)
 
     async def test_validate_wrong_pin_fails(self, pin_manager_with_db, db_session, test_user):
         """Test that wrong PIN validation fails."""
@@ -230,22 +256,27 @@ class TestPINValidationAndSessions:
         )
 
         # Try wrong PIN
-        session_id = await pin_manager_with_db.validate_pin(
+        result = await pin_manager_with_db.validate_pin(
             user_id=test_user.id,
             pin="5678",  # Wrong PIN
             pin_type="emergency",
         )
 
-        assert session_id is None
+        assert result.session_id is None
+        assert not result.success
 
         # Verify attempt was logged
         stmt = select(PINAttempt).filter_by(attempted_by_user_id=test_user.id)
-        result = await db_session.execute(stmt)
-        attempt = result.scalar_one_or_none()
+        result_db = await db_session.execute(stmt)
+        attempt = result_db.scalar_one_or_none()
 
         assert attempt is not None
         assert attempt.success is False
-        assert attempt.failure_reason == "invalid_pin"
+        # Production records human-readable failure reasons (not snake_case
+        # codes); see PINManager._record_attempt call sites in
+        # backend/services/pin_manager.py. Other failure_reasons used:
+        # "Database unavailable", "User locked out", "PIN not found".
+        assert attempt.failure_reason == "Invalid PIN"
 
     async def test_session_expiration(self, pin_manager_with_db, db_session, test_user):
         """Test that expired sessions are not valid."""
@@ -293,21 +324,22 @@ class TestLockoutProtection:
 
         # Make multiple failed attempts
         for _ in range(3):  # Max attempts = 3
-            session_id = await pin_manager_with_db.validate_pin(
+            result = await pin_manager_with_db.validate_pin(
                 user_id=test_user.id,
                 pin="wrong",
                 pin_type="emergency",
             )
-            assert session_id is None
+            assert result.session_id is None
 
         # Next attempt should fail due to lockout
-        session_id = await pin_manager_with_db.validate_pin(
+        result = await pin_manager_with_db.validate_pin(
             user_id=test_user.id,
             pin="1234",  # Even correct PIN should fail
             pin_type="emergency",
         )
 
-        assert session_id is None
+        assert result.session_id is None
+        assert result.lockout_until is not None  # locked out, not just rejected
 
         # Verify attempts were logged
         stmt = select(PINAttempt).filter_by(attempted_by_user_id=test_user.id)
@@ -348,13 +380,13 @@ class TestLockoutProtection:
         await db_session.commit()
 
         # Should be able to validate now
-        session_id = await pin_manager_with_db.validate_pin(
+        result = await pin_manager_with_db.validate_pin(
             user_id=test_user.id,
             pin="1234",
             pin_type="emergency",
         )
 
-        assert session_id is not None
+        assert result.session_id is not None
 
 
 class TestConcurrentOperations:
@@ -379,16 +411,18 @@ class TestConcurrentOperations:
 
         # Run 5 concurrent validations
         tasks = [validate() for _ in range(5)]
-        session_ids = await asyncio.gather(*tasks)
+        results = await asyncio.gather(*tasks)
+        session_ids = [r.session_id for r in results]
 
         # All should succeed with unique session IDs
+        assert all(r.success for r in results)
         assert all(sid is not None for sid in session_ids)
         assert len(set(session_ids)) == 5  # All unique
 
         # Verify all sessions exist in database
         stmt = select(PINSession).filter(PINSession.session_id.in_(session_ids))
-        result = await db_session.execute(stmt)
-        sessions = result.scalars().all()
+        db_result = await db_session.execute(stmt)
+        sessions = db_result.scalars().all()
 
         assert len(sessions) == 5
         assert all(s.is_active for s in sessions)
@@ -405,11 +439,13 @@ class TestConcurrentOperations:
         )
 
         # Create session with operation limit
-        session_id = await pin_manager_with_db.validate_pin(
+        result = await pin_manager_with_db.validate_pin(
             user_id=test_user.id,
             pin="1234",
             pin_type="emergency",
         )
+        session_id = result.session_id
+        assert session_id is not None
 
         # Update session to have max operations
         stmt = select(PINSession).filter_by(session_id=session_id)
@@ -452,37 +488,37 @@ class TestPINRotationAndManagement:
         )
 
         # Validate old PIN works
-        session_id = await pin_manager_with_db.validate_pin(
+        result = await pin_manager_with_db.validate_pin(
             user_id=test_user.id,
             pin="1234",
             pin_type="emergency",
         )
-        assert session_id is not None
+        assert result.session_id is not None
 
         # Rotate PIN
-        result = await pin_manager_with_db.rotate_pin(
+        result_bool = await pin_manager_with_db.rotate_pin(
             user_id=test_user.id,
             pin_type="emergency",
             old_pin="1234",
             new_pin="5678",
         )
-        assert result is True
+        assert result_bool is True
 
         # Old PIN should not work
-        session_id = await pin_manager_with_db.validate_pin(
+        result = await pin_manager_with_db.validate_pin(
             user_id=test_user.id,
             pin="1234",
             pin_type="emergency",
         )
-        assert session_id is None
+        assert result.session_id is None
 
         # New PIN should work
-        session_id = await pin_manager_with_db.validate_pin(
+        result = await pin_manager_with_db.validate_pin(
             user_id=test_user.id,
             pin="5678",
             pin_type="emergency",
         )
-        assert session_id is not None
+        assert result.session_id is not None
 
     async def test_deactivate_pin(self, pin_manager_with_db, db_session, test_user):
         """Test deactivating a PIN."""
@@ -494,22 +530,22 @@ class TestPINRotationAndManagement:
         )
 
         # Deactivate PIN
-        result = await pin_manager_with_db.deactivate_pin(
+        result_bool = await pin_manager_with_db.deactivate_pin(
             user_id=test_user.id,
             pin_type="emergency",
         )
-        assert result is True
+        assert result_bool is True
 
         # PIN should not work
-        session_id = await pin_manager_with_db.validate_pin(
+        result = await pin_manager_with_db.validate_pin(
             user_id=test_user.id,
             pin="1234",
             pin_type="emergency",
         )
-        assert session_id is None
+        assert result.session_id is None
 
         # Verify PIN is inactive in database
         stmt = select(UserPIN).filter_by(user_id=test_user.id, pin_type="emergency")
-        result = await db_session.execute(stmt)
-        pin = result.scalar_one()
+        db_result = await db_session.execute(stmt)
+        pin = db_result.scalar_one()
         assert pin.is_active is False


### PR DESCRIPTION
Closes #94. Cluster goes **5p / 7f / 1e → 12p / 0 / 0**.

## Production bugs found and fixed

1. **`PINManager` `AsyncSession` concurrency hazard.** `validate_pin` / `set_pin` / `deactivate_pin` / `authorize_operation` / `revoke_session` all share one `AsyncSession` but didn't serialize access. Concurrent calls produced `SAWarning: Session.add() within flush process` and could leave the session in an inconsistent state. **Threat-model relevant**: brute-force or burst-style PIN attempts must not corrupt auth state. Fixed by adding a per-instance `asyncio.Lock` and wrapping every public DB-mutating method.

2. **SQLite tz-stripping breaks lockout + session-expiry checks.** SQLite has no native `TIMESTAMP WITH TIME ZONE`; SQLAlchemy `DateTime(timezone=True)` silently degrades there. Tz-aware datetimes write fine but come back tz-naive, causing `TypeError: can't compare offset-naive and offset-aware datetimes` at three Python-side comparison sites. CoachIQ's reference deployment uses SQLite, so this shipped. Added `_ensure_utc_aware` helper (plus `_coerce_utc_aware` overload for non-nullable narrowing) and applied at all three sites in `pin_manager.py`. Surveyed the rest of the backend: this bug class only fires on Python-side comparisons of ORM-loaded datetimes; SQL-side filters (`Model.col > value`) are dialect-handled, and in-memory state in `user_invitation_service` / `safety_service` / `notification_batching` is unaffected.

3. **`validate_pin` dropped `ip_address` / `user_agent` on the floor.** The arguments were accepted, recorded on the `PINAttempt` audit row, but never plumbed through to `_create_session`, so the matching `PINSession` audit fields stayed `NULL`. Fixed by passing them through and persisting onto `PINSession`. Real audit-completeness bug for the API-side threat model.

4. **Pydantic `Field(positional default)` tripped pyright basic.** Switched all `PINConfig` / `PINSessionData` / `PINAttemptData` / `PINValidationResult` declarations to keyword `Field(default=...)`. Pyright count: **1543 → 1533**; ratcheted `EXPECTED_PYRIGHT_ERRORS` in `scripts/ci-quality-gate.sh`.

## Test-side fixes

- `pin_config` fixture used field names that don't exist on `PINConfig` (`min_length` / `max_attempts` / `require_letters` / `session_duration_minutes`); Pydantic v2 silently accepts unknown keys when extras are allowed, so the fixture wasn't actually overriding production defaults. Switched to the real names and bumped `max_concurrent_sessions` to 10 so the concurrency test can mint 5 sessions in parallel without LRU eviction.
- 12 `validate_pin` call sites updated to unwrap `PINValidationResult.session_id` (per the convention documented in `test_validate_pin_creates_session`).
- `failure_reason` assertion fixed to match production's human-readable reason strings (`"Invalid PIN"`), not snake_case codes.
- One test datetime comparison normalized to UTC-aware to mirror the production fix, so it matches the cross-DB contract instead of asserting a SQLAlchemy/SQLite quirk.

## Sanity check

The 14-cluster suite from the prompt: **318 passed, 1 failed**. The single failure is the known pre-existing `test_async_notification_dispatcher::test_force_queue_processing` pollution issue documented in `/memories/repo/handoff-2026-05-11.md` (passes in isolation, fails in full-suite). **No regressions from this PR.**

CI quality gate (`./scripts/ci-quality-gate.sh`) passes locally.

## Cumulative production bugs caught by the test-suite restoration sweep

21 (PRs #89 / #90) + **4 (this PR)** = **25**.

## Architectural framing

`PINManager` directly serves the realistic API-side threat model documented in `coachiq-architecture.md` (unauth'd API access, credential compromise, audit tampering). Bugs 1 and 3 above are exactly the class of issue the project's threat model cares about.