### PR TITLE
test(zod-validation): override get_auth_manager dep so schema endpoints are reachable

### DIFF
--- a/tests/contract/test_zod_validation.py
+++ b/tests/contract/test_zod_validation.py
@@ -18,6 +18,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from fastapi.testclient import TestClient
 
+from backend.core.dependencies import get_auth_manager
 from backend.main import create_app
 
 
@@ -26,9 +27,27 @@ class TestZodSchemaExport:
 
     @pytest.fixture
     def client(self):
-        """Create test client for schema export testing"""
-        app = create_app()
-        return TestClient(app)
+        """Create test client for schema export testing.
+
+        Updated 2026-05-13: the schema endpoints take an injected
+        ``AuthManager`` (via ``Depends(get_auth_manager)``) but never
+        actually use it -- the dependency is purely a 'must be wired up'
+        gate. In a TestClient that doesn't run lifespan, the
+        ServiceRegistry isn't initialized and ``get_auth_manager``
+        raises ``RuntimeError``, which Starlette converts to 500.
+
+        Override the dependency with a MagicMock so we can actually
+        exercise the schema-export contract. NOTE: if/when the schema
+        router is hardened to actually USE the auth_manager (or
+        switched to ``get_authenticated_user``), this override will
+        need to be revisited.
+        """
+        test_app = create_app()
+        test_app.dependency_overrides[get_auth_manager] = lambda: MagicMock()
+        try:
+            yield TestClient(test_app)
+        finally:
+            test_app.dependency_overrides.clear()
 
     def test_schema_export_availability(self, client):
         """Test that schema export endpoints are available"""


### PR DESCRIPTION
## Pattern
**B (test rewrite)** — production behavior is unchanged; the test fixture lacked the dependency override needed to reach the endpoint.

Cluster: `tests/contract/test_zod_validation.py` (2 of 10 failing → 0).

## Why
The two failing tests hit `/api/schemas/` and `/api/schemas/{name}`,
which take an injected `AuthManager` via `Depends(get_auth_manager)`.
The auth_manager is taken as a parameter but **never used** in the
function body — it's purely a 'must be wired up' dependency gate.

In a TestClient that doesn't run lifespan, the ServiceRegistry isn't
initialized and `get_auth_manager` raises `RuntimeError`, which
Starlette converts to **500** — causing the assertion failures (which
expected 200 or 503).

## What
Override the dependency with a `MagicMock` in the `client` fixture so
the schema-export contract can actually be exercised.

## Note on production
The auth_manager-as-unused-gate pattern in
`backend/api/routers/schemas.py` is itself a smell:
- If the intent is **'public schemas'** (likely — the frontend needs
  these even at the login screen), the dep should be **dropped**.
- If the intent is **'authenticated'**, it should use
  `get_authenticated_user` (which checks the user, not just whether
  the manager service is wired up).

Flagged as a follow-up cleanup but **out of scope** for this PR.
If/when the schema router is hardened, the test override here will
need to be revisited.

## Test delta
File-level (`tests/contract/test_zod_validation.py`):
- before: 8 passed, **2 failed**
- after:  **10 passed**, 0 failed

## Production bugs caught
**0**

## Refs
- #105 (test-restoration sweep #2)