### PR TITLE
fix(tests): restore test_notification_integration cluster (16/16) + 7 production bugs

### DIFF
--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -680,11 +680,47 @@ class NotificationSettings(BaseSettings):
     default_title: str = Field(
         default="CoachIQ Notification", description="Default notification title"
     )
+    app_name: str = Field(
+        default="CoachIQ",
+        description="Application name used in notification templates and headers",
+    )
     template_path: str = Field(
-        default="templates/notifications/", description="Path to notification templates"
+        default="backend/templates/email",
+        description=(
+            "Directory containing email notification templates. Earlier "
+            "revisions defaulted to ``templates/notifications/`` but the "
+            "shipped templates actually live at ``backend/templates/email`` "
+            "and ``EmailTemplateManager`` ignored this field anyway. "
+            "Default updated to match what's actually on disk and the "
+            "field is now honoured by the manager."
+        ),
     )
     log_notifications: bool = Field(
         default=True, description="Log notification attempts and results"
+    )
+
+    # SafeNotificationManager / NotificationQueue knobs.
+    # Production previously read these via ``getattr(self.config, ..., default)``
+    # because they weren't defined here, which meant operators couldn't
+    # actually tune them via env vars -- the ``getattr`` default was the
+    # only path. Defining them as proper fields restores the config
+    # surface and matches what the integration test fixture has expected
+    # for a long time.
+    queue_db_path: str = Field(
+        default="data/notifications.db",
+        description="SQLite path for the persistent notification queue (':memory:' for tests)",
+    )
+    rate_limit_max_tokens: int = Field(
+        default=100,
+        description="Token-bucket capacity for outbound notification rate limiting",
+    )
+    rate_limit_per_minute: int = Field(
+        default=60,
+        description="Token-bucket refill rate (tokens per minute) for outbound notifications",
+    )
+    debounce_minutes: int = Field(
+        default=15,
+        description="Suppression window for duplicate notifications (minutes)",
     )
 
     # Channel configurations

--- a/backend/services/email_template_manager.py
+++ b/backend/services/email_template_manager.py
@@ -66,7 +66,7 @@ class EmailTemplateManager:
     def __init__(
         self,
         config: NotificationSettings,
-        template_dir: str = "backend/templates/email",
+        template_dir: str | None = None,
         cache_ttl_minutes: int = 60,
         enable_template_caching: bool = True,
     ):
@@ -75,12 +75,20 @@ class EmailTemplateManager:
 
         Args:
             config: NotificationSettings configuration
-            template_dir: Directory containing email templates
+            template_dir: Optional override for the directory containing
+                email templates. When None (the typical case), the
+                directory is read from ``config.template_path`` so
+                operators can relocate templates via env var without
+                having to subclass. Earlier revisions hardcoded
+                ``backend/templates/email`` and ignored the config
+                field, which made the ``COACHIQ_NOTIFICATIONS__TEMPLATE_PATH``
+                env var a no-op AND caused tests to scribble into the
+                real shipped templates directory.
             cache_ttl_minutes: Template cache TTL in minutes
             enable_template_caching: Whether to enable template caching
         """
         self.config = config
-        self.template_dir = Path(template_dir)
+        self.template_dir = Path(template_dir or config.template_path)
         self.cache_ttl = timedelta(minutes=cache_ttl_minutes)
         self.enable_caching = enable_template_caching
 
@@ -472,12 +480,22 @@ This is a test message from {{app_name}}. No action required.
             bool: True if created successfully
         """
         try:
-            # Validate template syntax
+            # Validate template syntax. Surface syntax errors as exceptions
+            # rather than swallowing them and returning False -- a silent
+            # False here hid programmer errors (typos in templates) behind
+            # a generic boolean return for a long time. Render-time
+            # ``StrictUndefined`` violations remain a separate concern.
+            from jinja2 import TemplateSyntaxError
+
             if self.jinja_env:
-                self.jinja_env.parse(subject)
-                self.jinja_env.parse(html_content)
-                if text_content:
-                    self.jinja_env.parse(text_content)
+                try:
+                    self.jinja_env.parse(subject)
+                    self.jinja_env.parse(html_content)
+                    if text_content:
+                        self.jinja_env.parse(text_content)
+                except TemplateSyntaxError:
+                    self.logger.exception("Template syntax error creating '%s'", template_name)
+                    raise
 
             # Create template directory
             lang_dir = self.template_dir / language
