### PR TITLE
ci(ratchets): sync pyright baseline 1533->1484 + add ESLint baseline ratchet (closes #107)

### DIFF
--- a/docs/code-quality-tools.md
+++ b/docs/code-quality-tools.md
@@ -114,7 +114,23 @@ Both scripts are wired into Stage 1 of `scripts/ci-quality-gate.sh`, which is wh
 
 ### Updating baselines
 
-Some tools also have project-wide baselines (counts of acknowledged debt) inside `scripts/ci-quality-gate.sh`. When you legitimately reduce the count, lower the baseline in the same PR. The script prints "🎉 EXCELLENT" with the new count when this happens, and the gate fails until you lower the baseline — which locks in the improvement permanently.
+Three tools have project-wide baselines in `scripts/ci-quality-gate.sh` that act as one-way ratchets:
+
+| Tool | Variable | Stage | Current |
+|------|----------|-------|---------|
+| pyright | `EXPECTED_PYRIGHT_ERRORS` | Stage 3 | 1484 (PR #117) |
+| TypeScript (`tsc --noEmit`) | `EXPECTED_FRONTEND_TS_ERRORS` | Stage 4 | 0 (PR #110) |
+| ESLint (whole project) | `EXPECTED_FRONTEND_ESLINT_ERRORS` | Stage 5 | 648 (PR #117) |
+
+Behavior:
+
+- **Count goes UP** → CI fails. A regression was introduced; either fix it or (rare and discouraged) raise the baseline with a clear PR explanation.
+- **Count goes DOWN without baseline update** → CI also fails. This forces the author to lower the baseline in the same PR, locking in the improvement so a later regression can't silently restore the old count.
+- **Count equals baseline** → CI passes silently.
+
+The "fail on improvement" behavior is intentional. The first PR that reduces a baseline does the work twice (write the fix, lower the number); every subsequent PR benefits because the project has now committed to the new ceiling.
+
+For ESLint and ruff specifically, Stage 1's diff-aware checks (`scripts/eslint_diff_check.py`, `scripts/ruff_diff_check.py`) run *before* the whole-project ratchets and produce focused per-line error reports. The whole-project ratchets exist as a backstop in case the diff-check ever undercounts (e.g., issue #116, the shallow-clone false-positive bug).
 
 ## Pre-commit Integration
 

--- a/scripts/ci-quality-gate.sh
+++ b/scripts/ci-quality-gate.sh
@@ -19,8 +19,9 @@ RESET="\033[0m"
 # gate's job is to stop the count from going UP (a ratchet); fixing actual
 # pyright errors lower the count and the script will print a green message
 # nudging you to update the baseline downward.
-EXPECTED_PYRIGHT_ERRORS=1533  # Ratcheted 2026-05-11 by PIN-manager fixes (Pydantic Field(default=...) keyword form cleared 10 latent errors).
+EXPECTED_PYRIGHT_ERRORS=1484  # Ratcheted 2026-05-12 (PR #117). PRs #109+#111 dropped the count from 1533 by deleting AppState/entity_services dead code that was carrying type errors.
 EXPECTED_FRONTEND_TS_ERRORS=0  # Ratcheted 2026-05-12 to 0 by PR #110 (DatabaseManagementTab + can-sniffer + useCANScanWebSocket generic). Any new TS error is a hard fail.
+EXPECTED_FRONTEND_ESLINT_ERRORS=648  # Captured 2026-05-12 by PR #117. Whole-project ESLint baseline; the diff-aware gate (eslint_diff_check.py in Stage 1) catches NEW issues per-line, this baseline is the project-wide ratchet.
 
 # Determine target branch (for GitHub Actions or local testing)
 if [ -n "${GITHUB_BASE_REF:-}" ]; then
@@ -143,8 +144,11 @@ if [ "$ACTUAL_PYRIGHT_ERRORS" -gt "$EXPECTED_PYRIGHT_ERRORS" ]; then
     exit 1
 elif [ "$ACTUAL_PYRIGHT_ERRORS" -lt "$EXPECTED_PYRIGHT_ERRORS" ]; then
     echo -e "${GREEN}🎉 EXCELLENT: Type errors reduced from $EXPECTED_PYRIGHT_ERRORS to $ACTUAL_PYRIGHT_ERRORS!${RESET}"
-    echo -e "${GREEN}   Please update EXPECTED_PYRIGHT_ERRORS in this script to $ACTUAL_PYRIGHT_ERRORS${RESET}"
-    echo -e "${GREEN}   Include this baseline update in your PR${RESET}"
+    echo -e "${YELLOW}   Update EXPECTED_PYRIGHT_ERRORS in this script to $ACTUAL_PYRIGHT_ERRORS${RESET}"
+    echo -e "${YELLOW}   and include the baseline update in your PR. Failing here so the${RESET}"
+    echo -e "${YELLOW}   improvement is locked in (a future regression can't silently restore it).${RESET}"
+    rm -f "$PYRIGHT_OUTPUT_FILE"
+    exit 1
 else
     echo -e "${GREEN}✅ SUCCESS: Pyright error count stable at baseline of $EXPECTED_PYRIGHT_ERRORS${RESET}"
 fi
@@ -188,6 +192,54 @@ if [ -d "frontend" ]; then
 
     cd ..
     rm -f /tmp/ts-output.log
+fi
+
+# ===== STAGE 5: Whole-Project Frontend ESLint with Baseline =====
+# Stage 1's eslint_diff_check.py catches NEW issues on changed lines.
+# Stage 5 is the project-wide ratchet: it tracks total error count and
+# fails if the count goes UP (regression) OR DOWN without a baseline
+# update in the same PR (locking in any improvement).
+#
+# This mirrors Stage 3 (pyright). When the baseline reaches 0 the
+# diff-check in Stage 1 becomes redundant for blocking purposes, but
+# we keep both because the diff-check gives MUCH better error messages
+# (only the new ones, not the full 648-error wall of text).
+if [ -d "frontend" ]; then
+    echo -e "\n${BLUE}🎨 Stage 5: Full-project ESLint with baseline...${RESET}"
+
+    cd frontend
+
+    ESLINT_OUTPUT_FILE=$(mktemp)
+    npx eslint --format=json --no-error-on-unmatched-pattern -- \
+        "src/**/*.{ts,tsx,js,jsx}" > "$ESLINT_OUTPUT_FILE" 2>/dev/null || true
+
+    # Sum severity-2 (error) messages across all files. The python
+    # one-liner mirrors what scripts/eslint_diff_check.py uses, keeping
+    # the count semantics identical between the two stages.
+    ACTUAL_ESLINT_ERRORS=$(python3 -c "
+import json, sys
+with open('$ESLINT_OUTPUT_FILE') as f:
+    data = json.load(f)
+print(sum(1 for r in data for m in r.get('messages', []) if m.get('severity') == 2))
+")
+
+    rm -f "$ESLINT_OUTPUT_FILE"
+    cd ..
+
+    if [ "$ACTUAL_ESLINT_ERRORS" -gt "$EXPECTED_FRONTEND_ESLINT_ERRORS" ]; then
+        echo -e "${RED}❌ FAILURE: ESLint found $ACTUAL_ESLINT_ERRORS errors, exceeding baseline of $EXPECTED_FRONTEND_ESLINT_ERRORS${RESET}"
+        echo -e "${RED}   Stage 1's eslint_diff_check.py should have caught the specific new error(s).${RESET}"
+        echo -e "${RED}   Re-run with the failure context above to find which line is the regression.${RESET}"
+        exit 1
+    elif [ "$ACTUAL_ESLINT_ERRORS" -lt "$EXPECTED_FRONTEND_ESLINT_ERRORS" ]; then
+        echo -e "${GREEN}🎉 EXCELLENT: ESLint errors reduced from $EXPECTED_FRONTEND_ESLINT_ERRORS to $ACTUAL_ESLINT_ERRORS!${RESET}"
+        echo -e "${YELLOW}   Update EXPECTED_FRONTEND_ESLINT_ERRORS in this script to $ACTUAL_ESLINT_ERRORS${RESET}"
+        echo -e "${YELLOW}   and include the baseline update in your PR. Failing here so the${RESET}"
+        echo -e "${YELLOW}   improvement is locked in (a future regression can't silently restore it).${RESET}"
+        exit 1
+    else
+        echo -e "${GREEN}✅ SUCCESS: ESLint error count stable at baseline of $EXPECTED_FRONTEND_ESLINT_ERRORS${RESET}"
+    fi
 fi
 
 # ===== SUCCESS =====


### PR DESCRIPTION
Closes #107.

## TL;DR

```
± scripts/ci-quality-gate.sh    # pyright baseline synced + Stage 3 ratchet hardened + new Stage 5 (ESLint baseline)
± docs/code-quality-tools.md    # three-ratchet table + 'fail on improvement' rationale
```

After this lands, every project-wide quality counter (pyright, tsc, eslint) has the same one-way ratchet behavior:
- Count UP   → CI fails (regression).
- Count DOWN → CI fails (forces author to lower baseline in same PR — locks in improvement).
- Count EQUAL → silent pass.

## Three changes

### 1. Sync pyright baseline 1533 → 1484

Actual count on `main` after PRs #109 (state.py removal) and #111 (entity_services.py removal) deleted dead code that was carrying type errors: **1484**. The script's `EXPECTED_PYRIGHT_ERRORS` was still 1533, leaving 49 errors of slack — a future regression of up to 49 errors would have passed silently.

### 2. Harden Stage 3 (pyright) ratchet-down branch

Previously, when type-error count went DOWN, the script printed a green hint ("please update EXPECTED_PYRIGHT_ERRORS") and exited 0 — quietly allowing the improvement to slip away on the next PR. Now exits 1, forcing the author to update the baseline in the same PR.

This is the same pattern PR #110 introduced for the TypeScript baseline. Three ratchets, one consistent behavior.

### 3. New Stage 5: whole-project ESLint ratchet

Mirror of Stage 3 (pyright). Counts severity-2 ESLint messages across all frontend source files via `eslint --format=json` + a Python summing script (matches what `eslint_diff_check.py` uses, so the two stages have identical count semantics).

`EXPECTED_FRONTEND_ESLINT_ERRORS=648` (captured on `main` 2026-05-12).

### Why both Stage 1 (diff-aware) AND Stage 5 (whole-project) for ESLint?

- **Stage 1's `eslint_diff_check.py`** catches NEW issues on changed lines — focused per-line error reports, great UX. Limited to what `git-diff` can see (and currently has the shallow-clone false-positive bug, see #116).
- **Stage 5** is the project-wide backstop — fewer-detailed errors, but a true count. Catches any drift the Stage 1 check might miss.

When the baseline reaches 0 the diff-check becomes redundant for blocking purposes, but we'll keep both because the diff-check gives much better error messages.

## Verification

```bash
$ bash -n scripts/ci-quality-gate.sh                            # syntax OK
$ poetry run pyright --outputjson backend | jq .summary.errorCount
1484                                                            # matches EXPECTED_PYRIGHT_ERRORS

$ cd frontend && npx eslint --format=json -- 'src/**/*.{ts,tsx,js,jsx}' \\
  | python3 -c '...sum severity-2 messages...'
648                                                             # matches EXPECTED_FRONTEND_ESLINT_ERRORS
```

Both numbers match what the gate expects → this PR's own CI run exercises the "stable at baseline" path and should pass green.

## What this PR does NOT do

- Does NOT fix any of the 1484 pyright errors or 648 ESLint errors. That's the whole point of pragmatic mode — the ratchet locks them in as the ceiling, future PRs ratchet them down organically.
- Does NOT touch `EXPECTED_FRONTEND_TS_ERRORS` (already 0 from PR #110).
- Does NOT fix the shallow-clone false-positive bug (#116) — that's a separate, narrowly-scoped follow-up.

## Tracker
Updates checkbox in #108.