### PR TITLE
ci(diff-checks): set fetch-depth: 0 in CI + drop wrong two-dot fallback (closes #116)

### DIFF
--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -17,6 +17,17 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v4
+        with:
+          # Diff-aware quality gates (scripts/ruff_diff_check.py,
+          # scripts/eslint_diff_check.py) need access to the merge-base
+          # with `origin/main`. The default `fetch-depth: 1` (shallow
+          # clone) makes `git merge-base` fail, producing false-positive
+          # blocks when the base branch advances past the PR's branch
+          # base. See issue #116 for the exact failure mode that bit
+          # PR #115. The full clone adds a few seconds; the correctness
+          # gain is worth it. The `flake-build` job below does NOT need
+          # this since it doesn't run diff-aware checks.
+          fetch-depth: 0
 
       - name: "Install Nix (with flakes enabled)"
         uses: cachix/install-nix-action@v31

--- a/scripts/ci-quality-gate.sh
+++ b/scripts/ci-quality-gate.sh
@@ -19,7 +19,7 @@ RESET="\033[0m"
 # gate's job is to stop the count from going UP (a ratchet); fixing actual
 # pyright errors lower the count and the script will print a green message
 # nudging you to update the baseline downward.
-EXPECTED_PYRIGHT_ERRORS=1484  # Ratcheted 2026-05-12 (PR #117). PRs #109+#111 dropped the count from 1533 by deleting AppState/entity_services dead code that was carrying type errors.
+EXPECTED_PYRIGHT_ERRORS=1455  # Ratcheted 2026-05-12 (PR #118). CI's pyright environment reports 1455 (vs 1484 on local macOS dev). The CI count is the canonical one — local dev uses an older pyright version (1.1.401 per CI warning vs 1.1.409 in CI), accounting for the ~30-error delta. Self-tested the new ratchet-down-locks-in pattern (#117) along the way: CI failed at 1455, prompted update, here we are.
 EXPECTED_FRONTEND_TS_ERRORS=0  # Ratcheted 2026-05-12 to 0 by PR #110 (DatabaseManagementTab + can-sniffer + useCANScanWebSocket generic). Any new TS error is a hard fail.
 EXPECTED_FRONTEND_ESLINT_ERRORS=648  # Captured 2026-05-12 by PR #117. Whole-project ESLint baseline; the diff-aware gate (eslint_diff_check.py in Stage 1) catches NEW issues per-line, this baseline is the project-wide ratchet.
 

--- a/scripts/eslint_diff_check.py
+++ b/scripts/eslint_diff_check.py
@@ -99,9 +99,19 @@ def _run(cmd: list[str], *, cwd: Path | None = None, allow_nonzero: bool = False
 def _diff_range(base_ref: str) -> str:
     """Return the git diff range to use against ``base_ref``.
 
-    Prefers three-dot (``A...HEAD``) which compares against the merge
-    base -- matches GitHub PR diffs. Falls back to two-dot on shallow
-    clones where the merge base isn't fetched.
+    Always uses three-dot (``A...HEAD``) which compares against the
+    merge base -- matches what GitHub PR diffs show. If the merge base
+    can't be found (typically because the base ref isn't fully fetched
+    on a shallow CI clone), exit with a clear error rather than fall
+    back to two-dot.
+
+    Two-dot ``A..HEAD`` is intentionally NOT a fallback: when the base
+    branch has advanced past the PR's branch base, two-dot reports lines
+    that exist in HEAD but were ALREADY removed from main as "new in
+    this PR", producing false-positive blocks. See issue #116 for the
+    exact failure that bit PR #115. If you hit this error in CI, set
+    ``fetch-depth: 0`` on the actions/checkout step so the merge base
+    is reachable.
     """
     probe = subprocess.run(  # noqa: S603 - controlled git invocation; see _run() docstring
         ["git", "merge-base", base_ref, "HEAD"],  # noqa: S607
@@ -111,7 +121,13 @@ def _diff_range(base_ref: str) -> str:
     )
     if probe.returncode == 0 and probe.stdout.strip():
         return f"{base_ref}...HEAD"
-    return f"{base_ref}..HEAD"
+    sys.stderr.write(
+        f"ERROR: cannot find merge base for {base_ref} vs HEAD.\n"
+        f"This usually means a shallow clone (CI default fetch-depth: 1).\n"
+        f"Set fetch-depth: 0 on actions/checkout, or run\n"
+        f"  `git fetch --unshallow` locally, then retry.\n"
+    )
+    sys.exit(2)
 
 
 def _changed_frontend_files(base_ref: str) -> list[str]:

--- a/scripts/ruff_diff_check.py
+++ b/scripts/ruff_diff_check.py
@@ -77,10 +77,19 @@ def _run(cmd: list[str], *, allow_no_merge_base: bool = False) -> str:
 def _diff_range(base_ref: str) -> str:
     """Return the git diff range to use against ``base_ref``.
 
-    Prefers three-dot (``A...HEAD``) which compares against the merge
-    base -- this is what GitHub PR diffs show. Falls back to two-dot
-    (``A..HEAD``) on shallow clones where the merge base isn't fetched
-    (CI runners default to ``fetch-depth: 1``).
+    Always uses three-dot (``A...HEAD``) which compares against the
+    merge base -- this is what GitHub PR diffs show. If the merge base
+    can't be found (typically because the base ref isn't fully fetched
+    on a shallow CI clone), exit with a clear error rather than fall
+    back to two-dot.
+
+    Two-dot ``A..HEAD`` is intentionally NOT a fallback: when the base
+    branch has advanced past the PR's branch base, two-dot reports lines
+    that exist in HEAD but were ALREADY removed from main as "new in
+    this PR", producing false-positive blocks. See issue #116 for the
+    exact failure that bit PR #115. If you hit this error in CI, set
+    ``fetch-depth: 0`` on the actions/checkout step so the merge base
+    is reachable.
     """
     probe = subprocess.run(  # noqa: S603 - controlled git invocation; see _run() docstring
         ["git", "merge-base", base_ref, "HEAD"],  # noqa: S607 - relies on PATH-resolved git like every other CI helper in this repo
@@ -90,7 +99,13 @@ def _diff_range(base_ref: str) -> str:
     )
     if probe.returncode == 0 and probe.stdout.strip():
         return f"{base_ref}...HEAD"
-    return f"{base_ref}..HEAD"
+    sys.stderr.write(
+        f"ERROR: cannot find merge base for {base_ref} vs HEAD.\n"
+        f"This usually means a shallow clone (CI default fetch-depth: 1).\n"
+        f"Set fetch-depth: 0 on actions/checkout, or run\n"
+        f"  `git fetch --unshallow` locally, then retry.\n"
+    )
+    sys.exit(2)
 
 
 def _changed_python_files(base_ref: str) -> list[str]:


### PR DESCRIPTION
Closes #116. Eliminates the false-positive blocks that bit PR #115.

## TL;DR

```
± .github/workflows/nix-ci.yml      ← fetch-depth: 0 on ci job's checkout
± scripts/ruff_diff_check.py        ← drop two-dot fallback, exit 2 with clear error
± scripts/eslint_diff_check.py      ← drop two-dot fallback, exit 2 with clear error
```

## The bug

Both diff-check scripts had a fallback to two-dot `A..HEAD` git diff when `git merge-base` failed. Shallow CI clones (default `fetch-depth: 1`) consistently triggered the fallback, which gives wrong answers when the base branch has advanced past the PR's branch base:

1. PR opens at commit X on main.
2. Another PR merges into main, advancing it past X.
3. CI runs the diff-check on the original PR.
4. `git merge-base` fails (shallow clone) → script falls back to two-dot.
5. Two-dot `origin/main..HEAD` reports lines that exist in HEAD but were ALREADY removed from main as 'new in this PR'.
6. eslint/ruff flags those (correct, pre-existing) lines as new errors.
7. PR is blocked by a false positive.

PR #115 hit this exactly: main had advanced past its base via PR #110, and the old `onRefresh={refetchSafety}` line that #110 removed got reported as a new `no-misused-promises` error in #115.

## Fix (combined A + C from #116)

### A. Workflow checkout depth

Set `fetch-depth: 0` on the `ci` job's `actions/checkout` step so `git merge-base` always succeeds. The `flake-build` job is unaffected — it doesn't run diff-aware checks. Adds a few seconds to CI; correctness gain is worth it.

### C. Scripts: clear error instead of wrong answer

Replaced the two-dot fallback in `_diff_range` with an explicit error + exit 2 (tooling failure). The error message tells the user exactly how to fix it (`fetch-depth: 0` in CI, `git fetch --unshallow` locally).

Combined effect:
- CI is correct (full clone → three-dot diff works).
- Any future config change that breaks the assumption surfaces a clear error instead of silently producing wrong data and blocking PRs.

## Verification

```bash
# Failure path: error is clear and actionable
$ python3 scripts/eslint_diff_check.py refs/heads/nonexistent-ref
ERROR: cannot find merge base for refs/heads/nonexistent-ref vs HEAD.
This usually means a shallow clone (CI default fetch-depth: 1).
Set fetch-depth: 0 on actions/checkout, or run
  \`git fetch --unshallow\` locally, then retry.
exit=2

# Happy path: still works for both scripts
$ python3 scripts/eslint_diff_check.py origin/main
No changed frontend files vs origin/main — nothing to check.
exit=0

$ python3 scripts/ruff_diff_check.py origin/main
No changed Python files vs origin/main — nothing to check.
exit=0

# Lint clean
$ poetry run ruff check scripts/{ruff,eslint}_diff_check.py
All checks passed!
```

## What this PR does NOT do

- Does NOT change the diff-check scripts' main-loop behavior. Only `_diff_range`.
- Does NOT modify the `flake-build` job (which doesn't run diff checks).
- Does NOT need a forward fix for the still-shallow `release-please.yml` or `test-docs.yml` workflows since they don't invoke the diff-check scripts.

## Tracker
Updates checkbox in #108.