@@ -504,6 +522,13 @@ This is a test message from {{app_name}}. No action required.
 
         except Exception as e:
             self.logger.error(f"Failed to create template '{template_name}': {e}")
+            # Re-raise template syntax errors so callers can react; swallow
+            # other (probably-IO) failures with a False return for backward
+            # compat.
+            from jinja2 import TemplateSyntaxError
+
+            if isinstance(e, TemplateSyntaxError):
+                raise
             return False
 
     def clear_cache(self) -> None:

--- a/backend/services/notification_queue.py
+++ b/backend/services/notification_queue.py
@@ -128,6 +128,26 @@ class NotificationQueue:
 
         return notification.id
 
+    async def flush(self) -> None:
+        """Persist any in-memory write batch to disk immediately.
+
+        ``enqueue`` returns as soon as the notification is in the
+        in-memory batch — actual disk persistence is deferred until
+        either the batch fills, the batch timer fires, or ``close()``
+        runs. For callers that need an immediate after-write read
+        (statistics, durability checks, controlled shutdown without
+        closing the queue), this method flushes the batch synchronously.
+
+        Note: ``get_statistics()`` and ``dequeue_batch()`` already call
+        ``flush()`` internally so reads always reflect the latest
+        ``enqueue()`` calls. This is exposed as a public method so
+        callers that need durability without reading can still force a
+        flush (e.g. before a controlled restart in tests).
+        """
+        async with self._batch_lock:
+            if self._write_batch:
+                await self._flush_write_batch()
+
     async def dequeue_batch(self, size: int = 10) -> list[NotificationPayload]:
         """
         Get batch of pending notifications for processing.
@@ -140,6 +160,13 @@ class NotificationQueue:
         """
         if not self._db_initialized:
             await self.initialize()
+
+        # Flush any in-memory batch first so a dequeuer immediately after
+        # an enqueue actually sees the new row instead of waiting for the
+        # batch timer. Production previously had a window where enqueue()
+        # returned success but dequeue_batch() saw nothing for up to a
+        # batch-timeout interval -- a real consumer-perceived bug.
+        await self.flush()
 
         try:
             async with aiosqlite.connect(self.db_path) as db:
@@ -325,6 +352,13 @@ class NotificationQueue:
         Returns:
             QueueStatistics: Current queue statistics
         """
+        # Flush any in-memory batch first so the stats reflect every
+        # row a caller has already enqueued. Without this, callers who
+        # do enqueue() -> get_statistics() back-to-back see stale
+        # counts until the batch timer fires (up to ``_batch_timeout``
+        # seconds later).
+        await self.flush()
+
         # Use cached stats if recent
         now = datetime.utcnow()
         if self._stats_cache and self._stats_cache_expires and now < self._stats_cache_expires:

--- a/backend/services/notification_routing.py
+++ b/backend/services/notification_routing.py
@@ -24,6 +24,7 @@ Example:
 """
 
 import logging
+import re
 from collections.abc import Callable
 from datetime import datetime, time
 from enum import Enum
@@ -597,14 +598,21 @@ class NotificationRouter:
         """Evaluate content-based routing conditions."""
         notification = context["notification"]
 
-        # Keyword matching
+        # Keyword matching. Earlier revisions used naive substring
+        # matching (``"update" in "Status Update"`` -> True), which
+        # produced false-positive routes for any notification whose
+        # title happened to contain a configured keyword as a
+        # substring. Use word-boundary regex matching so the configured
+        # keyword "update" matches "Status update" but NOT
+        # "updateserver" or arbitrary substring collisions.
         keywords = conditions.get("keywords", [])
         if keywords:
-            message_lower = notification.message.lower()
-            title_lower = (notification.title or "").lower()
-
+            haystack = f"{notification.message or ''} {notification.title or ''}".lower()
             for keyword in keywords:
-                if keyword.lower() in message_lower or keyword.lower() in title_lower:
+                if not keyword:
+                    continue
+                pattern = r"\b" + re.escape(keyword.lower()) + r"\b"
+                if re.search(pattern, haystack):
                     return True
 
         # Tag matching
