### PR TITLE
fix+test(safety-state): block ops when parking-brake state is unknown + test rewrites

### DIFF
--- a/backend/core/safety_state_engine.py
+++ b/backend/core/safety_state_engine.py
@@ -137,20 +137,32 @@ class SafetyStateEngine:
         if self.current_state == VehicleState.UNSAFE:
             return False, "Vehicle in unsafe state - no operations allowed"
 
-        # Operation-specific safety rules
+        # Operation-specific safety rules.
+        #
+        # Important: parking-brake-required operations use ``is not True``
+        # rather than ``is False`` so that an *unknown* brake state
+        # (parking_brake_set is None — we never observed a brake event yet)
+        # blocks the operation. For a defense-in-depth API guardrail
+        # (Firefly MIRA owns the actual vehicle safety case; see
+        # /memories/repo/coachiq-architecture.md), the safer default is
+        # "deny unless we have confirmation the brake is set", not "allow
+        # whenever we haven't seen a release event".
         if operation == "slideout_extend":
+            # Check parking brake FIRST so the failure reason is actionable
+            # rather than the generic "state unknown" message that the
+            # state-check below would produce.
+            if self.state_data.parking_brake_set is not True:
+                return False, "Slideout extension requires parking brake to be set"
+
             if self.current_state not in [VehicleState.PARKED_SAFE, VehicleState.PARKED_RUNNING]:
                 return False, f"Slideout extension not allowed in state {self.current_state.value}"
-
-            if self.state_data.parking_brake_set is False:
-                return False, "Slideout extension requires parking brake to be set"
 
         elif operation == "engine_start":
             if self.state_data.transmission_gear not in [None, "park", "P"]:
                 return False, "Engine start not allowed when transmission not in park"
 
         elif operation in ["leveling_extend", "leveling_retract"]:
-            if self.state_data.parking_brake_set is False:
+            if self.state_data.parking_brake_set is not True:
                 return False, "Leveling operations require parking brake to be set"
 
         return True, "Operation allowed"

--- a/tests/test_canbus_decoder_safety.py
+++ b/tests/test_canbus_decoder_safety.py
@@ -345,6 +345,17 @@ class TestSafetyValidation:
 
         Ensures thread safety when multiple CAN messages trigger
         safety events simultaneously.
+
+        Updated 2026-05-13: ``SafetyStateEngine.process_event`` returns
+        ``SafetyCommand | None`` and correctly returns ``None`` for
+        events that do not require a follow-up action (which is most of
+        them; see ``_evaluate_safety_rules`` -- only
+        ``PARKING_BRAKE_RELEASED`` currently logs a warning, and even
+        that returns ``None``). The previous assertion
+        ``assert all(result is not None for result in results)``
+        encoded a contract that production never matched. The real
+        thread-safety contract under test is "concurrent events do not
+        raise"; we now verify that explicitly.
         """
         # Create multiple concurrent safety events
         events = [
@@ -360,13 +371,20 @@ class TestSafetyValidation:
             task = asyncio.create_task(self._process_safety_event(safety_engine, event, data))
             tasks.append(task)
 
-        # Wait for all to complete
-        results = await asyncio.gather(*tasks)
+        # Wait for all to complete. ``return_exceptions=False`` means a
+        # raised exception in any task would propagate out of gather --
+        # that's the actual thread-safety contract we want to verify.
+        results = await asyncio.gather(*tasks, return_exceptions=False)
 
-        # Verify all events were processed successfully
-        assert all(result is not None for result in results), (
-            "All events should process successfully"
-        )
+        # Each result must be either None (no command needed) or a
+        # SafetyCommand. Anything else means process_event returned an
+        # unexpected type.
+        from backend.core.safety_state_engine import SafetyCommand
+
+        for result in results:
+            assert result is None or isinstance(result, SafetyCommand), (
+                f"process_event should return None or SafetyCommand, got {type(result)}"
+            )
 
         # Verify final state is consistent
         final_state = safety_engine.get_current_state()


### PR DESCRIPTION
## Pattern
**C + B** — **real production safety bug** + 2 test rewrites.

Cluster: `tests/test_canbus_decoder_safety.py` (3 of 14 failing → 0).

## ⚠️ Real production safety bug fixed

`SafetyStateEngine.is_operation_safe` checked
`if self.state_data.parking_brake_set is False` for parking-brake-
required operations (`leveling_extend`, `leveling_retract`, slideout's
secondary check). Because `parking_brake_set` defaults to `None`
(unknown — we have not yet observed a brake event), the check
`is False` does **NOT** fire for `None`. Production therefore
**allowed leveling operations whenever the brake state was unknown**,
falling through to `return True, 'Operation allowed'`.

### Reproducer
```python
engine = SafetyStateEngine()
engine.process_event(SafetyEvent.VEHICLE_STOPPED, {'speed': 0})
is_safe, _ = engine.is_operation_safe('leveling_extend', 'jack')
# Before fix: is_safe == True   (UNSAFE — brake state unknown)
# After fix:  is_safe == False
```

For a defense-in-depth API guardrail (CoachIQ talks to a Firefly MIRA
panel which owns the actual vehicle safety case; see
`/memories/repo/coachiq-architecture.md`), the safer default is
**'deny unless we have confirmation the brake is set'**, NOT 'allow
whenever we have not seen a release event'.

### Impact assessment
This is API guardrail code, not the actual vehicle safety system, so
the impact is bounded: **CoachIQ would have forwarded a slideout/
leveling command to Firefly without doing its own pre-check**.
Firefly would presumably refuse the command if its own brake reading
disagreed. But for defense-in-depth, the right default is to refuse
upstream rather than rely on the OEM controller — a Firefly/CoachIQ
mode disagreement is exactly when this guardrail matters most.

### Fix
Change `is False` → `is not True` for the parking-brake checks in
`backend/core/safety_state_engine.py`. Also reordered the
`slideout_extend` checks so parking brake is tested **first**, making
the failure reason actionable ('parking brake required') rather than
the generic 'state unknown' message that would otherwise fire.

## Three issues, three fixes

### 1. `test_leveling_operations_require_parking_brake` (Pattern C)
**The real bug above.** Test was right; production was wrong.

### 2. `test_slideout_blocked_without_parking_brake` (Pattern C, side benefit)
Same fix path. Production was actually blocking slideout in the test
scenario via the state-check, but with an unhelpful 'state unknown'
message. Reordering the checks makes the message actionable.

### 3. `test_concurrent_safety_processing` (Pattern B)
Asserted `assert all(result is not None for result in results)` — i.e.,
every event must produce a `SafetyCommand`. But `process_event`
returns `SafetyCommand | None` and correctly returns `None` for events
that don't require a follow-up action (which is most of them). The
encoded contract was never matched by any production version.

**Fix:** rewrite the assertion to verify the actual thread-safety
contract (no exceptions raised; return is `None` or `SafetyCommand`).

## Test delta
File-level (`tests/test_canbus_decoder_safety.py`):
- before: 11 passed, **3 failed**
- after:  **14 passed**, 0 failed

## Production bugs caught
**1 real safety bug** — parking-brake unknown-state default.
Cumulative cycle count: **10** (was 9).

## Regression check
Ran `tests/core/` + `tests/services/` broadly (332 tests, 92s) — 5
failures all pre-existing in clusters #10 (`test_entity_manager`)
and 2 trailing tiny clusters (`github_update_checker`), unrelated to
the `safety_state_engine` change. No regressions from this fix.

## Refs
- #105 (test-restoration sweep #2)
- `/memories/repo/coachiq-architecture.md` (architectural framing)