### PR TITLE
ci(eslint): add diff-aware ESLint gate + fix path bug in pre-commit hook (closes #113)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -99,10 +99,10 @@ Implications for code generation in this repo:
 
 ### TypeScript/React
 
-- **ESLint**: Using flat config in eslint.config.js and eslint.config.mjs - **ZERO WARNINGS REQUIRED**
-- **TypeScript**: Strict mode enabled with project references - **COMPILATION MUST SUCCEED**
+- **ESLint**: Using flat config in eslint.config.js and eslint.config.mjs. Project runs in **pragmatic mode**: legacy debt on unchanged lines is allowed, but any NEW ESLint **error** on a line you touched fails CI (warnings are advisory). Enforced by `scripts/eslint_diff_check.py` in `scripts/ci-quality-gate.sh` Stage 1.
+- **TypeScript**: Strict mode enabled with project references - **COMPILATION MUST SUCCEED** (`npm run typecheck` baseline = 0 errors).
 - **Build Verification**: `npm run build` must complete successfully
-- **Formatting**: Follow ESLint configuration rules
+- **Formatting**: Follow ESLint configuration rules; the `eslint-staged` pre-commit hook applies `--fix` automatically on staged files.
 - **Line Endings**: LF (Unix style)
 - **Indentation**: 2 spaces
 - **TypeScript Interfaces**: Ensure all standalone interface files have imports to avoid parsing errors

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,8 +60,20 @@ repos:
   - repo: local
     hooks:
       - id: eslint-staged
-        name: eslint (staged files)
-        entry: bash -c 'cd frontend && npx eslint --fix -- "$@"' --
+        name: eslint --fix (staged files, autofix only)
+        # Pre-commit passes paths repo-relative (e.g. frontend/src/foo.tsx).
+        # After `cd frontend` those paths are wrong, so we strip the leading
+        # `frontend/` from each argument before invoking eslint.
+        #
+        # We deliberately apply --fix to canonicalize formatting on staged
+        # files but treat eslint's exit code as advisory: pre-existing
+        # legacy errors should NOT block a commit (the project has ~648
+        # baseline errors). The diff-aware gate that BLOCKS on NEW errors
+        # lives in `scripts/eslint_diff_check.py` and runs in CI via
+        # `scripts/ci-quality-gate.sh` Stage 1.5 -- mirroring how ruff is
+        # split into `ruff-format` (file-level autofix) and
+        # `ruff_diff_check.py` (line-level gate).
+        entry: bash -c 'cd frontend && args=(); for f in "$@"; do args+=("${f#frontend/}"); done; npx eslint --fix --no-error-on-unmatched-pattern -- "${args[@]}" || true' --
         language: system
         files: ^frontend/.*\.(js|jsx|ts|tsx)$
         exclude: ^frontend/(node_modules|dist|coverage)/

--- a/docs/code-quality-tools.md
+++ b/docs/code-quality-tools.md
@@ -66,6 +66,56 @@ npx pyright src
 # Use the built-in type checking with Pylance
 ```
 
+## Frontend Code Quality Tools
+
+### ESLint
+
+[ESLint](https://eslint.org/) is the standard linter for the React + TypeScript frontend. The configuration lives in `frontend/eslint.config.js` (flat config) and is imported from the repo-root `eslint.config.js` so monorepo-wide tooling stays consistent.
+
+#### Usage
+
+```bash
+# Check the frontend
+cd frontend && npm run lint
+
+# Apply auto-fixes
+cd frontend && npm run lint:fix
+```
+
+### TypeScript Compiler (`tsc --noEmit`)
+
+```bash
+# Type-check the frontend (strict mode)
+cd frontend && npm run typecheck
+```
+
+The CI quality gate runs `npm run typecheck` and fails if any error is found (baseline ratcheted to 0 in PR #110).
+
+## Diff-Aware Quality Gates ("Pragmatic Mode")
+
+Both Python and frontend toolchains have *pragmatic-mode* gates: pre-existing legacy debt on lines you didn't touch is allowed, but any **new** violation on a line you DID touch fails the gate. This lets the project ratchet down legacy debt over time without each PR drowning in it.
+
+The gates are implemented as paired diff-check scripts that mirror each other's UX:
+
+| Concern | Script | Invocation |
+|---------|--------|------------|
+| Python lint (ruff) | `scripts/ruff_diff_check.py` | `poetry run python scripts/ruff_diff_check.py [BASE_REF]` |
+| Frontend lint (ESLint) | `scripts/eslint_diff_check.py` | `poetry run python scripts/eslint_diff_check.py [BASE_REF] [--warnings-fail]` |
+
+Both scripts:
+
+1. Find files changed since `BASE_REF` (default `origin/main`, three-dot range to match GitHub PR diffs).
+2. Run the underlying tool with JSON output on those files.
+3. Cross-reference each diagnostic's line against the diff's added/changed line set.
+4. Exit 0 if no NEW issues; exit 1 with a focused report if any new issues; exit 2 on tooling failure.
+5. Print a "(N legacy issues on unchanged lines were ignored.)" footer so it's obvious what was suppressed.
+
+Both scripts are wired into Stage 1 of `scripts/ci-quality-gate.sh`, which is what GitHub Actions runs via `nix run .#ci`. The pre-commit hook for each tool runs only the autofix half (`ruff format`, `eslint --fix`) and ignores legacy errors; the diff-aware blocking is CI's job.
+
+### Updating baselines
+
+Some tools also have project-wide baselines (counts of acknowledged debt) inside `scripts/ci-quality-gate.sh`. When you legitimately reduce the count, lower the baseline in the same PR. The script prints "🎉 EXCELLENT" with the new count when this happens, and the gate fails until you lower the baseline — which locks in the improvement permanently.
+
 ## Pre-commit Integration
 
 These tools are integrated into our [pre-commit](https://pre-commit.com/) configuration, ensuring code quality checks run automatically before each commit.

--- a/scripts/ci-quality-gate.sh
+++ b/scripts/ci-quality-gate.sh
@@ -61,12 +61,14 @@ echo -e "${BLUE}🔧 Stage 1: Checking changed files for new linting issues...${
 # on PATH but pre-commit and ruff live inside the poetry-managed venv.
 PRECOMMIT_OK=true
 RUFF_OK=true
+ESLINT_OK=true
 
-# Skip pre-commit's `ruff` (linter) hook in Stage 1 — ruff_diff_check.py
-# below covers the ruff lint side with line-level filtering. We still
-# want pre-commit's `ruff-format` hook to run (formatting is correctly
-# a file-level concern: a file is either canonically formatted or not).
-if ! SKIP=ruff poetry run pre-commit run --from-ref "$TARGET_BRANCH" --to-ref HEAD; then
+# Skip pre-commit's `ruff` (linter) hook AND `eslint-staged` hook in Stage 1.
+# Their diff-aware counterparts (ruff_diff_check.py, eslint_diff_check.py)
+# below handle line-level filtering. We still want pre-commit's `ruff-format`
+# hook to run (formatting is correctly a file-level concern: a file is
+# either canonically formatted or not).
+if ! SKIP=ruff,eslint-staged poetry run pre-commit run --from-ref "$TARGET_BRANCH" --to-ref HEAD; then
     PRECOMMIT_OK=false
 fi
 
@@ -74,7 +76,16 @@ if ! poetry run python scripts/ruff_diff_check.py "$TARGET_BRANCH"; then
     RUFF_OK=false
 fi
 
-if $PRECOMMIT_OK && $RUFF_OK; then
+# Frontend ESLint diff-aware gate (mirror of ruff_diff_check.py).
+# Only relevant if the PR touches frontend files; the script reports
+# "No changed frontend files" and exits 0 in the no-op case.
+if [ -d "frontend" ]; then
+    if ! poetry run python scripts/eslint_diff_check.py "$TARGET_BRANCH"; then
+        ESLINT_OK=false
+    fi
+fi
+
+if $PRECOMMIT_OK && $RUFF_OK && $ESLINT_OK; then
     echo -e "${GREEN}✅ SUCCESS: No new linting issues in changed files${RESET}"
 else
     echo -e "${RED}❌ FAILURE: New linting issues found in your changes${RESET}"

--- a/scripts/eslint_diff_check.py
+++ b/scripts/eslint_diff_check.py
@@ -124,7 +124,7 @@ def _changed_frontend_files(base_ref: str) -> list[str]:
     bumps).
     """
     out = _run(
-        ["git", "diff", "--name-only", "--diff-filter=AM", _diff_range(base_ref)],  # noqa: S607
+        ["git", "diff", "--name-only", "--diff-filter=AM", _diff_range(base_ref)],
     )
     skip_prefixes = (
         "frontend/node_modules/",
@@ -176,7 +176,7 @@ def _changed_lines(base_ref: str, files: list[str]) -> dict[str, set[int]]:
         return {}
 
     out = _run(
-        ["git", "diff", "--unified=0", _diff_range(base_ref), "--", *files],  # noqa: S607
+        ["git", "diff", "--unified=0", _diff_range(base_ref), "--", *files],
     )
 
     result: dict[str, set[int]] = defaultdict(set)
@@ -219,7 +219,7 @@ def _eslint_issues(repo_relative_files: list[str], frontend_dir: Path) -> list[d
     stripped = [f[len("frontend/") :] for f in repo_relative_files]
 
     out = _run(
-        ["npx", "eslint", "--format=json", "--no-error-on-unmatched-pattern", "--", *stripped],  # noqa: S607
+        ["npx", "eslint", "--format=json", "--no-error-on-unmatched-pattern", "--", *stripped],
         cwd=frontend_dir,
         allow_nonzero=True,  # eslint exits 1 when issues found; that's fine
     )
@@ -348,7 +348,9 @@ def main() -> int:
     sys.stderr.write(":\n")
     _print_messages("Errors", new_errors, stream=sys.stderr)
     if warnings_fail:
-        _print_messages("Warnings (failing because --warnings-fail)", new_warnings, stream=sys.stderr)
+        _print_messages(
+            "Warnings (failing because --warnings-fail)", new_warnings, stream=sys.stderr
+        )
     elif new_warnings:
         _print_messages("Warnings (advisory; not blocking)", new_warnings, stream=sys.stdout)
 

--- a/scripts/eslint_diff_check.py
+++ b/scripts/eslint_diff_check.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3
+"""Line-level diff-aware ESLint check for the CoachIQ CI quality gate.
+
+Frontend equivalent of ``scripts/ruff_diff_check.py``. Runs ``eslint`` on
+every frontend file changed since a base ref, then filters the results down
+to the lines actually added or modified by those commits. Implements the
+project's "pragmatic mode" policy on the JavaScript/TypeScript side: legacy
+debt on lines we didn't touch is allowed, but any new violation on a line
+we DID touch fails the gate.
+
+Why this exists
+---------------
+``pre-commit run --from-ref --to-ref`` is *file-level* diff-aware: it only
+re-runs hooks on changed files. ESLint then lints the entire file and
+reports every issue. With ~648 pre-existing ESLint errors and ~1496
+warnings on the frontend, touching a single line in any frontend file
+floods the gate with hundreds of legacy violations.
+
+The script is intentionally small and stdlib-only, mirroring
+``ruff_diff_check.py`` -- same exit codes, same output style, same overall
+structure -- so the two ratchets behave consistently in CI logs.
+
+Severity policy
+---------------
+ESLint emits both errors (``severity: 2``) and warnings (``severity: 1``).
+By default this script BLOCKS on errors and reports warnings as advisory
+(printed but exit 0 if errors are 0). Pass ``--warnings-fail`` to also
+block on warnings.
+
+Exit codes
+----------
+- 0: no NEW ESLint errors on changed lines (warnings may be present)
+- 1: at least one NEW ESLint error on a changed line
+- 2: tooling failure (git command failed, npm/eslint invocation failed,
+  JSON parse failure, etc.)
+
+Usage
+-----
+    poetry run python scripts/eslint_diff_check.py [BASE_REF] [--warnings-fail]
+
+BASE_REF defaults to ``origin/main``. The script compares
+``BASE_REF...HEAD`` (three-dot range), matching what GitHub Actions uses
+for PR diffs against the target branch.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+# Frontend extensions ESLint cares about. Mirrors the
+# `files: ^frontend/.*\.(js|jsx|ts|tsx)$` regex in `.pre-commit-config.yaml`.
+FRONTEND_EXTENSIONS = (".js", ".jsx", ".ts", ".tsx")
+
+# A diff hunk header has the shape "@@ -OLD,LEN +NEW,LEN @@". After splitting
+# on whitespace we expect at least the leading "@@", the "-OLD,LEN" range
+# and the "+NEW,LEN" range -- three tokens. Anything shorter is malformed
+# (or a noisy line) and should be skipped silently.
+MIN_HUNK_HEADER_PARTS = 3
+
+# ESLint severity codes (per https://eslint.org/docs/latest/integrate/nodejs-api).
+SEVERITY_WARNING = 1
+SEVERITY_ERROR = 2
+
+
+def _run(cmd: list[str], *, cwd: Path | None = None, allow_nonzero: bool = False) -> str:
+    """Run a command and return stdout, raising on non-zero exit unless allowed.
+
+    ``allow_nonzero=True`` is the right setting for invoking eslint, which
+    exits 1 when issues are found and we still want the JSON. Genuine
+    tooling failures (no stdout, error on stderr) still exit 2.
+
+    ``# noqa: S603/S607`` here mirror the rationale in ``ruff_diff_check.py``:
+    this script INTENTIONALLY shells out to git, npm and eslint -- that's
+    its whole job. Argument lists come from caller-controlled paths/refs,
+    never from network input.
+    """
+    result = subprocess.run(  # noqa: S603
+        cmd,
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=cwd,
+    )
+    if result.returncode != 0 and not allow_nonzero:
+        sys.stderr.write(f"command failed: {' '.join(cmd)}\n{result.stderr}")
+        sys.exit(2)
+    if result.returncode != 0 and allow_nonzero and not result.stdout.strip():
+        # Tool exited non-zero AND produced no stdout -- this is a real
+        # failure (e.g. eslint configuration broken), not just "found issues".
+        sys.stderr.write(f"command failed: {' '.join(cmd)}\n{result.stderr}")
+        sys.exit(2)
+    return result.stdout
+
+
+def _diff_range(base_ref: str) -> str:
+    """Return the git diff range to use against ``base_ref``.
+
+    Prefers three-dot (``A...HEAD``) which compares against the merge
+    base -- matches GitHub PR diffs. Falls back to two-dot on shallow
+    clones where the merge base isn't fetched.
+    """
+    probe = subprocess.run(  # noqa: S603 - controlled git invocation; see _run() docstring
+        ["git", "merge-base", base_ref, "HEAD"],  # noqa: S607
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if probe.returncode == 0 and probe.stdout.strip():
+        return f"{base_ref}...HEAD"
+    return f"{base_ref}..HEAD"
+
+
+def _changed_frontend_files(base_ref: str) -> list[str]:
+    """Return PR-changed frontend source files (added/modified, not deleted).
+
+    Filters by the ``frontend/`` prefix and the JS/TS extension set ESLint
+    handles. Skips ``frontend/node_modules`` / ``dist`` / ``coverage`` so
+    we don't accidentally lint installed packages or build artifacts that
+    happen to appear in a diff (rare but possible during dependency
+    bumps).
+    """
+    out = _run(
+        ["git", "diff", "--name-only", "--diff-filter=AM", _diff_range(base_ref)],  # noqa: S607
+    )
+    skip_prefixes = (
+        "frontend/node_modules/",
+        "frontend/dist/",
+        "frontend/coverage/",
+    )
+    files = []
+    for line in out.splitlines():
+        if not line.startswith("frontend/"):
+            continue
+        if any(line.startswith(p) for p in skip_prefixes):
+            continue
+        if not line.endswith(FRONTEND_EXTENSIONS):
+            continue
+        if Path(line).exists():
+            files.append(line)
+    return files
+
+
+def _parse_hunk_header(line: str) -> tuple[int, int] | None:
+    """Parse a `@@ -OLD,LEN +NEW,LEN @@` line into (new_start, new_length).
+
+    Returns None for malformed headers so callers can skip silently.
+    Same algorithm as ``ruff_diff_check.py`` -- duplicated rather than
+    factored out because the two scripts are intentionally standalone
+    (each one can be invoked without the other being installed/working).
+    """
+    parts = line.split(" ")
+    if len(parts) < MIN_HUNK_HEADER_PARTS:
+        return None
+    new_part = parts[2].lstrip("+")
+    try:
+        if "," in new_part:
+            start_str, length_str = new_part.split(",")
+            return int(start_str), int(length_str)
+        return int(new_part), 1
+    except ValueError:
+        return None
+
+
+def _changed_lines(base_ref: str, files: list[str]) -> dict[str, set[int]]:
+    """Return {repo-relative path: set of changed/added line numbers}.
+
+    Uses ``git diff --unified=0`` so we get pure hunk ranges, not surrounding
+    context. Parses the ``@@ -old +new[,len] @@`` headers directly via
+    ``_parse_hunk_header``.
+    """
+    if not files:
+        return {}
+
+    out = _run(
+        ["git", "diff", "--unified=0", _diff_range(base_ref), "--", *files],  # noqa: S607
+    )
+
+    result: dict[str, set[int]] = defaultdict(set)
+    current_file: str | None = None
+
+    for line in out.splitlines():
+        if line.startswith("+++ b/"):
+            current_file = line[6:]
+            continue
+        if not line.startswith("@@") or current_file is None:
+            continue
+
+        parsed = _parse_hunk_header(line)
+        if parsed is None:
+            continue
+        start, length = parsed
+
+        # length 0 means "this is a deletion only" -- no lines added, skip
+        if length == 0:
+            continue
+
+        for offset in range(length):
+            result[current_file].add(start + offset)
+
+    return result
+
+
+def _eslint_issues(repo_relative_files: list[str], frontend_dir: Path) -> list[dict]:
+    """Run ``eslint --format=json`` on the given files and return parsed list.
+
+    ESLint runs from the ``frontend/`` directory, so file paths must be
+    stripped of the ``frontend/`` prefix when invoking. The returned
+    ``filePath`` is absolute, which we'll convert back to repo-relative
+    in the caller.
+    """
+    if not repo_relative_files:
+        return []
+
+    # Strip "frontend/" prefix -- eslint runs from the frontend dir.
+    stripped = [f[len("frontend/") :] for f in repo_relative_files]
+
+    out = _run(
+        ["npx", "eslint", "--format=json", "--no-error-on-unmatched-pattern", "--", *stripped],  # noqa: S607
+        cwd=frontend_dir,
+        allow_nonzero=True,  # eslint exits 1 when issues found; that's fine
+    )
+    if not out.strip():
+        return []
+    try:
+        return json.loads(out)
+    except json.JSONDecodeError as exc:
+        sys.stderr.write(f"failed to parse eslint JSON: {exc}\n{out[:500]}\n")
+        sys.exit(2)
+
+
+def _categorize_messages(
+    eslint_results: list[dict],
+    diff_lines: dict[str, set[int]],
+    repo_root: Path,
+) -> tuple[list[tuple[str, dict]], list[tuple[str, dict]], int, int]:
+    """Cross-reference eslint diagnostics against the changed-line map.
+
+    Returns ``(new_errors, new_warnings, legacy_error_count,
+    legacy_warning_count)`` where each "new_*" entry is a ``(rel_path,
+    message_dict)`` tuple ready for printing.
+    """
+    new_errors: list[tuple[str, dict]] = []
+    new_warnings: list[tuple[str, dict]] = []
+    legacy_errors = 0
+    legacy_warnings = 0
+
+    for result in eslint_results:
+        try:
+            rel = str(Path(result["filePath"]).resolve().relative_to(repo_root))
+        except (KeyError, ValueError):
+            continue
+
+        changed = diff_lines.get(rel, set())
+        for msg in result.get("messages", []):
+            line = msg.get("line")
+            severity = msg.get("severity")
+            if line is None or severity is None:
+                continue
+
+            is_new = line in changed
+            if severity == SEVERITY_ERROR:
+                if is_new:
+                    new_errors.append((rel, msg))
+                else:
+                    legacy_errors += 1
+            elif severity == SEVERITY_WARNING:
+                if is_new:
+                    new_warnings.append((rel, msg))
+                else:
+                    legacy_warnings += 1
+
+    return new_errors, new_warnings, legacy_errors, legacy_warnings
+
+
+def _print_messages(
+    label: str,
+    items: list[tuple[str, dict]],
+    *,
+    stream: object,
+) -> None:
+    """Print a categorized message list with consistent formatting."""
+    if not items:
+        return
+    stream.write(f"\n{label}:\n")
+    for rel, msg in items:
+        stream.write(
+            f"  {rel}:{msg.get('line', '?')}:{msg.get('column', '?')}: "
+            f"{msg.get('ruleId', '?')} -- {msg.get('message', '')}\n"
+        )
+
+
+def main() -> int:
+    args = sys.argv[1:]
+    warnings_fail = "--warnings-fail" in args
+    args = [a for a in args if not a.startswith("--")]
+    base_ref = args[0] if args else "origin/main"
+
+    repo_root = Path.cwd().resolve()
+    frontend_dir = repo_root / "frontend"
+    if not frontend_dir.is_dir():
+        sys.stderr.write(f"frontend/ directory not found at {frontend_dir}\n")
+        return 2
+
+    files = _changed_frontend_files(base_ref)
+    if not files:
+        print(f"No changed frontend files vs {base_ref} — nothing to check.")
+        return 0
+
+    diff_lines = _changed_lines(base_ref, files)
+    eslint_results = _eslint_issues(files, frontend_dir)
+
+    new_errors, new_warnings, legacy_errors, legacy_warnings = _categorize_messages(
+        eslint_results, diff_lines, repo_root
+    )
+
+    legacy_summary = (
+        f"({legacy_errors} legacy error(s) + {legacy_warnings} legacy warning(s) "
+        f"on unchanged lines were ignored.)"
+    )
+
+    # Decide pass/fail.
+    fail = bool(new_errors) or (warnings_fail and bool(new_warnings))
+
+    if not fail:
+        if new_warnings:
+            # Warnings present but not blocking -- print them as advisory.
+            _print_messages(
+                f"⚠️  {len(new_warnings)} NEW ESLint warning(s) on changed lines",
+                new_warnings,
+                stream=sys.stdout,
+            )
+        print(
+            f"✅ No NEW ESLint errors on changed lines "
+            f"({len(files)} file(s) checked). {legacy_summary}"
+        )
+        return 0
+
+    if new_errors:
+        sys.stderr.write(
+            f"❌ {len(new_errors)} NEW ESLint error(s) on lines added/changed in this PR"
+        )
+    if warnings_fail and new_warnings:
+        sys.stderr.write(f" + {len(new_warnings)} NEW warning(s) (--warnings-fail in effect)")
+    sys.stderr.write(":\n")
+    _print_messages("Errors", new_errors, stream=sys.stderr)
+    if warnings_fail:
+        _print_messages("Warnings (failing because --warnings-fail)", new_warnings, stream=sys.stderr)
+    elif new_warnings:
+        _print_messages("Warnings (advisory; not blocking)", new_warnings, stream=sys.stdout)
+
+    sys.stderr.write(f"\n{legacy_summary}\n")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #113. Brings the frontend ESLint quality gate to parity with the Python ruff gate from PR #89.

## TL;DR

```
+ scripts/eslint_diff_check.py (360 LOC)  ← line-level diff-aware ESLint gate
± .pre-commit-config.yaml                  ← strip 'frontend/' prefix; treat exit code as advisory
± scripts/ci-quality-gate.sh               ← Stage 1 invokes both diff-checks; SKIP eslint-staged in pre-commit
± docs/code-quality-tools.md (+50 LOC)     ← documents the paired diff-check pattern
± .github/copilot-instructions.md          ← drops stale 'ZERO WARNINGS REQUIRED' claim
```

After this lands, frontend PRs no longer need `--admin` to merge.

## What was broken

### Bug 1: path-stripping

`.pre-commit-config.yaml`'s `eslint-staged` hook did:
```yaml
entry: bash -c 'cd frontend && npx eslint --fix -- "$@"' --
```

Pre-commit passes paths repo-relative (`frontend/src/foo.tsx`). After `cd frontend`, eslint looked for `frontend/frontend/src/foo.tsx` and exited 2 with "No files matching the pattern". This caused PR #110's CI failure and is why every frontend PR since #89 has needed `--admin`.

### Bug 2: no diff-awareness

Even after Bug 1, eslint reports errors on the WHOLE file. The frontend has 648 pre-existing legacy errors. Touching one line in any frontend file would have flooded the gate.

This is exactly the problem ruff had until `scripts/ruff_diff_check.py` introduced line-level diff-awareness in PR #89. Now the frontend has the same treatment.

## What this PR adds

### `scripts/eslint_diff_check.py` (new, 360 LOC)

Mirror of `scripts/ruff_diff_check.py`:

| Feature | Behavior |
|---------|----------|
| Default base ref | `origin/main` |
| Diff range | three-dot (`A...HEAD`); falls back to two-dot on shallow clones |
| File scope | `frontend/.*\.(js\|jsx\|ts\|tsx)$`; skips node_modules / dist / coverage |
| Tool invocation | `npx eslint --format=json --no-error-on-unmatched-pattern` from `frontend/` with stripped paths |
| Blocking | NEW errors (severity 2) |
| Advisory | NEW warnings (severity 1) — printed but exit 0 unless `--warnings-fail` |
| Footer | `(N legacy error(s) + M legacy warning(s) on unchanged lines were ignored.)` |
| Exit codes | 0 = pass / 1 = new errors / 2 = tooling failure |

The script intentionally duplicates ~80 LOC of diff-parsing helpers from `ruff_diff_check.py` rather than factoring them into a shared module. Each script is a standalone tool that should not depend on the other being installed/working — same tradeoff the existing ruff script makes.

### `.pre-commit-config.yaml`

The `eslint-staged` hook now:
- Strips the `frontend/` prefix from each arg (fixes Bug 1).
- Treats eslint's exit code as advisory (`|| true`) — applying `--fix` is the goal; blocking on legacy errors is not.

This mirrors the existing Python pattern: `ruff format` is a file-level autofix in pre-commit, and `ruff_diff_check.py` is the diff-aware gate in CI.

### `scripts/ci-quality-gate.sh`

Stage 1 now also runs `scripts/eslint_diff_check.py`. The pre-commit invocation in Stage 1 SKIPs both `ruff` and `eslint-staged` (now CI-gate's job).

### Documentation

- `docs/code-quality-tools.md` — new "Diff-Aware Quality Gates" section + a "Frontend Code Quality Tools" subsection with the right `npm` commands.
- `.github/copilot-instructions.md` — replaced the stale "ESLint - ZERO WARNINGS REQUIRED" claim (the project has 1496 warnings) with the accurate description of the pragmatic-mode gate.

## Verification (three test cases)

```bash
# 1. PR #110's actual diff (should pass — that's the point):
$ python3 scripts/eslint_diff_check.py origin/main
✅ No NEW ESLint errors on changed lines (3 file(s) checked).
   (28 legacy error(s) + 39 legacy warning(s) on unchanged lines were ignored.)
exit=0

# 2. Synthetic new error (added a security/detect-object-injection violation):
$ python3 scripts/eslint_diff_check.py origin/main
❌ 2 NEW ESLint error(s) on lines added/changed in this PR:
Errors:
  frontend/src/pages/can-sniffer.tsx:660:12: @typescript-eslint/consistent-indexed-object-style ...
  frontend/src/pages/can-sniffer.tsx:662:13: security/detect-object-injection ...
exit=1

# 3. No frontend changes at all (no-op):
$ python3 scripts/eslint_diff_check.py origin/main
No changed frontend files vs origin/main — nothing to check.
exit=0
```

Bash + YAML + Python syntax all validate.

## What this PR does NOT do

- Does NOT fix any of the 648 pre-existing eslint errors. That's the whole point of pragmatic mode — those errors stay until someone touches their lines, and the diff-check forces them to be fixed-or-acknowledged.
- Does NOT add an ESLint baseline counter (the way pyright has `EXPECTED_PYRIGHT_ERRORS`). Could be added later; not needed for this PR's goal. #107 is the umbrella issue for ratcheting, and it can include ESLint when picked up.
- Does NOT touch the `npm run typecheck` gate that PR #110 already ratcheted to 0; this is a separate, parallel gate.

## Side effect on PR #110

Once both this PR and #110 land, PR #110's CI will pass on its own. No more `--admin` for routine frontend PRs.

## Tracker
Updates checkbox in #108.