@@ -718,7 +726,15 @@ class NotificationRouter:
         user_prefs: UserNotificationPreferences | None,
         notification: NotificationPayload,
     ) -> RoutingDecision:
-        """Apply user preferences to routing decision."""
+        """Apply user preferences to routing decision.
+
+        Adds preferred channels and removes blocked channels, but ALSO
+        respects per-channel minimum-priority thresholds so a user who
+        opts into SMTP only for WARNING+ doesn't get every INFO
+        notification emailed to them. Earlier revisions added every
+        preferred channel unconditionally, which silently spammed
+        users for INFO notifications they had configured to ignore.
+        """
         if not user_prefs:
             return decision
 
@@ -729,11 +745,50 @@ class NotificationRouter:
                 ch for ch in decision.target_channels if ch.value not in blocked
             ]
 
-        # Add preferred channels if not already included
+        # Map of channel -> per-channel minimum-priority threshold the
+        # user configured. Channels not in the map have no per-channel
+        # threshold and are always added when preferred.
+        priority_levels = {
+            NotificationType.INFO: 1,
+            NotificationType.SUCCESS: 1,
+            NotificationType.WARNING: 2,
+            NotificationType.ERROR: 3,
+            NotificationType.CRITICAL: 4,
+        }
+        notification_level = priority_levels.get(notification.level, 1)
+
+        per_channel_min = {
+            NotificationChannel.SMTP: user_prefs.min_priority_email,
+            NotificationChannel.PUSHOVER: user_prefs.min_priority_push,
+        }
+
+        # Add preferred channels if not already included AND the
+        # notification meets that channel's minimum priority.
         for preferred_channel in user_prefs.preferred_channels:
+            min_priority = per_channel_min.get(preferred_channel)
+            if min_priority is not None:
+                required_level = priority_levels.get(min_priority, 1)
+                if notification_level < required_level:
+                    # User opted into this channel only for higher priorities;
+                    # honour the threshold and skip the add.
+                    continue
             if preferred_channel not in decision.target_channels:
                 decision.target_channels.append(preferred_channel)
                 decision.user_preference_override = True
+
+        # Symmetrically, REMOVE channels from a base routing decision
+        # if the user's per-channel threshold says this notification
+        # is too low priority for that channel. (Without this, the
+        # "Default Routing" rule could attach SMTP to an INFO and
+        # the user's WARNING-only preference would be ignored.)
+        decision.target_channels = [
+            ch
+            for ch in decision.target_channels
+            if (
+                per_channel_min.get(ch) is None
+                or notification_level >= priority_levels.get(per_channel_min[ch], 1)  # type: ignore[arg-type]
+            )
+        ]
 
         return decision
 

--- a/backend/services/safe_notification_manager.py
+++ b/backend/services/safe_notification_manager.py
@@ -118,30 +118,38 @@ class SafeNotificationManager:
     async def initialize(self) -> None:
         """Initialize all components."""
         try:
-            # Initialize queue
-            queue_path = getattr(self.config, "queue_db_path", "data/notifications.db")
-            self.queue = NotificationQueue(queue_path)
+            # Initialize queue. Fields below were previously read via
+            # ``getattr(..., default)`` because they weren't defined on
+            # ``NotificationSettings``; now that they are real fields,
+            # access them directly so misconfiguration surfaces loudly.
+            self.queue = NotificationQueue(self.config.queue_db_path)
             await self.queue.initialize()
 
             # Initialize rate limiting
-            max_tokens = getattr(self.config, "rate_limit_max_tokens", 100)
-            refill_rate = getattr(self.config, "rate_limit_per_minute", 60)
-
             self.rate_limiter = TokenBucketRateLimiter(
-                max_tokens=max_tokens, refill_rate=refill_rate
+                max_tokens=self.config.rate_limit_max_tokens,
+                refill_rate=self.config.rate_limit_per_minute,
             )
 
             # Initialize debouncing
-            debounce_minutes = getattr(self.config, "debounce_minutes", 15)
-            self.debouncer = NotificationDebouncer(suppress_window_minutes=debounce_minutes)
+            self.debouncer = NotificationDebouncer(
+                suppress_window_minutes=self.config.debounce_minutes
+            )
 
             # Initialize per-channel rate limiting
             self.channel_rate_limiter = ChannelSpecificRateLimiter()
 
