### PR TITLE
fix(frontend): clear 4 TS typecheck errors + ratchet CI gate to 0 (closes #106)

### DIFF
--- a/frontend/src/components/admin/DatabaseManagementTab.tsx
+++ b/frontend/src/components/admin/DatabaseManagementTab.tsx
@@ -109,8 +109,8 @@ const startMigration = async (options: {
   confirm: boolean
   force?: boolean
   skip_backup?: boolean
-}) => {
-  return apiRequest("/api/database/migrate", {
+}): Promise<{ job_id: string }> => {
+  return apiRequest<{ job_id: string }>("/api/database/migrate", {
     method: "POST",
     body: JSON.stringify(options),
   })
@@ -123,7 +123,9 @@ function SafetyStatusCard({
   error,
   onRefresh
 }: {
-  safetyStatus?: SafetyStatus
+  // Allow explicit `undefined` (exactOptionalPropertyTypes-friendly) so
+  // react-query's `data: T | undefined` flows in without a wrapper.
+  safetyStatus?: SafetyStatus | undefined
   isLoading: boolean
   error: Error | null
   onRefresh: () => void
@@ -278,8 +280,10 @@ function MigrationControlCard({
   onMigrationStart,
   activeJobId,
 }: {
-  databaseStatus?: DatabaseStatus
-  safetyStatus?: SafetyStatus
+  // Allow explicit `undefined` (exactOptionalPropertyTypes-friendly) so
+  // react-query's `data: T | undefined` flows in without a wrapper.
+  databaseStatus?: DatabaseStatus | undefined
+  safetyStatus?: SafetyStatus | undefined
   onMigrationStart: (jobId: string) => void
   activeJobId: string | null
 }) {
@@ -728,14 +732,14 @@ export function DatabaseManagementTab() {
         safetyStatus={safetyStatus}
         isLoading={safetyLoading}
         error={safetyError}
-        onRefresh={refetchSafety}
+        onRefresh={() => { void refetchSafety() }}
       />
 
       {/* Migration Control / Progress */}
       <MigrationControlCard
         databaseStatus={databaseStatus}
         safetyStatus={safetyStatus}
-        onMigrationStart={setActiveJobId}
+        onMigrationStart={(jobId) => setActiveJobId(jobId)}
         activeJobId={activeJobId}
       />
 

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -428,11 +428,16 @@ export function useEntityWebSocket(options?: { autoConnect?: boolean }) {
 }
 
 /**
- * Hook for CAN message scanning via WebSocket
+ * Hook for CAN message scanning via WebSocket.
+ *
+ * The generic `TMessage` lets call sites opt into a narrower payload
+ * shape (e.g. `useCANScanWebSocket<CANMessage>({ onMessage: m => ... })`).
+ * Defaults to `unknown` because WebSocket frames are untrusted JSON;
+ * narrowing is the caller's responsibility.
  */
-export function useCANScanWebSocket(options?: {
+export function useCANScanWebSocket<TMessage = unknown>(options?: {
   autoConnect?: boolean;
-  onMessage?: (message: unknown) => void;
+  onMessage?: (message: TMessage) => void;
 }) {
   const queryClient = useQueryClient();
   const queryClientRef = useRef(queryClient);
@@ -443,7 +448,7 @@ export function useCANScanWebSocket(options?: {
     autoConnect: options?.autoConnect ?? false,
     onMessage: (message) => {
       setMessageCount(prev => prev + 1);
-      options?.onMessage?.(message);
+      options?.onMessage?.(message as TMessage);
 
       // Periodically invalidate CAN statistics
       if (messageCount % 100 === 0) {

--- a/frontend/src/pages/can-sniffer.tsx
+++ b/frontend/src/pages/can-sniffer.tsx
@@ -415,8 +415,11 @@ export default function CANSniffer() {
   const [maxMessages] = useState(1000)
   const [messages, setMessages] = useState<CANMessage[]>([])
 
-  // WebSocket connection for real-time CAN messages
-  const { isConnected, error: wsError, connect } = useCANScanWebSocket({
+  // WebSocket connection for real-time CAN messages.
+  // The generic `<CANMessage>` opts into a typed callback; payloads are
+  // still untrusted JSON at the wire — narrow further if/when the schema
+  // is validated server-side.
+  const { isConnected, error: wsError, connect } = useCANScanWebSocket<CANMessage>({
     autoConnect: !isPaused,
     onMessage: (message: CANMessage) => {
       if (!isPaused) {

--- a/scripts/ci-quality-gate.sh
+++ b/scripts/ci-quality-gate.sh
@@ -20,7 +20,7 @@ RESET="\033[0m"
 # pyright errors lower the count and the script will print a green message
 # nudging you to update the baseline downward.
 EXPECTED_PYRIGHT_ERRORS=1533  # Ratcheted 2026-05-11 by PIN-manager fixes (Pydantic Field(default=...) keyword form cleared 10 latent errors).
-EXPECTED_FRONTEND_TS_ERRORS=4  # Resynced 2026-05-11; pre-existing TS debt in DatabaseManagementTab + can-sniffer.
+EXPECTED_FRONTEND_TS_ERRORS=0  # Ratcheted 2026-05-12 to 0 by PR #110 (DatabaseManagementTab + can-sniffer + useCANScanWebSocket generic). Any new TS error is a hard fail.
 
 # Determine target branch (for GitHub Actions or local testing)
 if [ -n "${GITHUB_BASE_REF:-}" ]; then
@@ -166,12 +166,23 @@ if [ -d "frontend" ]; then
 
         if [ "$ACTUAL_TS_ERRORS" -gt "$EXPECTED_FRONTEND_TS_ERRORS" ]; then
             echo -e "${RED}❌ FAILURE: TypeScript found $ACTUAL_TS_ERRORS errors, exceeding baseline of $EXPECTED_FRONTEND_TS_ERRORS${RESET}"
+            cd ..
+            rm -f /tmp/ts-output.log
             exit 1
         elif [ "$ACTUAL_TS_ERRORS" -lt "$EXPECTED_FRONTEND_TS_ERRORS" ]; then
             echo -e "${GREEN}🎉 EXCELLENT: TypeScript errors reduced from $EXPECTED_FRONTEND_TS_ERRORS to $ACTUAL_TS_ERRORS!${RESET}"
-            echo -e "${GREEN}   Please update EXPECTED_FRONTEND_TS_ERRORS in this script${RESET}"
+            echo -e "${GREEN}   Please update EXPECTED_FRONTEND_TS_ERRORS in this script to $ACTUAL_TS_ERRORS${RESET}"
+            echo -e "${GREEN}   Include this baseline update in your PR${RESET}"
+            cd ..
+            rm -f /tmp/ts-output.log
+            exit 1  # Force the author to ratchet the baseline down so the win is locked in.
         else
-            echo -e "${YELLOW}⚠️  TypeScript compilation failed but error count within baseline${RESET}"
+            # Failure exit code from npm run typecheck but error count == baseline.
+            # When baseline is 0 this branch is unreachable. When baseline > 0
+            # this means the same number of pre-existing errors are still there
+            # (no regression, no improvement) — still treated as success since
+            # the diff didn't make things worse.
+            echo -e "${YELLOW}⚠️  TypeScript compilation failed but error count ($ACTUAL_TS_ERRORS) within baseline of $EXPECTED_FRONTEND_TS_ERRORS— ratchet down when fixed.${RESET}"
         fi
     fi
 


### PR DESCRIPTION
Closes #106. Implements `.github/prompts/fix-frontend-typecheck.prompt.md` (added in #101).

## TL;DR

```diff
- npm run typecheck  # 4 errors, exit 2
+ npm run typecheck  # 0 errors, exit 0

- EXPECTED_FRONTEND_TS_ERRORS=4
+ EXPECTED_FRONTEND_TS_ERRORS=0
```

The typecheck CI gate was already in place (Stage 4 of `scripts/ci-quality-gate.sh`, invoked by `nix run .#ci` from `flake.nix`) but the baseline absorbed the four errors. Now the baseline is 0 and any new TS error is a hard fail.

## Errors fixed (4 in 2 files)

| Location | Code | Cause |
|----------|------|-------|
| `DatabaseManagementTab.tsx:297` | TS18046 | `startMigration` returned untyped `apiRequest()` -> `data: unknown` |
| `DatabaseManagementTab.tsx:727` | TS2375 | exactOptional: `safetyStatus?: T` vs incoming `T \| undefined` |
| `DatabaseManagementTab.tsx:735` | TS2375 | exactOptional: same pattern, both props |
| `can-sniffer.tsx:421` | TS2322 | `(m: CANMessage) => void` vs hook's `(m: unknown) => void` |

### How each was fixed

- **TS18046** — added `Promise<{ job_id: string }>` return type and `apiRequest<{ job_id: string }>` generic.
- **TS2375 x2** — widened prop signatures to `?: T | undefined` (the documented exactOptional escape) so react-query's `data: T | undefined` flows in directly. Wrapped the two callback-shape mismatches at the call site rather than weakening the prop signatures.
- **TS2322** — made the hook generic: `useCANScanWebSocket<TMessage = unknown>(...)`. Default stays `unknown` (WebSocket payloads are untrusted JSON); call site opts in with `useCANScanWebSocket<CANMessage>({ ... })`. The cast happens at one controlled boundary inside the hook, not silently for every consumer.

No `// @ts-ignore`, no `// @ts-expect-error`, no `: any`.

## CI gate hardening

Two changes to `scripts/ci-quality-gate.sh` Stage 4:

1. **Baseline 4 -> 0.** New errors are hard fails.
2. **Ratchet-down branch hard-exits.** Previously, if typecheck failed but error count had DECREASED, the script printed a green hint and exited 0, silently letting the improvement slip away. Now it `exit 1`, forcing the author to ratchet the baseline down in the same PR — locking in the win permanently. With baseline=0 this branch is unreachable, but it matters for any future re-introduced baseline > 0.

## Verification

```
$ cd frontend && npm run typecheck     # 0 errors
$ npm run build                         # \u2713 built in 5.46s
$ npm run lint                          # 648 errors (was 649, dropped 1 as side-effect)
$ bash -n scripts/ci-quality-gate.sh    # syntax OK
```

## What this PR does NOT do

- Does NOT touch the 648 ESLint errors (separate effort).
- Does NOT install a pyright ratchet (#107).
- Does NOT update `EXPECTED_PYRIGHT_ERRORS` (still 1533 in the script even though current is 1488; orthogonal to this PR — that ratchet-down belongs in #107).

## Tracker
Updates checkbox in #108.