### PR TITLE
chore(prompts): add 6 subagent prompts from 2026-05-12 audit

### DIFF
--- a/.github/prompts/cleanup-entity-service-disambiguation.prompt.md
+++ b/.github/prompts/cleanup-entity-service-disambiguation.prompt.md
@@ -1,0 +1,115 @@
+# Subagent task: resolve `entity_service.py` vs `entity_services.py` ambiguity
+
+You are working on [carpenike/coachiq](https://github.com/carpenike/coachiq).
+This task closes the most consequential half of the post-test-restoration
+cleanup.
+
+## Read first
+
+1. `/memories/repo/coachiq-architecture.md` — what CoachIQ is/isn't.
+2. `/memories/repo/coachiq-state.md` — note the "Entity services —
+   three concerns" section. There are intentionally THREE classes here.
+3. `/memories/repo/wip-branch-analysis.md` — original analysis of the
+   `wip/security-rpi-hardening-2025` sprint that introduced the
+   half-merged duplicate. Read this carefully — it lays out
+   Options A/B/C and explains why the right answer is "pick one,
+   delete the loser".
+4. `/memories/repo/audit-2026-05-12.md` — current state.
+
+## Current situation
+
+Three entity service files coexist, two with confusingly similar names:
+
+```
+backend/services/entity_service.py       630 LOC
+backend/services/entity_services.py      650 LOC
+backend/services/entity_domain_service.py 582 LOC
+```
+
+`backend/main.py` imports BOTH top-level files:
+
+```python
+backend/main.py:103: from backend.services.entity_service import EntityService
+backend/main.py:104: from backend.services.entity_services import (
+```
+
+`backend/services/__init__.py:11` re-exports `EntityService` from the
+*singular* file. The 11 failures in `tests/services/test_entity_service.py`
+likely surface this disambiguation.
+
+Per `wip-branch-analysis.md`:
+
+> `backend/services/entity_service.py` was rewritten as a thin DB-only
+> reader. The INTENT was sound: build a fast cached persistence-layer
+> primitive over the EntityState SQLAlchemy table. The PROBLEM: it kept
+> the same class name and DI key, but other callers still expect the
+> old monolithic API. The migration was 50% done.
+
+The wip-branch-analysis flagged the singular file
+(`entity_service.py`) as the broken WIP rewrite. **However**, it's the
+one currently imported in `main.py:103`, so verify before deleting.
+
+## The job
+
+1. **Map the call graph.** For each of the three files, run:
+   ```bash
+   grep -rn "from backend.services.entity_service " backend/ tests/ --include="*.py"
+   grep -rn "from backend.services.entity_services" backend/ tests/ --include="*.py"
+   grep -rn "from backend.services.entity_domain_service" backend/ tests/ --include="*.py"
+   ```
+   Document which files import which.
+
+2. **Identify the live one.** Trace through `main.py` and
+   `backend/api/routers/entities*.py` and `backend/api/domains/entities.py`
+   to figure out which class actually services API requests at runtime.
+   The dependencies in `backend/core/dependencies.py` (look for
+   `get_entity_service`) are the single source of truth — whatever
+   that returns is the live one.
+
+3. **Decision point.** Three possible outcomes:
+   - **A.** `entity_services.py` (plural, layered) is live, `entity_service.py`
+     (singular) is the dead WIP rewrite → delete `entity_service.py`,
+     remove the `main.py:103` import, delete the `__init__.py:11`
+     re-export, fix `entity_domain_service.py:24` import.
+   - **B.** `entity_service.py` (singular) is live → confirm it's the
+     monolithic version (not the WIP rewrite), delete `entity_services.py`
+     (plural), remove the `main.py:104` import block, migrate any
+     callers of `EntityQueryService`/`EntityControlService`/
+     `EntityManagementService` back to the monolith methods.
+   - **C.** Both are partially live (different routes use different
+     services) → STOP and ask the user. This is a design decision,
+     not a cleanup.
+
+4. **Make the change.** Delete the loser. Update imports. Run the test
+   suite — `tests/services/test_entity_service.py` should improve
+   noticeably.
+
+5. **Update memory.** Edit `/memories/repo/coachiq-state.md` to remove
+   the duplicated entry from the "Entity services — three concerns"
+   section. Keep `entity_domain_service.py` as the still-distinct
+   third file (it adds command/ack pattern on top).
+
+## Acceptance
+
+- [ ] Exactly one of `entity_service.py` / `entity_services.py` remains.
+- [ ] `main.py` imports from one file, not two.
+- [ ] `tests/services/test_entity_service.py` failure count drops.
+- [ ] Pyright/ruff baseline doesn't regress.
+- [ ] Memory file updated.
+- [ ] PR description includes the call-graph mapping and which option
+      (A/B/C) was taken.
+
+## House rules
+
+- Never skip tests — if a test fails after the deletion, decide
+  whether it was guarding the dead file (delete it) or the live one
+  (fix the test or fix production).
+- Commit messages explain WHY + HOW, not just WHAT.
+- Don't touch `entity_domain_service.py` — it's the separately-purposed
+  third tier (bulk operations + command/ack).
+
+## Out of scope
+
+- Don't fix `core/state.py` — separate issue.
+- Don't audit the notification services — separate issue.
+- Don't fix frontend typecheck — separate issue.

--- a/.github/prompts/cleanup-notification-services-audit.prompt.md
+++ b/.github/prompts/cleanup-notification-services-audit.prompt.md
@@ -1,0 +1,92 @@
+# Subagent task: audit `backend/services/notification_*` (13 files)
+
+You are working on [carpenike/coachiq](https://github.com/carpenike/coachiq).
+This task is the third leg of the post-test-restoration cleanup.
+
+## Read first
+
+1. `/memories/repo/coachiq-architecture.md` — system framing.
+2. `/memories/repo/coachiq-state.md` — note the "Notification services
+   — three intentional variants" section. Three of the 13 files are
+   intentional and should NOT be merged or deleted.
+3. `/memories/repo/audit-2026-05-12.md` — current state.
+
+## The 13 files
+
+```
+backend/services/notification_analytics_service.py
+backend/services/notification_batching.py
+backend/services/notification_ingestion_service.py
+backend/services/notification_lightweight.py        ← intentional tier
+backend/services/notification_manager.py            ← intentional tier
+backend/services/notification_performance.py
+backend/services/notification_processing_service.py
+backend/services/notification_queue.py
+backend/services/notification_rate_limiting.py
+backend/services/notification_reporting_service.py
+backend/services/notification_routing.py
+backend/services/safe_notification_manager.py       ← intentional tier
+```
+
+The three marked tiers are documented as deliberate (Apprise generic /
+RV-C-safety-hardened / RPi-optimized). The other ten need
+classification.
+
+## The job
+
+For EACH of the ten unclassified files:
+
+1. **Find imports.** From repo root:
+   ```bash
+   grep -rn "from backend.services.notification_<name>" backend/ tests/ --include="*.py"
+   ```
+2. **Classify** as one of:
+   - **LIVE** — imported and exercised by production code (main.py,
+     a router, or one of the three notification managers).
+   - **TEST-ONLY** — only imported by tests. May be valid
+     infrastructure or may be dead.
+   - **DEAD** — no imports anywhere, or only imported by other dead
+     files.
+   - **WIP** — imported, but the importer is itself unused (e.g.
+     scaffolding from the shelved security-rpi sprint).
+
+3. **For LIVE files**: add a 1-line comment at the top of each file
+   explaining its role (e.g. "Persistent SQLite queue used by
+   SafeNotificationManager for retry-on-failure"). This single
+   sentence is what's missing right now.
+
+4. **For DEAD/WIP files**: delete them. Remove their imports from
+   `__init__.py` if any. Delete their tests if dead.
+
+5. **For TEST-ONLY files**: investigate — usually means a service
+   was scaffolded but never wired up. Either wire it up or delete it.
+   If unclear, leave the file but add a `# TODO(audit-2026-05-12):
+   classify — currently test-only` comment and document in the PR.
+
+6. **Update `coachiq-state.md`** to add a new subsection under
+   "Notification services" listing each LIVE file with its one-line
+   role. This becomes the canonical map.
+
+## Expected outcome
+
+The `tests/services/test_safe_notification_manager.py` (12 failures)
+and `tests/services/test_notification_rate_limiting.py` (5 failures)
+clusters may drop after dead-code removal exposes which fixtures point
+at nonexistent constructors. Don't try to FIX those test clusters in
+this PR — that's the test-restoration sweep. Just note in the PR if
+their counts changed.
+
+## Acceptance
+
+- [ ] All 10 unclassified files classified in the PR description.
+- [ ] LIVE files have a one-line top-of-file role comment.
+- [ ] DEAD/WIP files deleted.
+- [ ] `__init__.py` cleaned up.
+- [ ] `coachiq-state.md` updated with the LIVE-file map.
+- [ ] Test suite pass count stable or higher.
+
+## Out of scope
+
+- Don't merge or refactor the three intentional tiers.
+- Don't fix the notification test failures (separate sweep).
+- Don't touch `core/state.py` or entity services.

--- a/.github/prompts/cleanup-state-py-removal.prompt.md
+++ b/.github/prompts/cleanup-state-py-removal.prompt.md
@@ -1,0 +1,65 @@
+# Subagent task: delete `backend/core/state.py` (dead code, 609 LOC)
+
+You are working on [carpenike/coachiq](https://github.com/carpenike/coachiq).
+This task closes the dead-code half of the post-test-restoration cleanup.
+
+## Read first
+
+1. `/memories/repo/coachiq-architecture.md` — what CoachIQ is/isn't.
+2. `/memories/repo/coachiq-state.md` — repo state snapshot.
+3. `/memories/repo/audit-2026-05-12.md` — the audit that found this.
+
+## The job
+
+`backend/core/state.py` (609 LOC) is documented as "removed and
+decomposed into repositories" in `copilot-instructions.md` and
+`coachiq-state.md`. The file is still on disk. As of the 2026-05-12
+audit, the only import path into `core.state` is a self-import inside
+the file itself (`backend/core/state.py:517` does
+`from backend.core.state import CANSniffer`).
+
+Your job:
+
+1. **Verify** the file is genuinely dead. Run from repo root:
+   ```bash
+   grep -rn "from backend.core.state\|import backend.core.state\|backend\.core\.state" backend/ tests/ --include="*.py"
+   ```
+   Expected: only the one self-import inside `state.py` itself, plus
+   any test files that should also be deleted.
+2. If anything else imports from it, **stop and ask the user** —
+   the audit may have missed something.
+3. If truly dead:
+   - Delete `backend/core/state.py`.
+   - Delete any `tests/core/test_state.py` cases that test the dead
+     file (the audit shows `tests/core/test_state.py` has 6 failures —
+     some or all may be testing the dead file).
+   - Search for stale "AppState" docstring references in
+     `backend/repositories/` (e.g. "Part of Phase 2R: AppState
+     Repository Migration") and either delete the comment or rephrase
+     to past tense ("Replaced the monolithic AppState class").
+4. Run the full test suite. Pass count should not drop. Failure count
+   may go DOWN (the 6 test_state.py failures should go to 0).
+5. Run `poetry run ruff check backend/core/` and `poetry run pyright
+   backend/core/` — neither should regress.
+
+## Acceptance
+
+- [ ] `backend/core/state.py` deleted.
+- [ ] No grep hits for `backend.core.state` outside test files that
+      were also deleted.
+- [ ] Stale AppState docstrings in `backend/repositories/` updated.
+- [ ] Test suite passing count stable or higher.
+- [ ] PR description summarises the audit + verification grep output.
+
+## Why this matters
+
+The file's continued existence makes the agent guidance docs lie. Every
+new agent reads "AppState was removed" and then trips over a 609-line
+file claiming to be `AppState`. Documentation drift is the most
+expensive bug class on a multi-agent project.
+
+## Out of scope
+
+Don't touch the `entity_service.py` vs `entity_services.py`
+disambiguation — that's a separate issue/PR.
+Don't refactor the repositories — they're working fine.

--- a/.github/prompts/fix-frontend-typecheck.prompt.md
+++ b/.github/prompts/fix-frontend-typecheck.prompt.md
@@ -1,0 +1,67 @@
+# Subagent task: fix `npm run typecheck` failures on `main`
+
+You are working on [carpenike/coachiq](https://github.com/carpenike/coachiq).
+The frontend `tsc --noEmit` step is failing on `main`. The
+copilot-instructions explicitly mark this as a non-negotiable quality
+gate, but it isn't currently CI-blocking, so the failures landed
+silently.
+
+## Read first
+
+1. `/memories/repo/coachiq-architecture.md` — what CoachIQ is/isn't.
+2. `/memories/repo/audit-2026-05-12.md` — current state, including the
+   specific TS errors flagged.
+
+## Known failures (from audit)
+
+```
+src/components/admin/DatabaseManagementTab.tsx(735,8):
+  TS2375 — `exactOptionalPropertyTypes: true` violation. Component is
+  passed `databaseStatus: DatabaseStatus | undefined` and
+  `safetyStatus: SafetyStatus | undefined`, but the child's prop type
+  is `databaseStatus?: DatabaseStatus` (no explicit `| undefined`).
+
+src/pages/can-sniffer.tsx(421,5):
+  TS2322 — `(message: CANMessage) => void` is not assignable to
+  `(message: unknown) => void`. Likely a generic param missing
+  somewhere upstream of this callback registration.
+```
+
+There may be more once the first batch is fixed — run
+`cd frontend && npm run typecheck` to see the full list.
+
+## The job
+
+1. Get the full failure list with `cd frontend && npm run typecheck`.
+2. For each error:
+   - **Prefer narrowing over widening.** Don't add `| undefined` to
+     prop types just to make `exactOptionalPropertyTypes` happy —
+     instead, narrow at the parent (early return if undefined, or
+     pass a default).
+   - **Don't use `any`.** Add a proper type or use `unknown` + a
+     type guard.
+   - **Don't disable the rule.** No `// @ts-expect-error` or
+     `// @ts-ignore` without a linked issue.
+3. After fixing, run:
+   ```bash
+   cd frontend
+   npm run typecheck   # must exit 0
+   npm run lint        # baseline must not regress (currently 649/1496)
+   npm run build       # must succeed
+   ```
+4. **Add CI enforcement.** Update `scripts/ci-quality-gate.sh` (or the
+   appropriate CI step) to fail the build if `npm run typecheck` exits
+   non-zero. This is the core fix — without enforcement the gate will
+   re-break next week.
+
+## Acceptance
+
+- [ ] `npm run typecheck` exits 0 on the resulting branch.
+- [ ] CI step added that fails on typecheck regression.
+- [ ] No new `// @ts-ignore` / `// @ts-expect-error` / `: any`.
+- [ ] `npm run lint` and `npm run build` both succeed.
+
+## Out of scope
+
+- Don't try to fix the 649 ESLint errors in this PR — separate effort.
+- Don't refactor the components beyond what's needed for the type fix.

--- a/.github/prompts/pyright-ratchet.prompt.md
+++ b/.github/prompts/pyright-ratchet.prompt.md
@@ -1,0 +1,93 @@
+# Subagent task: install a pyright error ratchet
+
+You are working on [carpenike/coachiq](https://github.com/carpenike/coachiq).
+This task does NOT fix any pyright errors. It installs a one-way
+ratchet so the baseline can only go down, never up.
+
+## Read first
+
+1. `/memories/repo/coachiq-architecture.md` — what CoachIQ is/isn't.
+2. `/memories/repo/audit-2026-05-12.md` — current pyright baseline:
+   **1488 errors, 1529 warnings** on `pyright basic` over `backend/`.
+
+## Why a ratchet (not a fix)
+
+- 1488 errors won't be fixed in one PR, or even ten.
+- Pragmatic pre-commit currently blocks only NEW issues in changed
+  files — but pyright doesn't have file-level diff support like ruff
+  does, so changes silently introduce new errors elsewhere.
+- A ratchet makes the baseline visible and prevents drift in the
+  wrong direction. It's the cheapest possible governance.
+
+## The job
+
+1. **Capture the baseline.** Add `scripts/pyright-baseline.txt` with
+   a single integer (the current error count, 1488 at audit time).
+   Add a comment at the top of the file explaining what it is.
+
+2. **Add a script** `scripts/check-pyright-ratchet.sh`:
+   ```bash
+   #!/usr/bin/env bash
+   set -euo pipefail
+   BASELINE=$(grep -E "^[0-9]+$" scripts/pyright-baseline.txt | head -1)
+   ACTUAL=$(poetry run pyright backend 2>&1 | \
+     grep -E "^[0-9]+ errors?," | awk '{print $1}')
+   if [[ -z "$ACTUAL" ]]; then
+     echo "ERROR: could not parse pyright output"
+     exit 2
+   fi
+   if (( ACTUAL > BASELINE )); then
+     echo "FAIL: pyright errors $ACTUAL > baseline $BASELINE"
+     echo "Either fix the regression OR (if intentional) raise the baseline."
+     exit 1
+   fi
+   if (( ACTUAL < BASELINE )); then
+     echo "RATCHET: pyright errors dropped from $BASELINE to $ACTUAL"
+     echo "Lower the baseline in scripts/pyright-baseline.txt."
+     exit 1
+   fi
+   echo "OK: pyright errors == baseline ($ACTUAL)"
+   ```
+   The `ACTUAL < BASELINE` failure mode is intentional — it forces
+   PRs that improve type safety to also lower the baseline, locking
+   in the improvement.
+
+3. **Wire into CI.** Add a step to `scripts/ci-quality-gate.sh` (or
+   the relevant workflow) that runs `bash scripts/check-pyright-ratchet.sh`.
+
+4. **Document** in `docs/code-quality-tools.md` (or create a section
+   in `CONTRIBUTING.md`):
+   - What the ratchet does.
+   - How to lower the baseline (run pyright, count errors, edit file).
+   - How to raise the baseline (with explicit explanation in the PR
+     description — this should be rare).
+
+5. **Optional**: do the same for ruff (`scripts/ruff-baseline.txt`,
+   currently ~4624). The same pattern works. Keep it in the same PR
+   if straightforward, separate if it grows.
+
+## Acceptance
+
+- [ ] `scripts/pyright-baseline.txt` exists with current count.
+- [ ] `scripts/check-pyright-ratchet.sh` exists and is executable.
+- [ ] CI runs the ratchet check on every PR.
+- [ ] CI fails the PR if the count goes UP.
+- [ ] CI fails the PR if the count goes DOWN without baseline update
+      (this is what locks in improvements).
+- [ ] Documentation explains the rules.
+
+## Out of scope
+
+- Fixing any actual pyright errors. The point is the ratchet, not the
+  cleanup. Cleanup happens organically as the baseline ratchets down.
+- Switching pyright from `basic` to `strict`. Premature.
+- Adding mypy or other type checkers.
+
+## Why this is high-leverage
+
+Once landed, every future PR that touches typed code will either
+- leave the baseline alone (no change), or
+- improve it (which forces the author to update the baseline number).
+
+The baseline number in git history then becomes a built-in progress
+chart. No one has to remember to run pyright manually.

--- a/.github/prompts/test-restoration-sweep-2.prompt.md
+++ b/.github/prompts/test-restoration-sweep-2.prompt.md
@@ -1,0 +1,110 @@
+# Subagent task: test-restoration sweep #2
+
+You are continuing the test-suite restoration project on
+[carpenike/coachiq](https://github.com/carpenike/coachiq). PRs #89,
+#90, #97, #98, #99, #100 (the first sweep) restored 12 clusters and
+caught 39 production bugs. 149 failures+errors remain.
+
+## Read first
+
+1. `/memories/repo/coachiq-architecture.md` — what CoachIQ is/isn't.
+2. `/memories/repo/coachiq-state.md` — repo state snapshot.
+3. `/memories/repo/handoff-2026-05-11.md` — methodology that worked
+   for the first sweep. **THIS IS THE PLAYBOOK.** Don't deviate.
+4. `/memories/repo/audit-2026-05-12.md` — current state, including the
+   ranked top-cluster table.
+
+## Target clusters (ordered by failure+error count)
+
+Pick clusters in this order. Each is roughly an independent PR.
+
+| Count | Cluster | Likely category |
+|-------|---------|------------------|
+| 12 | `tests/services/test_safe_notification_manager.py` | service drift |
+| 12 | `tests/contract/test_feature_parity_validation.py` | contract drift |
+| 11 | `tests/unit/test_configuration_service.py` | constructor drift |
+| 11 | `tests/services/test_entity_service.py` | **see note below** |
+| 10 | `tests/integration/test_safety_emergency_scenarios.py` | integration |
+| 10 | `tests/core/test_config.py` | Pydantic v2 / settings |
+| 10 | `tests/contract/test_domain_api_contract.py` | contract drift |
+|  9 | `tests/unit/test_database_management_api.py` | constructor drift |
+|  9 | `tests/api/test_entities.py` | API surface drift |
+
+### `test_entity_service.py` blocker
+
+Don't touch `tests/services/test_entity_service.py` until the
+`entity_service.py` vs `entity_services.py` disambiguation PR
+(see `cleanup-entity-service-disambiguation.prompt.md`) merges.
+Some or all of these failures will resolve as a side effect.
+
+### `tests/core/test_state.py` (6 failures)
+
+These may all disappear when `backend/core/state.py` is deleted (see
+`cleanup-state-py-removal.prompt.md`). Skip until that lands.
+
+## Methodology — copy verbatim from prior PRs
+
+For each cluster:
+
+1. Run with `--tb=line` to see all failures briefly:
+   ```bash
+   nix develop --command bash -c 'poetry run pytest <path> --no-cov -q --tb=line'
+   ```
+2. Look at the FIRST failure with `--tb=short`. Decide:
+   - **API drift** (test stale) → update test to match current API.
+   - **Real bug** → fix production, verify test passes.
+   - **Test infra** → fix fixture.
+3. Re-run, repeat until cluster is clean.
+4. Run a wider sanity check (a few adjacent clusters) to confirm no
+   regressions.
+5. Commit with a detailed message: WHY + HOW, including a list of any
+   production bugs caught. The first-sweep PRs (#89, #90, #97-100)
+   are the format reference.
+
+## Pacing
+
+- One cluster per PR is ideal. The first-sweep PRs averaged ~3-5h per
+  cluster including bug investigation.
+- Don't open more than two PRs in flight — the user is reviewing.
+- After each PR merges, update `audit-2026-05-12.md` with the new
+  totals (run `pytest --no-cov -q --tb=no --continue-on-collection-errors
+  | tail -3`).
+
+## Stop and ask the user when
+
+- A cluster appears to require an architectural change (e.g. a
+  service rewrite).
+- More than 5 production bugs surface in a single cluster — that's
+  a sign the cluster is guarding a bigger drift than expected.
+- The "fix" requires breaking an established API contract.
+
+## House rules (from prior sweep)
+
+- Never skip tests — fix them.
+- Commit messages explain WHY + HOW.
+- Production bugs caught are wins; call them out.
+- Architectural framing: consumer-grade backend, NOT safety-critical.
+- Use `--no-verify` for pre-push if Cachix is broken.
+- User's shell is fish — bash arithmetic / heredocs need `bash -lc`.
+
+## Useful commands
+
+```bash
+# Full suite totals
+nix develop --command bash -c 'poetry run pytest --no-cov -q --tb=no --continue-on-collection-errors 2>&1 | tail -3'
+
+# Top failing clusters
+nix develop --command bash -c 'poetry run pytest --no-cov -q --tb=no --continue-on-collection-errors 2>&1 | grep -E "^(FAILED|ERROR)" | awk -F"::" "{print \$1}" | sed "s/^FAILED //; s/^ERROR //" | sort | uniq -c | sort -rn | head -20'
+
+# Single cluster, brief failures
+nix develop --command bash -c 'poetry run pytest <path> --no-cov -q --tb=line'
+
+# Single test, full traceback
+nix develop --command bash -c 'poetry run pytest <path>::TestClass::test_name --no-cov --tb=long'
+```
+
+## Goal
+
+Get from 750/91/58 → 850+/<30/<20 over the course of this sweep.
+That gets the suite to ~93%+ pass rate, which is good-enough to start
+treating green CI as a real signal again.


### PR DESCRIPTION
Adds six self-contained subagent prompts under `.github/prompts/` capturing the follow-up work identified in the 2026-05-12 comprehensive audit (after the test-restoration sweep landed via PRs #89/#90/#97-100).

Pattern matches PR #91 (the four prior subagent prompts).

## Prompts added

**Cleanup (mechanical, high signal-to-noise):**
- `cleanup-state-py-removal.prompt.md` — delete the 609-LOC dead `backend/core/state.py` (only self-import remains; docs already say it's gone).
- `cleanup-entity-service-disambiguation.prompt.md` — pick one of the two `entity_service.py` / `entity_services.py` files (both currently imported in main.py).
- `cleanup-notification-services-audit.prompt.md` — classify 10 of 13 notification-service files as live / dead / WIP (3 are intentional tiers).
- `fix-frontend-typecheck.prompt.md` — fix `npm run typecheck` failures and wire the check into CI so it can't silently re-break.

**Continuation:**
- `test-restoration-sweep-2.prompt.md` — drive the remaining 149 failures+errors down using the methodology that worked for the first sweep.
- `pyright-ratchet.prompt.md` — install a one-way error ratchet so the 1488-error baseline can only go down.

## Audit summary

After the test-restoration sweep:
- Test pass rate: 64% → 83% (+313 passing tests, 39 production bugs caught)
- Documented security gaps verified closed
- CI gate restored (was silently broken via Cachix infra)

Remaining gaps (each addressed by a prompt above):
- 149 failures+errors in 14+ test clusters
- 1488 pyright errors / 4624 ruff errors with no ratchet
- Frontend `npm run typecheck` failing on main, not CI-blocking
- Three architectural drift items (state.py, entity_service duplication, notification proliferation)

## Memory files

The audit findings are documented in `/memories/repo/audit-2026-05-12.md` (agent-only memory, not in this repo). Each prompt links to it plus the two existing permanent memory files.

## Next step after merge

Tracking issues will be opened that link to specific prompt files in this PR. Each issue is independent and any agent (or human) can pick one up.