### PR TITLE
fix+test(perf-monitor): per-component error isolation + 3 stale-test rewrites

### DIFF
--- a/backend/integrations/can/performance_monitor.py
+++ b/backend/integrations/can/performance_monitor.py
@@ -236,56 +236,70 @@ class PerformanceMonitor:
                 await asyncio.sleep(self.collection_interval)
 
     async def _collect_metrics(self) -> None:
-        """Collect current performance metrics."""
+        """Collect current performance metrics.
+
+        Per-component collection is wrapped in try/except so a single
+        broken ``ComponentStats`` (e.g. a faulty subclass that raises
+        from ``get_avg_processing_time``) cannot crash the whole
+        background monitoring task. The bad component's metric for
+        this tick is dropped and logged; the next tick will retry.
+        """
         current_time = time.time()
 
         with self._lock:
             # Collect component metrics
             for component, stats in self.component_stats.items():
-                # Processing time metrics
-                if stats.messages_processed > 0:
+                try:
+                    # Processing time metrics
+                    if stats.messages_processed > 0:
+                        self._add_metric(
+                            f"{component.value}_avg_processing_time_ms",
+                            MetricType.GAUGE,
+                            component,
+                            stats.get_avg_processing_time(),
+                            {"component": component.value},
+                        )
+
+                        self._add_metric(
+                            f"{component.value}_p95_processing_time_ms",
+                            MetricType.GAUGE,
+                            component,
+                            stats.get_percentile_processing_time(95.0),
+                            {"component": component.value},
+                        )
+
+                    # Throughput metrics
                     self._add_metric(
-                        f"{component.value}_avg_processing_time_ms",
+                        f"{component.value}_throughput_msg_sec",
                         MetricType.GAUGE,
                         component,
-                        stats.get_avg_processing_time(),
+                        stats.get_throughput(),
                         {"component": component.value},
                     )
 
+                    # Error rate metrics
                     self._add_metric(
-                        f"{component.value}_p95_processing_time_ms",
+                        f"{component.value}_error_rate_percent",
                         MetricType.GAUGE,
                         component,
-                        stats.get_percentile_processing_time(95.0),
+                        stats.get_error_rate(),
                         {"component": component.value},
                     )
 
-                # Throughput metrics
-                self._add_metric(
-                    f"{component.value}_throughput_msg_sec",
-                    MetricType.GAUGE,
-                    component,
-                    stats.get_throughput(),
-                    {"component": component.value},
-                )
-
-                # Error rate metrics
-                self._add_metric(
-                    f"{component.value}_error_rate_percent",
-                    MetricType.GAUGE,
-                    component,
-                    stats.get_error_rate(),
-                    {"component": component.value},
-                )
-
-                # Message count metrics
-                self._add_metric(
-                    f"{component.value}_messages_total",
-                    MetricType.COUNTER,
-                    component,
-                    stats.messages_processed,
-                    {"component": component.value},
-                )
+                    # Message count metrics
+                    self._add_metric(
+                        f"{component.value}_messages_total",
+                        MetricType.COUNTER,
+                        component,
+                        stats.messages_processed,
+                        {"component": component.value},
+                    )
+                except Exception as exc:  # defensive: see method docstring
+                    logger.warning(
+                        "Skipping metrics for component %s this tick: %s",
+                        getattr(component, "value", component),
+                        exc,
+                    )
 
             # BAM-specific metrics
             self._collect_bam_metrics()

--- a/tests/unit/test_performance_monitor.py
+++ b/tests/unit/test_performance_monitor.py
@@ -191,12 +191,21 @@ class TestPerformanceMonitor:
         return PerformanceMonitor(collection_interval=0.1, retention_hours=1)
 
     def test_monitor_initialization(self, monitor):
-        """Test performance monitor initialization."""
+        """Test performance monitor initialization.
+
+        Updated 2026-05-13: production groups counters into
+        ``system_stats`` / ``security_stats`` dicts (see
+        ``backend/integrations/can/performance_monitor.py:184``)
+        rather than exposing them as top-level attributes. This is
+        consistent with how every other test in this file already
+        accesses these counters (e.g. ``monitor.system_stats[...]``
+        on line 213).
+        """
         assert monitor.collection_interval == 0.1
         assert monitor.retention_hours == 1
         assert len(monitor.component_stats) == len(ComponentType)
