### PR TITLE
test(entities): skip-stub legacy /api/entities + v2 contract tests

### DIFF
--- a/tests/api/test_entities.py
+++ b/tests/api/test_entities.py
@@ -1,300 +1,60 @@
-"""
-Tests for the entities API endpoints.
+"""Tests for the entities API endpoints.
 
-This module tests the entity endpoints. It will attempt to use Domain API v2
-endpoints first, and fall back to legacy endpoints if they're not available.
-This supports the migration period where both APIs may coexist.
+The previous version of this file targeted a hybrid legacy+v2 entity
+API where the test would try ``/api/v2/entities`` first and fall back
+to ``/api/entities`` if v2 returned 404. That layout no longer
+matches production:
+
+- The legacy ``/api/entities``, ``/api/metadata``, ``/api/unmapped``,
+  and ``/api/unknown-pgns`` endpoints were retired; only the v2 paths
+  remain (see ``backend/api/domains/entities.py``).
+- The v2 endpoints are mounted unconditionally — there is no
+  feature-flag gate, so the ``override_feature_manager`` fixture the
+  tests required does not (and should not) exist.
+- The v2 ``GET /api/v2/entities`` endpoint expects
+  ``EntityService.list_entities()`` to return a *dict-of-dicts* keyed
+  by ``entity_id`` with raw entity payloads (see
+  ``backend/services/entity_service.py:98`` and the conversion loop
+  at ``backend/api/domains/entities.py:480``); the previous test mocks
+  returned a paginated ``{"entities": [...]}`` list, which the router
+  would refuse to convert.
+- ``GET /api/v2/entities/ids`` was never implemented on the v2 router
+  at all.
+
+Because each of these clashes is structural (contract change, not a
+mock typo), restoring real coverage for ``/api/v2/entities/*`` requires
+purpose-built tests against the actual v2 schema and service contract,
+not a tweak of the existing test bodies. That is a feature task that
+deserves its own PR (likely paired with the still-open
+``EntityService.control_light`` refactor in #112).
+
+This file is therefore skip-stubbed. When the v2 entity router gets
+its own dedicated test file, those tests should:
+
+- Mount only the v2 entity router on a fresh ``FastAPI()`` app (see
+  ``tests/api/test_safety_pin_endpoints.py`` for the canonical
+  pattern).
+- Override ``backend.core.dependencies.get_entity_service`` directly
+  via ``app.dependency_overrides`` rather than ``unittest.mock.patch``
+  on import paths.
+- Use ``EntitySchemaV2`` / ``EntityCollectionV2`` from
+  ``backend.api.domains.entities`` for response assertions so the
+  contract is enforced at the schema layer, not via ad-hoc dict checks.
+
+Refs: PRs #109 (state.py removal), #111 (entity service
+disambiguation), #115 (notification cleanup), #120 (v1→v2 migration
+parity skip-stub), issue #105 (test sweep #2), issue #112
+(``control_light`` refactor).
 """
 
 import pytest
-from httpx import AsyncClient
 
-
-@pytest.mark.api
-@pytest.mark.asyncio
-async def test_list_entities_success(
-    async_client: AsyncClient, override_entity_service, override_feature_manager
-):
-    """Test successful retrieval of all entities."""
-    # Arrange
-    mock_entities = {
-        "entities": [
-            {
-                "entity_id": "light_1",
-                "name": "Kitchen Light",
-                "device_type": "light",
-                "state": {"state": True},
-                "protocol": "rvc",
-                "available": True,
-                "last_updated": "2023-01-01T12:00:00Z",
-            },
-            {
-                "entity_id": "sensor_1",
-                "name": "Temperature Sensor",
-                "device_type": "sensor",
-                "state": {"value": 20.5},
-                "protocol": "rvc",
-                "available": True,
-                "last_updated": "2023-01-01T12:00:00Z",
-            },
-        ],
-        "total_count": 2,
-        "page": 1,
-        "page_size": 50,
-        "has_next": False,
-        "filters_applied": {},
-    }
-    override_entity_service.list_entities.return_value = mock_entities
-    override_feature_manager.is_enabled.return_value = True
-
-    # Act - Try Domain API v2 first, fall back to legacy if not available
-    response = await async_client.get("/api/v2/entities")
-
-    if response.status_code == 404:
-        # Domain API v2 not available, use legacy endpoint
-        # Update mock for legacy format
-        override_entity_service.list_entities.return_value = {
-            "light_1": {
-                "id": "light_1",
-                "name": "Kitchen Light",
-                "device_type": "light",
-                "value": True,
-            },
-            "sensor_1": {
-                "id": "sensor_1",
-                "name": "Temperature Sensor",
-                "device_type": "sensor",
-                "value": 20.5,
-            },
-        }
-        response = await async_client.get("/api/entities")
-
-        # Assert legacy format
-        assert response.status_code == 200
-        data = response.json()
-        assert len(data) == 2
-        assert "light_1" in data
-        assert "sensor_1" in data
-    else:
-        # Assert Domain API v2 format
-        assert response.status_code == 200
-        data = response.json()
-        assert "entities" in data
-        assert len(data["entities"]) == 2
-        # Check entity IDs in the paginated response
-        entity_ids = [entity["entity_id"] for entity in data["entities"]]
-        assert "light_1" in entity_ids
-        assert "sensor_1" in entity_ids
-
-    override_entity_service.list_entities.assert_called_once_with(device_type=None, area=None)
-
-
-@pytest.mark.api
-@pytest.mark.asyncio
-async def test_list_entities_with_device_type_filter(
-    async_client: AsyncClient, override_entity_service, override_feature_manager
-):
-    """Test entity listing with device_type filter."""
-    # Arrange
-    mock_entities = {
-        "entities": [
-            {
-                "entity_id": "light_1",
-                "name": "Kitchen Light",
-                "device_type": "light",
-                "state": {"state": True},
-                "protocol": "rvc",
-                "available": True,
-                "last_updated": "2023-01-01T12:00:00Z",
-            },
-        ],
-        "total_count": 1,
-        "page": 1,
-        "page_size": 50,
-        "has_next": False,
-        "filters_applied": {"device_type": "light"},
-    }
-    override_entity_service.list_entities.return_value = mock_entities
-    override_feature_manager.is_enabled.return_value = True
-
-    # Act
-    response = await async_client.get("/api/v2/entities?device_type=light")
-
-    # Assert
-    assert response.status_code == 200
-    data = response.json()
-    assert "entities" in data
-    assert len(data["entities"]) == 1
-    # Check entity ID in the paginated response
-    entity_ids = [entity["entity_id"] for entity in data["entities"]]
-    assert "light_1" in entity_ids
-    override_entity_service.list_entities.assert_called_once_with(device_type="light", area=None)
-
-
-@pytest.mark.api
-@pytest.mark.asyncio
-async def test_list_entities_rvc_disabled(
-    async_client: AsyncClient, override_entity_service, override_feature_manager
-):
-    """Test entity listing when RVC feature is disabled."""
-    # Arrange
-    override_feature_manager.is_enabled.return_value = False
-
-    # Act
-    response = await async_client.get("/api/v2/entities")
-
-    # Assert
-    assert response.status_code == 404
-    data = response.json()
-    assert "rvc feature is disabled" in data["detail"]
-    override_entity_service.list_entities.assert_not_called()
-
-
-@pytest.mark.api
-@pytest.mark.asyncio
-async def test_list_entity_ids_success(
-    async_client: AsyncClient, override_entity_service, override_feature_manager
-):
-    """Test successful retrieval of entity IDs."""
-    # Arrange
-    mock_ids = ["light_1", "sensor_1", "lock_1"]
-    override_entity_service.list_entity_ids.return_value = mock_ids
-    override_feature_manager.is_enabled.return_value = True
-
-    # Act
-    response = await async_client.get("/api/v2/entities/ids")
-
-    # Assert
-    assert response.status_code == 200
-    data = response.json()
-    assert data == mock_ids
-    override_entity_service.list_entity_ids.assert_called_once()
-
-
-@pytest.mark.api
-@pytest.mark.asyncio
-async def test_get_entity_success(
-    async_client: AsyncClient, override_entity_service, override_feature_manager
-):
-    """Test successful retrieval of a specific entity by ID."""
-    # Arrange
-    entity_id = "light_1"
-    mock_entity = {
-        "entity_id": entity_id,
-        "name": "Kitchen Light",
-        "device_type": "light",
-        "state": {"state": True},
-        "protocol": "rvc",
-        "available": True,
-        "last_updated": "2023-01-01T12:00:00Z",
-    }
-    override_entity_service.get_entity.return_value = mock_entity
-    override_feature_manager.is_enabled.return_value = True
-
-    # Act
-    response = await async_client.get(f"/api/v2/entities/{entity_id}")
-
-    # Assert
-    assert response.status_code == 200
-    data = response.json()
-    assert data["entity_id"] == entity_id
-    assert data["name"] == "Kitchen Light"
-    override_entity_service.get_entity.assert_called_once_with(entity_id)
-
-
-@pytest.mark.api
-@pytest.mark.asyncio
-async def test_get_entity_not_found(
-    async_client: AsyncClient, override_entity_service, override_feature_manager
-):
-    """Test entity not found returns 404."""
-    # Arrange
-    entity_id = "nonexistent_entity"
-    override_entity_service.get_entity.return_value = None
-    override_feature_manager.is_enabled.return_value = True
-
-    # Act
-    response = await async_client.get(f"/api/v2/entities/{entity_id}")
-
-    # Assert
-    assert response.status_code == 404
-    data = response.json()
-    assert "Entity 'nonexistent_entity' not found" in data["detail"]
-    override_entity_service.get_entity.assert_called_once_with(entity_id)
-
-
-@pytest.mark.api
-@pytest.mark.asyncio
-async def test_get_unmapped_entries_success(
-    async_client: AsyncClient, override_entity_service, override_feature_manager
-):
-    """Test successful retrieval of unmapped entries."""
-    # Arrange
-    mock_unmapped = {
-        "unmapped_entries": [
-            {"dgn": 65280, "instance": 1, "count": 5, "last_seen": "2023-01-01T12:00:00Z"}
-        ]
-    }
-    override_entity_service.get_unmapped_entries.return_value = mock_unmapped
-    override_feature_manager.is_enabled.return_value = True
-
-    # Act
-    response = await async_client.get("/api/unmapped")
-
-    # Assert
-    assert response.status_code == 200
-    data = response.json()
-    assert "unmapped_entries" in data
-    assert len(data["unmapped_entries"]) == 1
-    override_entity_service.get_unmapped_entries.assert_called_once()
-
-
-@pytest.mark.api
-@pytest.mark.asyncio
-async def test_get_unknown_pgns_success(
-    async_client: AsyncClient, override_entity_service, override_feature_manager
-):
-    """Test successful retrieval of unknown PGNs."""
-    # Arrange
-    mock_unknown = {
-        "unknown_pgns": [{"pgn": 123456, "count": 3, "last_seen": "2023-01-01T12:00:00Z"}]
-    }
-    override_entity_service.get_unknown_pgns.return_value = mock_unknown
-    override_feature_manager.is_enabled.return_value = True
-
-    # Act
-    response = await async_client.get("/api/unknown-pgns")
-
-    # Assert
-    assert response.status_code == 200
-    data = response.json()
-    assert "unknown_pgns" in data
-    assert len(data["unknown_pgns"]) == 1
-    override_entity_service.get_unknown_pgns.assert_called_once()
-
-
-@pytest.mark.api
-@pytest.mark.asyncio
-async def test_get_metadata_success(
-    async_client: AsyncClient, override_entity_service, override_feature_manager
-):
-    """Test successful retrieval of metadata."""
-    # Arrange
-    mock_metadata = {
-        "entity_types": ["light", "sensor", "lock"],
-        "areas": ["kitchen", "living_room", "bedroom"],
-        "total_entities": 15,
-    }
-    override_entity_service.get_metadata.return_value = mock_metadata
-    override_feature_manager.is_enabled.return_value = True
-
-    # Act
-    response = await async_client.get("/api/metadata")
-
-    # Assert
-    assert response.status_code == 200
-    data = response.json()
-    assert "entity_types" in data
-    assert "areas" in data
-    assert data["total_entities"] == 15
-    override_entity_service.get_metadata.assert_called_once()
+pytest.skip(
+    reason=(
+        "Tests in this file targeted the legacy /api/entities + feature-flag "
+        "gated v2 endpoints. The legacy paths are retired and the v2 service "
+        "contract is incompatible with the original mocks. Rewriting these "
+        "as real v2 contract tests is a feature task; see module docstring."
+    ),
+    allow_module_level=True,
+)


### PR DESCRIPTION
## Pattern
**A (skip-stub)** — legacy + feature-flag contract is gone; v2 contract is incompatible with the existing mocks.

## Why
The previous test file targeted a hybrid legacy+v2 entity API where each
test would try `/api/v2/entities` first and fall back to `/api/entities`
if v2 returned 404. That layout no longer matches production:

- Legacy `/api/entities`, `/api/metadata`, `/api/unmapped`,
  `/api/unknown-pgns` are retired. Only v2 paths remain
  (`backend/api/domains/entities.py`).
- v2 endpoints are mounted **unconditionally** (no feature-flag gate),
  so the `override_feature_manager` fixture the tests required does
  not (and should not) exist — there is no `feature_manager` service.
- v2 `GET /api/v2/entities` expects `EntityService.list_entities()` to
  return a *dict-of-dicts* keyed by `entity_id` with raw entity
  payloads (see `backend/services/entity_service.py:98` and the
  conversion loop at `backend/api/domains/entities.py:480`); the
  previous mocks returned a paginated `{entities:[...]}` list, which
  the router would refuse to convert.
- `GET /api/v2/entities/ids` was never implemented on the v2 router.

Restoring real coverage for `/api/v2/entities/*` requires
purpose-built tests against the actual v2 schema and service contract,
not a tweak of the existing test bodies. That is a feature task that
deserves its own PR (likely paired with the still-open
`EntityService.control_light` refactor in #112).

## What
Replace the file with a module-level `pytest.skip` stub plus a
docstring that documents:
1. Why the file is skipped (contract change, not a mock typo).
2. What the right v2-only test pattern looks like — use a fresh
   `FastAPI()` app like `tests/api/test_safety_pin_endpoints.py`
   does, override `get_entity_service` via
   `app.dependency_overrides` rather than `unittest.mock.patch`.
3. Which schemas to assert against (`EntitySchemaV2` /
   `EntityCollectionV2`).

## Test delta
File-level (`tests/api/test_entities.py`):
- before: 0 passed, **9 errors** (fixture `override_feature_manager` not found)
- after:  0 passed, 1 skipped (file-level marker)

## Production bugs caught
**0** (Pattern A — the API contract is gone, no production bug.)

## Refs
- #105 (test-restoration sweep #2)
- #112 (`control_light` refactor — the natural pair for v2 entity test coverage)
- #109 (state.py removal), #111 (entity service disambiguation),
  #115 (notification cleanup), #120 (v1→v2 migration parity skip-stub)