-            # Initialize email template manager
-            if hasattr(self.config, "smtp") and self.config.smtp.enabled:
-                self.template_manager = EmailTemplateManager(self.config)
-                await self.template_manager.initialize()
+            # Initialize email template manager.
+            # Earlier revisions only created this when ``self.config.smtp.enabled``,
+            # which conflated "user wants to send via SMTP" with "user wants
+            # to render templates". Templates are also useful for non-SMTP
+            # channels (system log structured rendering, magic-link previews
+            # in tests, etc.), and ``create_email_template`` /
+            # ``render_template_preview`` failed silently when SMTP was off.
+            # Always construct the template manager; it has no SMTP-specific
+            # initialisation cost.
+            self.template_manager = EmailTemplateManager(self.config)
+            await self.template_manager.initialize()
 
             # Initialize notification router
             self.router = NotificationRouter()
@@ -247,7 +255,15 @@ class SafeNotificationManager:
             )
 
             # Use router to determine optimal channels if available
-            if self.router:
+            # AND the caller didn't explicitly request specific channels.
+            # When ``channels`` is explicitly supplied, honour the
+            # caller's intent rather than letting the router second-guess
+            # them. Earlier revisions silently discarded the explicit
+            # ``channels`` argument and let routing decide -- a real
+            # API contract violation that broke any caller that wanted
+            # to pin a notification to e.g. the local "system" channel
+            # only (e.g. structured-log fan-out, integration tests).
+            if self.router and not channels:
                 system_context = SystemContext(
                     queue_depth=await self._get_queue_depth(),
                     connectivity_status=self._get_connectivity_status(),
@@ -265,7 +281,9 @@ class SafeNotificationManager:
                 preliminary_notification.scheduled_for = routing_decision.scheduled_for
 
             else:
-                # Fallback to simple channel resolution
+                # Caller-supplied channels OR no router available: use the
+                # explicit channel list (or all enabled channels if not
+                # supplied).
                 target_channels = self._resolve_target_channels(channels)
 
             # Apply per-channel rate limiting
@@ -386,7 +404,7 @@ class SafeNotificationManager:
         context = {
             "magic_link": magic_link,
             "user_name": user_name or "User",
-            "app_name": "CoachIQ",
+            "app_name": self.config.app_name,
             "support_email": self.config.smtp.from_email or "support@coachiq.com",
             "expires_minutes": expires_minutes,
         }
@@ -628,7 +646,7 @@ class SafeNotificationManager:
             # Provide sample context for preview
             context = {
                 "user_name": "John Doe",
-                "app_name": "CoachIQ",
+                "app_name": self.config.app_name,
                 "magic_link": "https://example.com/auth/magic/sample-token",
                 "expires_minutes": 15,
                 "support_email": "support@coachiq.com",

--- a/tests/integration/test_notification_integration.py
+++ b/tests/integration/test_notification_integration.py
@@ -85,15 +85,27 @@ def integration_config():
 
 
 @pytest.fixture
-async def test_notification_config(integration_config):
-    """Create test notification configuration."""
+async def test_notification_config(integration_config, tmp_path):
+    """Create test notification configuration.
+
+    Uses a per-test temp file rather than ``:memory:`` for the queue
+    DB. SQLite ``:memory:`` databases are scoped to a single connection
+    -- ``NotificationQueue`` opens a fresh connection per operation,
+    so a literal ``:memory:`` path means each call sees an empty
+    schema. ``tmp_path`` is pytest-managed and auto-cleans, and per-test
+    isolation is preserved because each test gets its own directory.
+    """
     smtp_enabled = integration_config.use_real_smtp
 
     config = NotificationSettings(
         enabled=True,
         default_title="CoachIQ Test",
         app_name="CoachIQ Test",
-        queue_db_path=":memory:",  # Use in-memory SQLite for tests
+        queue_db_path=str(tmp_path / "notifications.db"),
+        # Per-test temp dir for templates so create_template tests don't
+        # scribble into the real shipped ``backend/templates/email``
+        # directory and check those files into git accidentally.
+        template_path=str(tmp_path / "email_templates"),
         rate_limit_max_tokens=1000,  # Higher limits for testing
         rate_limit_per_minute=600,
         debounce_minutes=1,  # Shorter debounce for testing
@@ -362,13 +374,21 @@ class TestEmailTemplateIntegration:
         assert rendered_subject == "Test Subject: John Doe"
 
     async def test_template_validation(self, email_template_manager):
-        """Test template validation catches errors."""
-        # Test invalid template syntax
+        """Test template validation catches errors.
+
+        ``EmailTemplateManager.create_template`` validates Jinja syntax
+        at parse time. ``{{invalid.variable.access}}`` is valid Jinja
+        syntax (a chained attribute access expression) and only fails
+        at *render* time when ``StrictUndefined`` sees ``invalid`` is
+        undefined. Use an actually-malformed template (unclosed
+        ``{{ ... }}``) so the parse step in ``create_template`` raises.
+        """
+        # Test invalid template syntax (unclosed expression)
         with pytest.raises(Exception):
             await email_template_manager.create_template(
                 "invalid_template",
                 "Valid Subject",
-                "<html><body>{{invalid.variable.access}}</body></html>",
+                "<html><body>{{ broken.unterminated.expression </body></html>",
                 "Valid text",
             )
 
@@ -503,10 +523,15 @@ class TestNotificationRoutingIntegration:
         assert "maintenance_alerts" in decision.applied_rules
         assert decision.target_channels == [NotificationChannel.SYSTEM]
 
-        # Test notification not matching rule
+        # Test notification not matching rule. Title is intentionally
+        # picked to avoid every configured keyword
+        # (``maintenance``/``update``/``scheduled``); production now uses
+        # word-boundary matching, so e.g. ``"Status Update"`` would
+        # still match the keyword ``"update"`` (which is the right
+        # routing behaviour). Use a title that doesn't collide.
         regular_notification = NotificationPayload(
             message="Battery level normal",
-            title="Status Update",
+            title="Battery Status",
             level=NotificationType.INFO,
             channels=[],
         )
@@ -800,14 +825,24 @@ class TestMockedServiceIntegration:
         # Allow dispatcher to process notifications
         await asyncio.sleep(1)
 
-        # Force processing completion
+        # Force processing completion. The dispatcher's background worker
+        # runs at ``processing_interval=0.1`` (per the fixture) so it may
+        # have already drained the queue during the sleep above; that's
+        # fine, ``force_queue_processing`` is idempotent and just no-ops
+        # when there's nothing left. Don't assert on
+        # ``result["processed_batches"]`` -- that's an implementation
+        # detail of who-drained-first (worker vs force call). Assert on
+        # the actual user-visible outcome instead: every enqueued
+        # notification was delivered and the queue is empty.
         result = await mock_dispatcher.force_queue_processing()
+        assert "error" not in result, f"force_queue_processing errored: {result}"
+        assert result["queue_depth_after"] == 0, (
+            f"Queue not drained: {result['queue_depth_after']} notifications still pending"
+        )
 
-        # Verify processing
-        assert result["processed_batches"] >= 1
-        assert result["queue_depth_after"] < result["queue_depth_before"]
-
-        # Check dispatcher metrics
+        # Check dispatcher metrics -- the real success criterion. The
+        # mock notification manager returns True for every send, so all
+        # 5 notifications should be processed and counted as successful.
         metrics = mock_dispatcher.get_metrics()
         assert metrics["total_processed"] >= len(notifications)
         assert metrics["successful_deliveries"] >= len(notifications)


### PR DESCRIPTION
Closes #95. Cluster goes **3p / 5f / 1s / 8e → 16p / 0 / 1s**.

## Production bugs found and fixed

1. **`NotificationSettings` missing the `SafeNotificationManager` knobs.** `SafeNotificationManager.initialize` read four config knobs via `getattr(self.config, ..., default)`: `queue_db_path`, `rate_limit_max_tokens`, `rate_limit_per_minute`, `debounce_minutes`. They were never defined on `NotificationSettings`, so the env-var `COACHIQ_NOTIFICATIONS__*` path never reached them and the `getattr` default was the only value possible. Defined as proper fields and switched the manager to direct attribute access so misconfiguration surfaces loudly. Also added `app_name` (was hardcoded `"CoachIQ"` in two places, now reads from config).

2. **`NotificationSettings.template_path` was a no-op AND wrong.** `EmailTemplateManager` ignored the field entirely and used a hardcoded `"backend/templates/email"` constructor default. Meanwhile the config field defaulted to `"templates/notifications/"` which doesn't exist in the repo. Made the manager read from `config.template_path` and updated the field's default to match where the templates actually live.

3. **`NotificationQueue` lazy-write batch returned stale reads.** `enqueue()` returned the notification ID as soon as the row was in the in-memory write batch, but `get_statistics()` and `dequeue_batch()` queried the DB without flushing the batch first. So callers immediately after an enqueue saw stale counts and missed notifications until the batch timer (up to `_batch_timeout`) fired. Added a public `flush()` method, wired `get_statistics` and `dequeue_batch` to flush before reading. Production behaviour preserved under load (batches still coalesce); read-after-write semantics now correct.

4. **`NotificationRouter` content rule used substring matching.** `_evaluate_content_condition` matched configured keywords with raw substring search, so the keyword `"update"` would match any title containing that letter sequence (e.g. `"updateserver"`). Switched to `\b<keyword>\b` regex so matching honours word boundaries and operators get the routing they configured.

5. **`NotificationRouter` user-preference layer ignored priority thresholds.** `_apply_user_preferences` added every preferred channel unconditionally and never consulted `min_priority_email` / `min_priority_push`. So a user who opted into SMTP for WARNING+ got every INFO emailed to them, and there was no way to filter the base routing decision by the user's per-channel threshold. Now respects the thresholds in BOTH directions: doesn't ADD a preferred channel below threshold, and REMOVES a base-routed channel below threshold.

6. **`SafeNotificationManager.notify` silently discarded the `channels` arg.** The public `notify(... channels=[...] ...)` API accepted an explicit channel list and then completely ignored it — the router decided based on level/rules. Real API contract violation that broke any caller wanting to pin a notification to a specific channel (test fixtures, structured-log fan-out, single-channel ack flows). Now: explicit `channels` short-circuits the router and uses the caller-supplied set.

7. **`EmailTemplateManager.create_template` swallowed Jinja syntax errors.** Returned False on any exception, hiding programmer-error templates (typos, unclosed tags) behind a generic boolean. Now re-raises `TemplateSyntaxError` so callers can react; non-syntax exceptions (probably IO) still return False for backward compat.

## Test-side fixes

- `test_notification_config` fixture now uses `tmp_path` for both the queue DB and the templates dir. `:memory:` wasn't viable because `NotificationQueue` opens a fresh `aiosqlite.connect` per operation — each call would have got a brand-new in-memory DB with no schema. Per-test temp paths preserve isolation cleanly.
- Pulled three test-pollution template files out of `backend/templates/email/en/` (`integration_test*`, `invalid_template*`, `test_custom*`) that the previous fixture had been writing into the shipped template directory.
- `test_template_validation` now uses an unclosed `{{ ... }}` expression instead of valid-but-undefined `{{invalid.x.y}}`. `StrictUndefined` violations are render-time, not parse-time; testing the validation path needs an actual syntax error.
- `test_custom_routing_rules` regular notification title changed from `"Status Update"` to `"Battery Status"` to avoid legitimately matching the maintenance-route keyword `"update"` under the new word-boundary matching.
- `test_dispatcher_processing_with_mocks` now asserts on the user-visible outcome (queue drained, all notifications counted as successful) rather than the racey implementation detail `result['processed_batches'] >= 1` — which was unreliable because the dispatcher's background worker (0.1s interval) often drained the queue before the explicit `force_queue_processing` call ran.

## Sanity check

15-cluster suite: **304 passed, 1 failed**. The single failure is the known pre-existing `test_async_notification_dispatcher::test_force_queue_processing` pollution issue documented in `/memories/repo/handoff-2026-05-11.md` (passes in isolation, fails in full-suite). **No regressions from this PR.**

CI quality gate (`./scripts/ci-quality-gate.sh`) passes locally.

## Cumulative production bugs caught by the test-suite restoration sweep

28 (PRs #89 / #90 / #97 / #98) + **7 (this PR)** = **35**.

## Architectural framing

`SafeNotificationManager` is the rate-limited / template-sandboxed tier (vs `notification_manager.py` and `notification_lightweight.py` — see `coachiq-state.md`). Bugs 1, 3, 5, 6 are exactly the API-side defense-in-depth class the project's threat model cares about (silent config no-ops, stale-read inconsistency, ignored user privacy thresholds, dropped explicit caller intent).