### PR TITLE
test(user-invitation): use _role= to match production signature

### DIFF
--- a/tests/integrations/auth/test_user_invitation_integration.py
+++ b/tests/integrations/auth/test_user_invitation_integration.py
@@ -52,11 +52,22 @@ class TestUserInvitationService:
 
     @pytest.mark.asyncio
     async def test_create_invitation_success(self, invitation_service):
-        """Test successful invitation creation."""
+        """Test successful invitation creation.
+
+        Updated 2026-05-13: production's ``UserInvitationService.create_invitation``
+        accepts ``_role`` (with leading underscore -- 'reserved for future
+        implementation' per its docstring). The underscore prefix is
+        ergonomically awkward and ideally would be renamed to ``role``
+        when the role is actually wired through, but that's a feature
+        task; here we just match the current signature.
+        See ``backend/services/user_invitation_service.py:80`` and
+        ``backend/api/routers/auth.py:855`` (the router also passes
+        ``_role=request.role or 'user'`` for the same reason).
+        """
         response = await invitation_service.create_invitation(
             email="user@example.com",
             invited_by_admin="admin",
-            role="user",
+            _role="user",
             message="Welcome to CoachIQ!",
         )
 
@@ -305,12 +316,14 @@ class TestUserInvitationEmailIntegration:
 
         invitation_service = UserInvitationService(auth_manager, notification_manager)
 
-        # Create invitation with personal message
+        # Create invitation with personal message. See
+        # ``test_create_invitation_success`` for why ``_role`` is
+        # underscore-prefixed in the production signature.
         await invitation_service.create_invitation(
             email="user@example.com",
             invited_by_admin="admin",
             message="Welcome to our team!",
-            role="user",
+            _role="user",
         )
 
         # Verify email was sent with correct content


### PR DESCRIPTION
## Pattern
**B (test rewrite)** — production signature is unchanged, two test calls used the wrong keyword arg.

Cluster: `tests/integrations/auth/test_user_invitation_integration.py` (2 of 14 failing → 0).

## Why
Production's `UserInvitationService.create_invitation` accepts `_role`
(with leading underscore — *'reserved for future implementation'* per
its docstring at `backend/services/user_invitation_service.py:80`).
Two of the 14 tests in this file were calling it with `role=`, which
raises `TypeError`. The other 12 tests don't pass the role at all and
rely on the default.

The router (`backend/api/routers/auth.py:855`) also uses
`_role=request.role or 'user'` — so the awkward underscore-prefix
is consistent end-to-end in production code.

## What
Change `role=` → `_role=` in the two failing test calls and document
the convention so the next reader doesn't have to re-derive it.

## Note on production
The underscore prefix is ergonomically awkward for callers; ideally
it would be renamed to `role` once the role is actually wired through
(currently unused — the param name is just a future-API placeholder).
But that's a feature task, not a test restoration. **Out of scope
for this PR.**

## Test delta
File-level (`tests/integrations/auth/test_user_invitation_integration.py`):
- before: 12 passed, **2 failed**
- after:  **14 passed**, 0 failed

## Production bugs caught
**0**

## Refs
- #105 (test-restoration sweep #2)