### PR TITLE
test(config): rewrite test_configuration_service against real production layout (4/15 -> 24/24, progress on #105)

### DIFF
--- a/tests/unit/test_configuration_service.py
+++ b/tests/unit/test_configuration_service.py
@@ -1,378 +1,408 @@
 """
-Unit Tests for Configuration Service
+Unit Tests for ConfigurationService
 
 Tests TTL caching behavior, thread safety, and hot-reload functionality
-for the enhanced configuration service implementation.
+for the centralized configuration service in
+``backend/core/configuration_service.py``.
+
+Filesystem layout
+-----------------
+The production service reads configuration from FOUR file types under a
+single ``config_dir``::
+
+    rvc.json                       # Complete RV-C spec (all DGNs in one file)
+    <device_type>_mapping.yml      # Per-device mapping, e.g. coach_mapping.yml
+    coach_mapping.default.yml      # Fallback when a per-device mapping is absent
+    protocol_config.yml            # Per-protocol config, top-level keys per protocol
+
+There is NO per-DGN file layout (``dgn_specs/0xNNNN.yaml``) and no per-protocol
+file layout (``protocols/<name>.yaml``). The previous version of this file
+asserted against an aspirational per-DGN layout that was never implemented in
+production; that test body has been rewritten in PR #119 against the real
+layout. See PR #119's commit message for the full audit.
 """
 
+import json
 import tempfile
 import threading
 import time
 from pathlib import Path
-from unittest.mock import mock_open, patch
 
 import pytest
 import yaml
 
-from backend.core.configuration_service import ConfigurationService
+from backend.core.configuration_service import (
+    ConfigurationLoadError,
+    ConfigurationService,
+)
+
+# ----------------------------------------------------------------------------
+# Fixtures
+# ----------------------------------------------------------------------------
 
 
-class TestConfigurationService:
-    """Test configuration service TTL caching and hot-reload functionality."""
+@pytest.fixture
+def temp_config_dir():
+    """Create a temporary directory for test configuration files."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        yield Path(temp_dir)
 
-    @pytest.fixture
-    def temp_config_dir(self):
-        """Create a temporary directory for test configuration files."""
-        with tempfile.TemporaryDirectory() as temp_dir:
-            yield Path(temp_dir)
 
-    @pytest.fixture
-    def config_service(self, temp_config_dir):
-        """Create a configuration service instance for testing."""
-        return ConfigurationService(temp_config_dir, cache_ttl=1, max_cache_size=10)
+@pytest.fixture
+def config_service(temp_config_dir):
+    """Create a configuration service instance with short TTL for testing."""
+    return ConfigurationService(temp_config_dir, cache_ttl=1, max_cache_size=10)
+
+
+def _write_rvc_json(config_dir: Path, dgns: dict[str, dict]) -> Path:
+    """Helper: write a minimal ``rvc.json`` containing the given DGN map."""
+    spec_file = config_dir / "rvc.json"
+    spec = {"version": "test", "dgns": dgns}
+    spec_file.write_text(json.dumps(spec))
+    return spec_file
+
+
+def _write_default_mapping(config_dir: Path, mapping: dict) -> Path:
+    """Helper: write the default ``coach_mapping.default.yml``."""
+    mapping_file = config_dir / "coach_mapping.default.yml"
+    mapping_file.write_text(yaml.safe_dump(mapping))
+    return mapping_file
+
+
+def _write_device_mapping(config_dir: Path, device_type: str, mapping: dict) -> Path:
+    """Helper: write a per-device mapping ``<device_type>_mapping.yml``."""
+    mapping_file = config_dir / f"{device_type}_mapping.yml"
+    mapping_file.write_text(yaml.safe_dump(mapping))
+    return mapping_file
+
+
+def _write_protocol_config(config_dir: Path, all_configs: dict) -> Path:
+    """Helper: write ``protocol_config.yml`` keyed by protocol name."""
+    config_file = config_dir / "protocol_config.yml"
+    config_file.write_text(yaml.safe_dump(all_configs))
+    return config_file
+
+
+# ----------------------------------------------------------------------------
+# Constructor / initialization
+# ----------------------------------------------------------------------------
+
+
+class TestInitialization:
+    """Constructor + cache-shape assertions."""
 
     def test_initialization(self, temp_config_dir):
-        """Test configuration service initialization."""
+        """Custom cache_ttl + max_cache_size are propagated to the dgn_cache."""
         service = ConfigurationService(temp_config_dir, cache_ttl=300, max_cache_size=1000)
 
         assert service.config_dir == temp_config_dir
+        # Only the dgn_cache uses the user-supplied max_cache_size; the other
+        # caches have their own fixed sizes (current production design).
         assert service.dgn_cache.maxsize == 1000
         assert service.dgn_cache.ttl == 300
         assert service.mapping_cache.maxsize == 100
         assert service.spec_cache.maxsize == 10
         assert service.protocol_cache.maxsize == 50
 
+    def test_missing_config_dir_raises(self, tmp_path):
+        """Pointing the service at a nonexistent directory must error fast."""
+        nonexistent = tmp_path / "does_not_exist"
+        with pytest.raises(ConfigurationLoadError):
+            ConfigurationService(nonexistent)
+
+
+# ----------------------------------------------------------------------------
+# get_full_spec
+# ----------------------------------------------------------------------------
+
+
+class TestFullSpec:
+    """``rvc.json`` loading + caching."""
+
+    def test_returns_none_when_missing(self, config_service):
+        """No ``rvc.json`` on disk -> returns None, no exception."""
+        assert config_service.get_full_spec() is None
+
+    def test_loads_and_caches(self, config_service, temp_config_dir):
+        """First call loads from disk; subsequent calls return the same object."""
+        _write_rvc_json(temp_config_dir, {"1FED1": {"name": "Test"}})
+
+        spec1 = config_service.get_full_spec()
+        spec2 = config_service.get_full_spec()
+
+        assert spec1 == {"version": "test", "dgns": {"1FED1": {"name": "Test"}}}
+        assert spec1 is spec2  # cache hit returns same object
+
+
+# ----------------------------------------------------------------------------
+# get_dgn_spec
+# ----------------------------------------------------------------------------
+
+
+class TestDgnSpec:
+    """``get_dgn_spec(dgn: int)`` resolves via ``rvc.json``."""
+
     def test_dgn_spec_caching(self, config_service, temp_config_dir):
-        """Test DGN specification caching behavior."""
-        # Create a test DGN spec file
-        dgn_file = temp_config_dir / "dgn_specs" / "0x1FED1.yaml"
-        dgn_file.parent.mkdir(parents=True, exist_ok=True)
+        """Second lookup returns the cached object."""
+        # Production lookup uses the 4-char uppercase hex key in rvc.json.
+        _write_rvc_json(temp_config_dir, {"1FED1": {"name": "Test DGN"}})
 
-        test_spec = {
-            "dgn": "0x1FED1",
-            "name": "Test DGN",
-            "signals": [{"name": "test_signal", "start_bit": 0, "length": 8}],
-        }
-
-        with open(dgn_file, "w") as f:
-            yaml.dump(test_spec, f)
-
-        # First call should load from file
         spec1 = config_service.get_dgn_spec(0x1FED1)
-        assert spec1 == test_spec
-
-        # Second call should use cache
         spec2 = config_service.get_dgn_spec(0x1FED1)
-        assert spec2 == test_spec
-        assert spec1 is spec2  # Should be same object from cache
 
-    def test_dgn_spec_cache_miss(self, config_service):
-        """Test DGN specification cache miss behavior."""
-        # Non-existent DGN should return None
-        spec = config_service.get_dgn_spec(0x9999)
-        assert spec is None
+        assert spec1 == {"name": "Test DGN"}
+        assert spec1 is spec2
 
-    def test_device_mapping_caching(self, config_service, temp_config_dir):
-        """Test device mapping caching behavior."""
-        # Create a test device mapping file
-        mapping_file = temp_config_dir / "device_mappings" / "test_device.yaml"
-        mapping_file.parent.mkdir(parents=True, exist_ok=True)
+    def test_dgn_spec_cache_miss_returns_none(self, config_service, temp_config_dir):
+        """A DGN not in rvc.json returns None (no exception)."""
+        _write_rvc_json(temp_config_dir, {"1FED1": {"name": "Other"}})
 
-        test_mapping = {
-            "device_type": "test_device",
-            "dgns": ["0x1FED1", "0x1FED2"],
-            "configuration": {"sample_rate": 100},
-        }
+        assert config_service.get_dgn_spec(0x9999) is None
 
-        with open(mapping_file, "w") as f:
-            yaml.dump(test_mapping, f)
+    def test_dgn_spec_no_spec_file_returns_none(self, config_service):
+        """No rvc.json at all -> all DGN lookups return None."""
+        assert config_service.get_dgn_spec(0x1FED1) is None
 
-        # First call should load from file
-        mapping1 = config_service.get_device_mapping("test_device")
-        assert mapping1 == test_mapping
-
-        # Second call should use cache
-        mapping2 = config_service.get_device_mapping("test_device")
-        assert mapping2 == test_mapping
-        assert mapping1 is mapping2  # Should be same object from cache
-
-    def test_protocol_config_caching(self, config_service, temp_config_dir):
-        """Test protocol configuration caching behavior."""
-        # Create a test protocol config file
-        protocol_file = temp_config_dir / "protocols" / "rvc.yaml"
-        protocol_file.parent.mkdir(parents=True, exist_ok=True)
-
-        test_config = {
-            "protocol": "rvc",
-            "version": "2.0",
-            "features": {"enable_encoder": True, "enable_security": True},
-        }
-
-        with open(protocol_file, "w") as f:
-            yaml.dump(test_config, f)
-
-        # First call should load from file
-        config1 = config_service.get_protocol_config("rvc")
-        assert config1 == test_config
-
-        # Second call should use cache
-        config2 = config_service.get_protocol_config("rvc")
-        assert config2 == test_config
-        assert config1 is config2  # Should be same object from cache
-
-    def test_complete_spec_caching(self, config_service, temp_config_dir):
-        """Test complete specification caching behavior."""
-        # Create a test complete spec file
-        spec_file = temp_config_dir / "specs" / "rvc_complete.json"
-        spec_file.parent.mkdir(parents=True, exist_ok=True)
-
-        test_spec = {
-            "version": "2.0",
-            "dgns": {"0x1FED1": {"name": "Test DGN 1"}, "0x1FED2": {"name": "Test DGN 2"}},
-        }
-
-        import json
-
-        with open(spec_file, "w") as f:
-            json.dump(test_spec, f)
-
-        # First call should load from file
-        spec1 = config_service.get_complete_spec("rvc_complete")
-        assert spec1 == test_spec
-
-        # Second call should use cache
-        spec2 = config_service.get_complete_spec("rvc_complete")
-        assert spec2 == test_spec
-        assert spec1 is spec2  # Should be same object from cache
-
-    def test_cache_ttl_expiration(self, temp_config_dir):
-        """Test that cache entries expire after TTL."""
-        # Use very short TTL for testing
-        service = ConfigurationService(temp_config_dir, cache_ttl=0.1, max_cache_size=10)
-
-        # Create a test DGN spec file
-        dgn_file = temp_config_dir / "dgn_specs" / "0x1FED1.yaml"
-        dgn_file.parent.mkdir(parents=True, exist_ok=True)
-
-        test_spec = {"dgn": "0x1FED1", "name": "Test DGN"}
-
-        with open(dgn_file, "w") as f:
-            yaml.dump(test_spec, f)
-
-        # Load spec into cache
-        spec1 = service.get_dgn_spec(0x1FED1)
-        assert spec1 == test_spec
-
-        # Wait for TTL to expire
-        time.sleep(0.2)
-
-        # Should reload from file (not cached)
-        spec2 = service.get_dgn_spec(0x1FED1)
-        assert spec2 == test_spec
-        # Objects should be different (reloaded)
-        assert spec1 is not spec2
-
-    def test_cache_size_limit(self, temp_config_dir):
-        """Test that cache respects size limits."""
-        # Use small cache size for testing
+    def test_dgn_spec_cache_size_limit(self, temp_config_dir):
+        """``max_cache_size`` is enforced by the underlying TTLCache."""
         service = ConfigurationService(temp_config_dir, cache_ttl=300, max_cache_size=2)
 
-        # Create test DGN spec directory
-        dgn_dir = temp_config_dir / "dgn_specs"
-        dgn_dir.mkdir(parents=True, exist_ok=True)
+        # Populate rvc.json with several DGNs so all lookups hit the cache.
+        _write_rvc_json(
+            temp_config_dir,
+            {f"{0x1FED1 + i:04X}": {"name": f"DGN {i}"} for i in range(5)},
+        )
 
-        # Create multiple DGN specs
-        for i in range(5):
-            dgn_file = dgn_dir / f"0x{0x1FED1 + i:04X}.yaml"
-            test_spec = {"dgn": f"0x{0x1FED1 + i:04X}", "name": f"Test DGN {i}"}
-
-            with open(dgn_file, "w") as f:
-                yaml.dump(test_spec, f)
-
-        # Load specs into cache (should evict older entries)
         for i in range(5):
             service.get_dgn_spec(0x1FED1 + i)
 
-        # Cache should only contain recent entries
         assert len(service.dgn_cache) <= 2
 
-    def test_hot_reload_configuration(self, config_service, temp_config_dir):
-        """Test hot-reload of configuration files."""
-        # Create initial DGN spec file
-        dgn_file = temp_config_dir / "dgn_specs" / "0x1FED1.yaml"
-        dgn_file.parent.mkdir(parents=True, exist_ok=True)
+    def test_dgn_spec_ttl_expiration(self, temp_config_dir):
+        """Cached DGN is reloaded after TTL expires."""
+        # Use very short TTL; cachetools' TTLCache uses time.monotonic() and
+        # a >TTL sleep is enough to evict the entry on the next access.
+        service = ConfigurationService(temp_config_dir, cache_ttl=1, max_cache_size=10)
 
-        initial_spec = {"dgn": "0x1FED1", "name": "Initial DGN", "version": 1}
+        _write_rvc_json(temp_config_dir, {"1FED1": {"name": "Cached"}})
+        service.get_dgn_spec(0x1FED1)
+        assert "dgn_1FED1" in service.dgn_cache
 
-        with open(dgn_file, "w") as f:
-            yaml.dump(initial_spec, f)
+        # Wait past the TTL; the next access must NOT find the entry in cache.
+        time.sleep(1.5)
+        # Confirm the cache is empty (TTLCache lazily evicts on access; the
+        # __contains__ trigger above + this fresh probe both count as access).
+        assert "dgn_1FED1" not in service.dgn_cache
 
-        # Load initial spec
-        spec1 = config_service.get_dgn_spec(0x1FED1)
-        assert spec1["version"] == 1
 
-        # Trigger hot reload
+# ----------------------------------------------------------------------------
+# get_device_mapping
+# ----------------------------------------------------------------------------
+
+
+class TestDeviceMapping:
+    """``get_device_mapping(device_type: str)`` reads YAML mappings."""
+
+    def test_loads_specific_mapping_when_present(self, config_service, temp_config_dir):
+        """``<device_type>_mapping.yml`` takes precedence over the default."""
+        specific = {"device_type": "coach", "dgns": ["0x1FED1"]}
+        _write_device_mapping(temp_config_dir, "coach", specific)
+
+        result = config_service.get_device_mapping("coach")
+        assert result == specific
+
+    def test_falls_back_to_default(self, config_service, temp_config_dir):
+        """Without a device-specific file, falls back to coach_mapping.default.yml."""
+        default = {"device_type": "default", "dgns": []}
+        _write_default_mapping(temp_config_dir, default)
+
+        # Request a device type with no specific file.
+        result = config_service.get_device_mapping("unknown_device")
+        assert result == default
+
+    def test_returns_none_when_no_mappings_exist(self, config_service):
+        """No mapping files at all -> None."""
+        assert config_service.get_device_mapping("anything") is None
+
+    def test_caching(self, config_service, temp_config_dir):
+        """Second call returns the cached object."""
+        _write_default_mapping(temp_config_dir, {"device_type": "x"})
+
+        m1 = config_service.get_device_mapping("anything")
+        m2 = config_service.get_device_mapping("anything")
+        assert m1 is m2
+
+
+# ----------------------------------------------------------------------------
+# get_protocol_config
+# ----------------------------------------------------------------------------
+
+
+class TestProtocolConfig:
+    """``get_protocol_config(protocol: str)`` reads ``protocol_config.yml``."""
+
+    def test_returns_default_when_no_file(self, config_service):
+        """Without protocol_config.yml the service returns built-in defaults."""
+        result = config_service.get_protocol_config("rvc")
+
+        # The built-in default for "rvc" is non-empty and includes priority/data_rate.
+        assert result is not None
+        assert result["priority"] == 6
+        assert result["data_rate"] == 250000
+
+    def test_reads_user_override(self, config_service, temp_config_dir):
+        """A protocol entry in protocol_config.yml overrides the built-in default."""
+        _write_protocol_config(
+            temp_config_dir,
+            {"rvc": {"priority": 3, "data_rate": 500000, "extended_id": True, "timeout_ms": 50}},
+        )
+
+        result = config_service.get_protocol_config("rvc")
+        assert result == {
+            "priority": 3,
+            "data_rate": 500000,
+            "extended_id": True,
+            "timeout_ms": 50,
+        }
+
+    def test_unknown_protocol_falls_back_to_default(self, config_service, temp_config_dir):
+        """Asking for a protocol not in the file returns the built-in default."""
+        _write_protocol_config(temp_config_dir, {"j1939": {"priority": 6}})
+
+        result = config_service.get_protocol_config("rvc")
+        # Built-in rvc default has priority 6, data_rate 250000, etc.
+        assert result["priority"] == 6
+        assert result["data_rate"] == 250000
+
+    def test_caching(self, config_service):
+        """Second call returns the cached object even when only the default applies."""
+        c1 = config_service.get_protocol_config("rvc")
+        c2 = config_service.get_protocol_config("rvc")
+        assert c1 is c2
+
+
+# ----------------------------------------------------------------------------
+# Hot reload
+# ----------------------------------------------------------------------------
+
+
+class TestReload:
+    """``reload_configuration`` and ``check_for_updates`` semantics."""
+
+    def test_reload_clears_caches(self, config_service, temp_config_dir):
+        """After reload, the next get_full_spec() must hit the disk again."""
+        _write_rvc_json(temp_config_dir, {"1FED1": {"version": 1}})
+        spec1 = config_service.get_full_spec()
+        assert spec1["dgns"]["1FED1"]["version"] == 1
+
+        # Mutate file + reload.
+        _write_rvc_json(temp_config_dir, {"1FED1": {"version": 2}})
         config_service.reload_configuration()
 
-        # Update the file
-        updated_spec = {"dgn": "0x1FED1", "name": "Updated DGN", "version": 2}
+        spec2 = config_service.get_full_spec()
+        assert spec2["dgns"]["1FED1"]["version"] == 2
+        assert spec1 is not spec2
 
-        with open(dgn_file, "w") as f:
-            yaml.dump(updated_spec, f)
+    def test_check_for_updates_rate_limits(self, config_service, temp_config_dir):
+        """``check_for_updates`` only checks the filesystem every _check_interval seconds."""
+        _write_rvc_json(temp_config_dir, {"1FED1": {"version": 1}})
 
-        # Should load updated spec after reload
-        spec2 = config_service.get_dgn_spec(0x1FED1)
-        assert spec2["version"] == 2
+        # First call sets the timestamp baseline.
+        # We can't easily prove the rate limit without sleeping for the full
+        # interval, so just confirm the method doesn't crash and returns bool.
+        result1 = config_service.check_for_updates()
+        result2 = config_service.check_for_updates()
+        assert isinstance(result1, bool)
+        assert isinstance(result2, bool)
+        # The second call within _check_interval seconds is rate-limited.
+        assert result2 is False
 
-    def test_thread_safety(self, config_service, temp_config_dir):
-        """Test thread safety of cache operations."""
-        # Create a test DGN spec file
-        dgn_file = temp_config_dir / "dgn_specs" / "0x1FED1.yaml"
-        dgn_file.parent.mkdir(parents=True, exist_ok=True)
 
-        test_spec = {"dgn": "0x1FED1", "name": "Thread Safety Test"}
+# ----------------------------------------------------------------------------
+# Cache stats
+# ----------------------------------------------------------------------------
 
-        with open(dgn_file, "w") as f:
-            yaml.dump(test_spec, f)
+
+class TestCacheStats:
+    """``get_cache_stats`` (NOT ``get_cache_statistics`` — that name was
+    invented by the old test file and never existed in production)."""
+
+    def test_returns_size_maxsize_ttl_per_cache(self, config_service):
+        """The stats dict reports size/maxsize/ttl for each of the four caches."""
+        stats = config_service.get_cache_stats()
+
+        for cache_name in ("dgn_cache", "mapping_cache", "spec_cache", "protocol_cache"):
+            assert cache_name in stats, f"missing {cache_name} in stats"
+            for field in ("size", "maxsize", "ttl"):
+                assert field in stats[cache_name], f"missing {field} in {cache_name}"
+
+    def test_size_increases_with_use(self, config_service, temp_config_dir):
+        """Loading a DGN increases dgn_cache.size by 1."""
+        _write_rvc_json(temp_config_dir, {"1FED1": {"name": "Test"}})
+
+        before = config_service.get_cache_stats()["dgn_cache"]["size"]
+        config_service.get_dgn_spec(0x1FED1)
+        after = config_service.get_cache_stats()["dgn_cache"]["size"]
+
+        assert after == before + 1
+
+
+# ----------------------------------------------------------------------------
+# Thread safety
+# ----------------------------------------------------------------------------
+
+
+class TestThreadSafety:
+    """The internal RLock guards cache reads/writes across threads."""
+
+    def test_concurrent_dgn_lookups(self, config_service, temp_config_dir):
+        """10 threads x 100 ops on the same DGN must not raise or return inconsistent data."""
+        _write_rvc_json(temp_config_dir, {"1FED1": {"name": "Thread Safety"}})
 
         results = []
-        exceptions = []
+        exceptions: list[BaseException] = []
 
         def worker():
-            """Worker thread that accesses cache concurrently."""
             try:
                 for _ in range(100):
                     spec = config_service.get_dgn_spec(0x1FED1)
                     results.append(spec)
-                    time.sleep(0.001)  # Small delay to increase contention
+                    time.sleep(0.001)
             except Exception as e:
                 exceptions.append(e)
 
-        # Start multiple threads
-        threads = []
-        for _ in range(10):
-            thread = threading.Thread(target=worker)
-            threads.append(thread)
-            thread.start()
+        threads = [threading.Thread(target=worker) for _ in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
 
-        # Wait for all threads to complete
-        for thread in threads:
-            thread.join()
+        assert exceptions == [], f"Thread safety violations: {exceptions}"
+        assert len(results) == 1000
+        # Every result is the same dict (same identity, since it's the cached object).
+        first = results[0]
+        for r in results:
+            assert r == first
 
-        # Check that no exceptions occurred
-        assert len(exceptions) == 0, f"Thread safety violations: {exceptions}"
 
-        # Check that all results are consistent
-        assert len(results) == 1000  # 10 threads * 100 operations
-        for result in results:
-            assert result == test_spec
+# ----------------------------------------------------------------------------
+# Error handling
+# ----------------------------------------------------------------------------
 
-    def test_error_handling_invalid_yaml(self, config_service, temp_config_dir):
-        """Test error handling for invalid YAML files."""
-        # Create invalid YAML file
-        dgn_file = temp_config_dir / "dgn_specs" / "0x1FED1.yaml"
-        dgn_file.parent.mkdir(parents=True, exist_ok=True)
 
-        with open(dgn_file, "w") as f:
-            f.write("invalid: yaml: content: [")
+class TestErrorHandling:
+    """Bad input data must not crash the service."""
 
-        # Should handle invalid YAML gracefully
-        spec = config_service.get_dgn_spec(0x1FED1)
-        assert spec is None
+    def test_invalid_json_in_rvc_returns_none(self, config_service, temp_config_dir):
+        """Malformed rvc.json -> ``get_full_spec`` returns None."""
+        (temp_config_dir / "rvc.json").write_text("{not valid json")
 
-    def test_error_handling_missing_file(self, config_service):
-        """Test error handling for missing configuration files."""
-        # Request non-existent spec
-        spec = config_service.get_dgn_spec(0x9999)
-        assert spec is None
+        assert config_service.get_full_spec() is None
 
-        mapping = config_service.get_device_mapping("non_existent")
-        assert mapping is None
-
-        protocol = config_service.get_protocol_config("non_existent")
-        assert protocol is None
-
-        complete_spec = config_service.get_complete_spec("non_existent")
-        assert complete_spec is None
-
-    def test_cache_key_generation(self, config_service):
-        """Test that cache keys are generated correctly."""
-        # Test DGN cache keys
-        assert "dgn_1FED1" in str(config_service._get_dgn_cache_key(0x1FED1))
-
-        # Test different representations generate same key
-        key1 = config_service._get_dgn_cache_key(0x1FED1)
-        key2 = config_service._get_dgn_cache_key(130769)  # Same as 0x1FED1
-        assert key1 == key2
-
-    def test_cache_statistics(self, config_service, temp_config_dir):
-        """Test cache statistics and monitoring."""
-        # Create test files
-        dgn_file = temp_config_dir / "dgn_specs" / "0x1FED1.yaml"
-        dgn_file.parent.mkdir(parents=True, exist_ok=True)
-
-        test_spec = {"dgn": "0x1FED1", "name": "Stats Test"}
-
-        with open(dgn_file, "w") as f:
-            yaml.dump(test_spec, f)
-
-        # Initial cache should be empty
-        stats = config_service.get_cache_statistics()
-        assert stats["dgn_cache"]["size"] == 0
-        assert stats["dgn_cache"]["hits"] == 0
-        assert stats["dgn_cache"]["misses"] == 0
-
-        # Load spec (cache miss)
-        config_service.get_dgn_spec(0x1FED1)
-
-        stats = config_service.get_cache_statistics()
-        assert stats["dgn_cache"]["size"] == 1
-        assert stats["dgn_cache"]["misses"] == 1
-
-        # Load same spec again (cache hit)
-        config_service.get_dgn_spec(0x1FED1)
-
-        stats = config_service.get_cache_statistics()
-        assert stats["dgn_cache"]["size"] == 1
-        assert stats["dgn_cache"]["hits"] == 1
-        assert stats["dgn_cache"]["misses"] == 1
-
-    def test_memory_usage_optimization(self, temp_config_dir):
-        """Test memory usage optimization with large datasets."""
-        # Use small cache to test memory optimization
-        service = ConfigurationService(temp_config_dir, cache_ttl=300, max_cache_size=5)
-
-        # Create directory for test files
-        dgn_dir = temp_config_dir / "dgn_specs"
-        dgn_dir.mkdir(parents=True, exist_ok=True)
-
-        # Create many large specs to test memory usage
-        for i in range(20):
-            dgn_file = dgn_dir / f"0x{0x1FED1 + i:04X}.yaml"
-            # Create larger spec with many signals
-            large_spec = {
-                "dgn": f"0x{0x1FED1 + i:04X}",
-                "name": f"Large DGN {i}",
-                "signals": [
-                    {
-                        "name": f"signal_{j}",
-                        "start_bit": j * 8,
-                        "length": 8,
-                        "description": f"Test signal {j} with long description",
-                    }
-                    for j in range(50)  # 50 signals per DGN
-                ],
-            }
-
-            with open(dgn_file, "w") as f:
-                yaml.dump(large_spec, f)
-
-        # Load all specs (should trigger cache eviction)
-        for i in range(20):
-            service.get_dgn_spec(0x1FED1 + i)
-
-        # Cache should remain within size limits
-        assert len(service.dgn_cache) <= 5
-
-        stats = service.get_cache_statistics()
-        assert stats["dgn_cache"]["size"] <= 5
+    def test_missing_files_return_none(self, config_service):
+        """All accessors return None when their backing file is absent."""
+        assert config_service.get_dgn_spec(0x1FED1) is None
+        assert config_service.get_device_mapping("nope") is None
+        # protocol falls back to a built-in default rather than None — see
+        # TestProtocolConfig.test_returns_default_when_no_file. That's the
+        # documented behavior of get_protocol_config.


### PR DESCRIPTION
First cluster from issue #105 (test-restoration sweep #2). Restores `tests/unit/test_configuration_service.py` from **4/15 passing to 24/24 passing**.

## TL;DR

```
tests/unit/test_configuration_service.py | +321 / -291  (rewrite)
```

The previous test body asserted against an aspirational filesystem layout that production never implemented. Same pattern as PRs #109 (test_state.py) and #111 (test_entity_service.py) — 2025-era scaffolding tests written against a designed-but-never-built API.

## What was wrong

| Test expected                        | Production actually reads          |
|--------------------------------------|------------------------------------|
| `dgn_specs/0xNNNN.yaml` (per-DGN)    | `rvc.json` (one big file)          |
| `device_mappings/<type>.yaml`        | `<type>_mapping.yml` or `coach_mapping.default.yml` |
| `protocols/rvc.yaml`                 | `protocol_config.yml` (top-level keys per protocol) |
| `specs/rvc_complete.json`            | `rvc.json`                         |
| `get_complete_spec(name)`            | `get_full_spec()` (no name arg)    |
| `get_cache_statistics()`             | `get_cache_stats()`                |
| `_get_dgn_cache_key(int)`            | (does not exist)                  |

Of the 15 tests in the old file:
- **2 genuinely passed** (`test_initialization`, `test_dgn_spec_cache_miss`)
- **2 passed for the WRONG reason**: `test_cache_size_limit` and `test_error_handling_invalid_yaml` created files in the unused `dgn_specs/` subdir, which the production code never reads, so the cache stayed empty and the assertions passed vacuously.
- **11 failed** because the layout-under-test doesn't exist.

## What this PR does

Rewrites the file end-to-end against the ACTUAL production layout. Restructures into 8 focused test classes mirroring the public API:

- `TestInitialization` (2 tests)
- `TestFullSpec` (2)
- `TestDgnSpec` (4)
- `TestDeviceMapping` (4)
- `TestProtocolConfig` (4)
- `TestReload` (2)
- `TestCacheStats` (2)
- `TestThreadSafety` (1) — same 10x100-op stress as before, ported to real layout
- `TestErrorHandling` (2) — including the invalid-JSON-in-rvc.json case the old version was *supposed* to cover but didn't

**Result: 4/15 (27%) → 24/24 (100%).**

## Production findings during the rewrite

**None.** The production `ConfigurationService` is well-behaved:
- Returns `None` on missing files instead of crashing.
- Falls back to `coach_mapping.default.yml` when a per-device mapping is absent.
- Returns built-in protocol defaults when `protocol_config.yml` is missing OR when the requested protocol isn't in the file.
- Cache eviction (TTL + maxsize) works as expected.
- Thread-safe via `_cache_lock` (RLock).

The new tests all exercise real code paths, not stubbed ones. **No production bug was hiding here** — the old tests were just guarding the wrong code.

## Test suite delta

| Metric  | Before | After | Δ |
|---------|--------|-------|---|
| Passed  | 711    | 732   | +21 |
| Failed  | 82     | 70    | -12 |
| Errors  | 47     | 47    | 0 |
| Skipped | 22     | 22    | 0 |

Math check: +9 new tests in the file (24 - 15), all passing, plus 11 broken old tests becoming green = expected +20 pass / -11 fail. Observed +21/-12; the +1 delta is most likely `test_async_notification_dispatcher::test_force_queue_processing` flickering (known pollution issue documented in handoff-2026-05-11.md).

## What this PR does NOT do

- Does NOT modify `backend/core/configuration_service.py` — production code is fine as-is.
- Does NOT add the per-DGN/per-device file layer the old tests presumed. If anyone wants that someday, this rewritten test file documents what the real layout looks like and the old test file (in git history) shows what the proposed-but-unimplemented layout would look like.
- Does NOT close issue #105 — that's the umbrella sweep with ~140 more failures+errors. This PR closes the test_configuration_service.py cluster (~11 of those).

## Tracker

Updates progress on #105 (test-restoration sweep #2). Cluster `tests/unit/test_configuration_service.py (11 failures)` ✅ closed.