-        assert monitor.total_messages_processed == 0
-        assert monitor.total_anomalies_detected == 0
+        assert monitor.system_stats["total_messages_processed"] == 0
+        assert monitor.security_stats["anomalies_detected"] == 0
 
         # Check that all components have stats
         for component in ComponentType:
@@ -442,9 +451,22 @@ class TestPerformanceMonitor:
             assert stats.error_count == 0
 
     def test_metric_retention_limits(self, monitor):
-        """Test metric retention and memory management."""
-        # Set very small retention for testing
-        monitor.metrics.maxlen = 5
+        """Test metric retention and memory management.
+
+        Updated 2026-05-13: ``collections.deque.maxlen`` is read-only
+        in Python 3.12 (and was always read-only at runtime --
+        attribute setting raises ``AttributeError``). The previous
+        version of this test wrote ``monitor.metrics.maxlen = 5``
+        which crashed before any retention logic could be exercised.
+
+        Replace the deque entirely with a fresh ``deque(maxlen=5)``
+        so we can verify the actual retention contract: when more
+        than ``maxlen`` metrics are appended, only the most recent
+        ``maxlen`` are kept (FIFO eviction).
+        """
+        from collections import deque as _deque
+
+        monitor.metrics = _deque(maxlen=5)
 
         # Add more metrics than the limit
         for i in range(10):


### PR DESCRIPTION
## Pattern
**C + B** — small production resilience improvement + test rewrites.

Cluster: `tests/unit/test_performance_monitor.py` (3 of 33 failing → 0).

## Three issues, three fixes

### 1. `test_monitor_initialization` (Pattern B)
Asserted `monitor.total_messages_processed` and
`monitor.total_anomalies_detected` as top-level attributes. Production
groups these into dicts:
- `self.system_stats['total_messages_processed']`
  (`backend/integrations/can/performance_monitor.py:184`)
- `self.security_stats['anomalies_detected']` (line 177)

The OTHER tests in the same file already use the dict form (see line
213's `monitor.system_stats[...]`); only the init test was stale.

**Fix:** assert against the dict form.

### 2. `test_metric_retention_limits` (Pattern B)
Wrote `monitor.metrics.maxlen = 5` to set retention. But
`collections.deque.maxlen` has been read-only at runtime in CPython
forever — the assignment raises `AttributeError`, which crashed the
test before any retention logic could run.

**Fix:** replace `monitor.metrics` with a fresh `deque(maxlen=5)` so
we actually exercise FIFO eviction at the limit.

### 3. `test_metric_collection_error_handling` (Pattern C, defensive)
The test asserted that `PerformanceMonitor._collect_metrics()` should
not crash when a single `ComponentStats` object's
`get_avg_processing_time` raises. Production didn't handle this — one
broken component would crash the entire background monitoring task
for that tick (and every subsequent tick if the underlying defect
persists).

**Honest assessment**: this is a defensive fix. We don't have evidence
of a known caller that triggers the failure today; `ComponentStats`
is internal to the can package and its math is straightforward
(`statistics.mean` over a deque of floats). But for a long-running
background metric collector, swallow-and-log per-component errors
is the right resilience posture: losing one component's metric for
one tick is strictly better than dropping the whole monitoring loop.

**Fix:** wrap the per-component for-loop body in try/except + warning
log. The bad component's metric for that tick is dropped; next tick
will retry.

## Test delta
File-level (`tests/unit/test_performance_monitor.py`):
- before: 30 passed, **3 failed**
- after:  **33 passed**, 0 failed

The 'Invalid file descriptor: -1' pytest unraisable-exception warning
at the end of the run is a pre-existing artifact unrelated to these
changes (visible on `main` too).

## Production bugs caught
**1 (defensive)** — preventive resilience improvement, no known
trigger today but reasonable hardening for a long-running
metric-collection loop. Cumulative cycle count: **9** (was 8).

## Refs
- #105 (test-restoration sweep #2)