### PR TITLE
fix+test(dep-resolver): use post-fallback graph in stage optimization + test rewrite

### DIFF
--- a/backend/core/service_dependency_resolver.py
+++ b/backend/core/service_dependency_resolver.py
@@ -206,6 +206,18 @@ class ServiceDependencyResolver:
 
         Services can potentially start earlier if all their dependencies
         are satisfied in earlier stages.
+
+        Reads dependencies from ``self._dependency_graph`` (the post-
+        fallback-resolution view) rather than from ``node.dependencies``
+        (the original raw list). This matters when a primary REQUIRED
+        dependency was substituted for its declared ``fallback`` in
+        ``_validate_dependencies``: the original ``node.dependencies``
+        entry still references the missing primary, but the actual
+        startup edge is on the fallback. Iterating the raw list would
+        cause ``dep.name in self._nodes`` to silently skip the missing
+        primary, leaving ``max_dep_stage = -1`` and putting the
+        dependent service in stage 0 — exactly when its real (fallback)
+        dependency must run first.
         """
         # Calculate depth (distance from root) for each node
         self._calculate_depths()
@@ -214,11 +226,12 @@ class ServiceDependencyResolver:
         optimized_stages = defaultdict(list)
 
         for service_name, node in self._nodes.items():
-            # Find the maximum stage of all dependencies
+            # Find the maximum stage of all dependencies. Use the
+            # post-fallback dependency graph (see method docstring).
             max_dep_stage = -1
-            for dep in node.dependencies:
-                if dep.type == DependencyType.REQUIRED and dep.name in self._nodes:
-                    dep_stage = self._nodes[dep.name].stage
+            for dep_name in self._dependency_graph.get(service_name, ()):
+                if dep_name in self._nodes:
+                    dep_stage = self._nodes[dep_name].stage
                     if dep_stage is not None:
                         max_dep_stage = max(max_dep_stage, dep_stage)
 

--- a/tests/test_service_dependency_resolver.py
+++ b/tests/test_service_dependency_resolver.py
@@ -137,13 +137,37 @@ class TestServiceDependencyResolver:
         assert stages[1] == ["A"]
 
     def test_runtime_dependency_validation(self):
-        """Test runtime dependency validation."""
+        """Test runtime dependency validation.
+
+        Updated 2026-05-13: the previous version of this test had two
+        bugs that made it impossible to pass:
+
+        1. ``missing[0]`` and ``missing[1]`` are integer subscripts on a
+           ``dict[str, list[str]]`` -- they would raise ``KeyError``,
+           not check anything.
+        2. It asserted ``"A" in missing`` while passing
+           ``available_services={"A", "B"}``. But A's only runtime dep
+           is B, and B IS available, so production correctly reports A
+           as having no missing deps. Runtime validation does direct-
+           dep checking only; it does NOT do transitive analysis (and
+           shouldn't -- if an upstream dependency goes degraded, that's
+           the upstream's failure to report, not ours).
+
+        Rewrite to match the actual contract:
+        - All declared services start in stage 0 (RUNTIME deps don't
+          gate startup).
+        - validate_runtime_dependencies({"A","B"}) returns
+          {"B": ["C"]} -- only B's runtime dep is missing.
+        - If we drop B from available_services, then A's direct dep is
+          missing too: validate_runtime_dependencies({"A"}) returns
+          {"A": ["B"]}.
+        """
         resolver = ServiceDependencyResolver()
 
         # A has runtime dependency on B
         resolver.add_service("A", [ServiceDependency("B", type=DependencyType.RUNTIME)])
 
-        # B has runtime dependency on C
+        # B has runtime dependency on C (which is never registered)
         resolver.add_service("B", [ServiceDependency("C", type=DependencyType.RUNTIME)])
 
         stages = resolver.resolve_dependencies()
@@ -152,12 +176,19 @@ class TestServiceDependencyResolver:
         assert len(stages) == 1
         assert set(stages[0]) == {"A", "B"}
 
-        # Validate runtime dependencies
+        # Validate runtime dependencies with both services available.
+        # Direct-dep check: A is satisfied (B is up); B is missing C.
         missing = resolver.validate_runtime_dependencies({"A", "B"})
-        assert "A" in missing
-        assert "B" in missing[0]
-        assert "B" in missing
-        assert "C" in missing[1]
+        assert missing == {"B": ["C"]}, (
+            "Runtime validation should only flag B (its dep C is missing); "
+            f"A's direct dep B is available, got: {missing}"
+        )
+
+        # If B is also down, A's direct runtime dep becomes missing too.
+        missing = resolver.validate_runtime_dependencies({"A"})
+        assert missing == {"A": ["B"]}, (
+            f"With only A available, A should be flagged as missing B; got: {missing}"
+        )
 
     def test_dependency_report(self):
         """Test dependency report generation."""


### PR DESCRIPTION
## Pattern
**C + B** — real production bug + test rewrite.

Cluster: `tests/test_service_dependency_resolver.py` (2 of 13 failing → 0).

## Real production bug

`ServiceDependencyResolver._optimize_stages` iterated the original
`node.dependencies` list and checked `dep.name in self._nodes`. But
`_validate_dependencies` substitutes a missing primary dependency
for its declared `fallback` only in `_dependency_graph` — the
original `node.dependencies` entry still references the missing
primary.

### Reproducer
```python
resolver = ServiceDependencyResolver()
resolver.add_service('A', [ServiceDependency('B', fallback='C')])
resolver.add_service('C', [])
stages = resolver.resolve_dependencies()
# Before fix: {0: ['A', 'C']}   (A in same stage as its fallback C — wrong)
# After fix:  {0: ['C'], 1: ['A']}  (A correctly waits for C)
```

`_validate_dependencies` correctly rewrote
`_dependency_graph[A] = {C}`, but `_optimize_stages` iterated
`node.dependencies = [Dep('B', fallback='C')]`, checked
`'B' in self._nodes` (False — B was never registered), and silently
skipped the dependency. `max_dep_stage` stayed at -1, so A landed
in stage 0 alongside C.

### Real-world impact
Any service that uses `fallback=` to declare an alternative
dependency would start in the **wrong stage** — potentially before
its actual fallback dependency was up. This defeats the entire
purpose of the fallback feature.

### Fix
Read from `self._dependency_graph[service_name]` (the post-fallback
view, populated by `add_service` and possibly rewritten by
`_validate_dependencies`) instead of iterating the raw
`node.dependencies` list. Method docstring updated to explain the
subtlety.

## Test rewrite

`test_runtime_dependency_validation` had two bugs that made it
impossible to pass:

1. `missing[0]` and `missing[1]` are integer subscripts on a
   `dict[str, list[str]]` — they would raise `KeyError`.
2. Asserted `'A' in missing` while passing
   `available_services={'A', 'B'}`. But A's only runtime dep is B,
   and B IS available, so production correctly reports A as having
   no missing deps. Runtime validation does direct-dep checking
   only; it does NOT do transitive analysis (and shouldn't —
   transitive runtime degradation is the upstream's responsibility
   to report).

**Fix:** rewrite to verify the actual contract — direct-dep
checking with two scenarios (B available vs B down).

## Test delta
File-level (`tests/test_service_dependency_resolver.py`):
- before: 11 passed, **2 failed**
- after:  **13 passed**, 0 failed

## Regression check
Ran `tests/core/` + `tests/test_service_dependency_resolver.py`
(60 tests) — all pass.

## Production bugs caught
**1 real** — fallback dependencies were ignored by the stage
optimizer. Cumulative cycle count: **11**.

## Refs
- #105 (test-restoration sweep #2)