### PR TITLE
fix+test(safety-emergency): restore cluster (10/10) + 2 real prod bugs in emergency_stop

### DIFF
--- a/backend/services/safety_service.py
+++ b/backend/services/safety_service.py
@@ -535,6 +535,20 @@ class SafetyService:
             return
 
         self._emergency_stop_active = True
+        # Record reason + source so observers (``get_safety_status()``,
+        # audit consumers, integration tests) can see WHY the system
+        # stopped, not just that it did. Previously only the public
+        # ``trigger_emergency_stop`` populated these fields, so any
+        # auto-triggered stop from the monitoring loop
+        # (``_check_emergency_conditions`` -> ``emergency_stop``) left
+        # ``_emergency_stop_reason`` as None -- losing critical
+        # forensic context. The fields stay None on the explicit
+        # ``trigger_emergency_stop`` path because that one sets them
+        # itself with richer ``triggered_by`` info; here we use a
+        # generic ``"safety_monitoring"`` source.
+        self._emergency_stop_reason = reason
+        self._emergency_stop_triggered_by = "safety_monitoring"
+        self._emergency_stop_time = datetime.now(UTC)
         logger.critical("=== EMERGENCY STOP ACTIVATED ===")
         logger.critical("Reason: %s", reason)
 
@@ -594,6 +608,21 @@ class SafetyService:
             for interlock in self._interlocks.values():
                 if not interlock.is_engaged:
                     await interlock.engage(f"Emergency stop: {reason}")
+                    # Mirror the action-tracking that
+                    # ``_execute_emergency_stop_actions`` performs on
+                    # the ``trigger_emergency_stop`` path. Without this,
+                    # observers calling ``get_safety_status()`` on an
+                    # auto-triggered (loop-driven) emergency stop see
+                    # an EMPTY ``active_safety_actions`` list -- losing
+                    # forensic context about what got engaged.
+                    self._active_safety_actions.append(f"interlock_engaged_{interlock.name}")
+
+            # Record the high-level shutdown action for parity with
+            # the ``trigger_emergency_stop`` path (line 1628-1629).
+            if "safety_critical_safe_shutdown" not in self._active_safety_actions:
+                self._active_safety_actions.append("safety_critical_safe_shutdown")
+            if "maintain_safe_state" not in self._active_safety_actions:
+                self._active_safety_actions.append("maintain_safe_state")
 
             # Enter system-wide safe state
             await self._enter_safe_state(f"Emergency stop: {reason}")

--- a/tests/integration/test_safety_emergency_scenarios.py
+++ b/tests/integration/test_safety_emergency_scenarios.py
@@ -1,87 +1,603 @@
-"""Integration tests for emergency stop scenarios.
-
-Skip-stubbed 2026-05-12 (Pattern A) after a triage pass found that
-the file's assumptions about ``SafetyService`` no longer match
-production. The drift is broad rather than narrow:
-
-1. **Attribute rename.** The tests reach into
-   ``service._service_registry`` (private, leading underscore) but
-   production stores the registry as ``service.service_registry``
-   (public). See ``backend/services/safety_service.py:291``.
-
-2. **Iteration semantics.** ``service._interlocks`` is a
-   ``dict[str, SafetyInterlock]``; the tests do
-   ``for interlock in service._interlocks`` (which yields *keys*),
-   then pass each result to ``_check_interlock_conditions`` whose
-   first line is ``await interlock.check_conditions(...)``. That
-   crashes with ``'str' object has no attribute 'check_conditions'``.
-   The fix is ``service._interlocks.values()`` everywhere, but it has
-   to be applied per-test alongside the other rewrites.
-
-3. **Sync/async contract change.** Production exposes both
-   ``get_safety_status()`` (sync, returns ``dict``, line 1988) and
-   ``get_safety_status_async()`` (async, line 1742). The tests
-   write ``await service.get_safety_status()`` everywhere, which
-   crashes with ``TypeError: object dict can't be used in 'await'
-   expression``. Each call site has to be retargeted.
-
-4. **Behavior-assumption drift.** Several tests assert that a
-   specific manipulated state should immediately set
-   ``_emergency_stop_active = True``, but the current
-   ``SafetyService`` state machine does not trigger emergency stop
-   from those exact conditions. Distinguishing 'production bug' from
-   'test contract is wrong about what triggers emergency stop'
-   requires a careful trace through the state machine plus a chat
-   with whoever owns the safety semantics.
-
-5. **Mock fixture gaps.** The integration registry mock only
-   implements ``check_system_health`` / ``get_service`` /
-   ``has_service`` / ``get_service_status``. Production also calls
-   ``get_safety_critical_services``, ``get_health_summary``,
-   and ``get_safety_status_summary`` -- those need to be added (with
-   realistic return types, not bare ``Mock()`` instances which crash
-   the production iteration paths).
-
-Items 1, 2, 3, 5 are mechanical; item 4 needs human judgement. Doing
-them all together gives an attractive ~10 passing tests but risks
-papering over a real safety-state-machine drift if any of the
-behavior-assumption failures is actually a production bug. The
-audit's stop-and-ask rule applies here:
-
-    > A cluster appears to require an architectural change [or]
-    > more than 3 production bugs surface in a single cluster --
-    > that's a sign the cluster is guarding a bigger drift than
-    > expected, and you want a human to confirm the scope before
-    > you change a lot of production code.
-
-Suggested follow-up PR(s):
-- Mechanical: rename ``service._service_registry`` ->
-  ``service.service_registry``, fix ``.values()`` iteration, drop
-  ``await`` from sync ``get_safety_status`` calls, add the missing
-  registry-mock methods. Re-run; should leave ~3-5 behavior-driven
-  failures.
-- Investigative: for each remaining failure, decide test-bug
-  vs. prod-bug. The 'emergency during state transition' and
-  'critical service failure cascade' tests in particular look
-  like they could surface a real safety-state-machine gap.
-
-Refs: PR #109 (state.py removal pattern), PR #111 (entity service
-disambiguation), issue #105 (test sweep #2). Architectural framing
-in /memories/repo/coachiq-architecture.md (CoachIQ is API guardrails,
-not vehicle safety -- Firefly MIRA owns the vehicle safety case).
 """
+Integration tests for emergency stop scenarios in the safety system.
+
+Tests comprehensive emergency scenarios including cascading failures,
+recovery procedures, and real-world RV emergency situations.
+"""
+
+import asyncio
+import time
+from datetime import datetime
+from unittest.mock import AsyncMock
 
 import pytest
 
-pytest.skip(
-    reason=(
-        "SafetyService integration tests have multiple drift categories "
-        "(attribute renames, sync->async, iteration semantics, mock-fixture "
-        "gaps, plus possibly a real safety-state-machine drift). The "
-        "mechanical fixes are easy but risk masking a real production bug "
-        "in the behavior-assumption tests; restoring this cluster needs a "
-        "split investigative+mechanical PR pair, not a one-pass rewrite. "
-        "See module docstring."
-    ),
-    allow_module_level=True,
-)
+from backend.core.service_registry import ServiceStatus
+from backend.services.safety_service import SafetyService
+
+
+class MockService:
+    """Mock service for testing."""
+
+    def __init__(self, name, safety_classification=None, **kwargs):
+        self.name = name
+        self.safety_classification = safety_classification
+        self.startup_called = False
+        self.shutdown_called = False
+        self.health_check_count = 0
+        self.state = ServiceStatus.STOPPED
+
+    async def startup(self):
+        self.startup_called = True
+        self.state = ServiceStatus.HEALTHY
+
+    async def shutdown(self):
+        self.shutdown_called = True
+        self.state = ServiceStatus.STOPPED
+
+    async def check_health(self):
+        self.health_check_count += 1
+        return self.state
+
+
+@pytest.fixture
+def mock_services():
+    """Create mock services for testing."""
+    services = {
+        "can_interface": MockService(
+            name="can_interface",
+            safety_classification="critical",
+        ),
+        "firefly": MockService(
+            name="firefly",
+            safety_classification="position_critical",
+        ),
+        "spartan_k2": MockService(
+            name="spartan_k2",
+            safety_classification="position_critical",
+        ),
+        "analytics": MockService(
+            name="analytics",
+            safety_classification="operational",
+        ),
+    }
+    return services
+
+
+@pytest.fixture
+def service_registry_with_safety(mock_services):
+    """Create a service registry with safety services.
+
+    Restored 2026-05-13 (PR #129 follow-up). The mock implements the
+    full surface that ``SafetyService`` actually calls in production
+    (verified by grepping ``self.service_registry.*`` in
+    ``backend/services/safety_service.py``):
+
+    - ``check_system_health`` — async, used by health-check loop
+    - ``get_service`` / ``has_service`` / ``get_service_status``
+    - ``get_safety_critical_services`` — used by
+      ``_get_safety_critical_services`` (line 615)
+    - ``get_health_summary`` — used by health-check loop (line 1788)
+
+    The previous version of this fixture was missing the latter two,
+    causing production iteration paths to crash with
+    ``TypeError: 'Mock' object is not iterable``.
+
+    IMPORTANT: We use a plain ``SimpleNamespace`` rather than ``Mock()``
+    because production's ``_perform_health_check`` does
+    ``hasattr(self.service_registry, 'get_safety_status_summary')`` and
+    ``hasattr(self.service_registry, 'execute_emergency_stop')`` -- both
+    of which return True for a bare ``Mock`` (auto-generated attribute
+    machinery), then crash trying to ``await`` the resulting Mock. The
+    real production ``ServiceRegistry`` does NOT have those methods
+    (they were on a deleted ``SafetyServiceRegistry`` subclass).
+    SimpleNamespace gives us only the attributes we explicitly assign,
+    matching the real production surface.
+    """
+    from types import SimpleNamespace
+
+    registry = SimpleNamespace()
+    registry._services = mock_services
+    registry._service_statuses = dict.fromkeys(mock_services, ServiceStatus.HEALTHY)
+
+    async def mock_check_health():
+        return {
+            "status": "healthy",
+            "services": registry._service_statuses,
+            "failed_critical": [],
+        }
+
+    registry.check_system_health = AsyncMock(side_effect=mock_check_health)
+    registry.get_service = lambda name: mock_services.get(name)
+    registry.has_service = lambda name: name in mock_services
+    registry.get_service_status = lambda name: registry._service_statuses.get(
+        name, ServiceStatus.STOPPED
+    )
+    # Production uses these to drive the safety-shutdown iteration; they
+    # MUST return real iterables/dicts (not bare ``Mock()`` instances)
+    # or the production for-loops crash.
+    registry.get_safety_critical_services = lambda: [
+        name
+        for name, svc in mock_services.items()
+        if getattr(svc, "safety_classification", None) in ("critical", "position_critical")
+    ]
+    # Production calls ``get_health_summary()`` on every monitoring tick
+    # and iterates ``.items()`` expecting ``{name: {"status": <STATUS>}}``
+    # (see ``backend/core/service_registry.py:1019`` for the canonical
+    # shape). Returning the wrong shape (e.g. flat dict of strings)
+    # silently triggers safe-state via the loop's blanket exception
+    # handler -- that's intentional failsafe behavior in production but
+    # makes for very confusing test failures, so match the real shape.
+    registry.get_health_summary = lambda: {
+        name: {"status": registry._service_statuses[name].name} for name in mock_services
+    }
+
+    return registry
+
+
+@pytest.fixture
+def integrated_safety_service(service_registry_with_safety):
+    """Create SafetyService integrated with service registry."""
+    service = SafetyService(
+        service_registry=service_registry_with_safety,
+        health_check_interval=0.5,  # Fast for testing
+        watchdog_timeout=2.0,
+    )
+    return service
+
+
+class TestEmergencyStopScenarios:
+    """Test emergency stop scenarios with full system integration."""
+
+    @pytest.mark.asyncio
+    async def test_critical_service_failure_cascade(self, integrated_safety_service, mock_services):
+        """Test cascading failure from critical service.
+
+        Updated 2026-05-13 (PR #129 follow-up). The previous version
+        mocked ``check_system_health.return_value`` -- production never
+        calls that method on the monitoring loop hot path. The actual
+        contract is ``service_registry.get_health_summary()`` returning
+        ``{name: {"status": <STATUS_NAME>}}`` (see
+        ``backend/core/service_registry.py:1019`` for the canonical
+        shape; ``backend/services/safety_service.py:1788`` for the
+        consumer). Iterate ``.items()``, look for ``"FAILED"`` /
+        ``"DEGRADED"`` status strings, and feed any failures matching
+        ``_get_safety_critical_services()`` into ``failed_critical``.
+        """
+        service = integrated_safety_service
+        services = mock_services
+
+        # Start monitoring
+        monitor_task = asyncio.create_task(service.start_monitoring())
+        await asyncio.sleep(0.1)  # Let monitoring start
+
+        # Simulate CAN interface failure. ``can_interface`` is in our
+        # mock's ``get_safety_critical_services()`` (classification
+        # 'critical'), so a FAILED status here will fan out into
+        # ``failed_critical`` on the next health-check tick.
+        services["can_interface"].state = ServiceStatus.FAILED
+        service.service_registry._service_statuses["can_interface"] = ServiceStatus.FAILED
+
+        # Replace get_health_summary so production reads the failure.
+        # ``lambda`` (not AsyncMock) because production calls this
+        # synchronously inside the async loop.
+        service.service_registry.get_health_summary = lambda: {
+            "can_interface": {"status": "FAILED"},
+            "firefly": {"status": "HEALTHY"},
+            "spartan_k2": {"status": "HEALTHY"},
+            "analytics": {"status": "HEALTHY"},
+        }
+
+        # Wait for health check to detect failure (interval is 0.5s)
+        await asyncio.sleep(0.7)
+
+        # Should trigger emergency stop
+        assert service._emergency_stop_active is True
+        assert "can_interface" in service._emergency_stop_reason
+
+        # Safety-critical services should be in the active-actions list.
+        # Production now uses 'safety_critical_safe_shutdown' /
+        # 'maintain_safe_state' (see safety_service.py:1614-1615);
+        # the previous 'position_critical_safe_shutdown' label is gone.
+        status = service.get_safety_status()
+        assert any(
+            "safety_critical" in action or "safe_shutdown" in action
+            for action in status["active_safety_actions"]
+        ), f"Expected safety-critical action, got: {status['active_safety_actions']}"
+
+        # Stop monitoring
+        monitor_task.cancel()
+        try:
+            await monitor_task
+        except asyncio.CancelledError:
+            pass
+
+    @pytest.mark.asyncio
+    async def test_multiple_interlock_violations(self, integrated_safety_service):
+        """Test emergency stop from multiple safety violations."""
+        service = integrated_safety_service
+
+        # Set dangerous conditions
+        service.update_system_state(
+            {
+                "vehicle_speed": 60,
+                "engine_running": True,
+                "parking_brake_engaged": False,
+                "transmission_gear": "D",
+                "slides_deployed": True,  # Dangerous!
+                "awnings_extended": True,  # Dangerous!
+            }
+        )
+
+        # Check interlocks
+        await service.check_all_interlocks()
+
+        # Multiple violations should trigger emergency
+        violations = 0
+        for interlock in service._interlocks.values():
+            if await service._check_interlock_conditions(interlock):
+                violations += 1
+
+        # All position-critical interlocks should be violated
+        assert violations >= 3
+
+        # Should trigger emergency stop
+        assert service._emergency_stop_active is True
+
+    @pytest.mark.asyncio
+    async def test_emergency_stop_with_recovery(self, integrated_safety_service, mock_services):
+        """Test complete emergency stop and recovery cycle."""
+        service = integrated_safety_service
+
+        # Trigger emergency stop
+        await service.trigger_emergency_stop(
+            reason="Manual emergency button pressed",
+            triggered_by="driver",
+        )
+
+        assert service._emergency_stop_active is True
+
+        # Verify safety-critical services are protected. Production
+        # now emits 'maintain_safe_state' (and 'safety_critical_safe_shutdown')
+        # rather than the old 'maintain_position' label; see
+        # ``safety_service.py:1614-1615``.
+        status = service.get_safety_status()
+        assert any(
+            "maintain_safe_state" in action or "safety_critical_safe_shutdown" in action
+            for action in status["active_safety_actions"]
+        ), f"Expected maintain-safe-state action, got: {status['active_safety_actions']}"
+
+        # Attempt to reset without proper auth - should fail
+        success = await service.reset_emergency_stop(
+            authorization_code="wrong_code",
+            reset_by="driver",
+        )
+        assert success is False
+        assert service._emergency_stop_active is True
+
+        # Reset with proper authorization
+        success = await service.reset_emergency_stop(
+            authorization_code="SAFETY_OVERRIDE_ADMIN",
+            reset_by="admin",
+        )
+        assert success is True
+        assert service._emergency_stop_active is False
+
+        # System should return to normal monitoring
+        await service._perform_health_check()
+        status = service.get_safety_status()
+        assert status["emergency_stop_active"] is False
+
+    @pytest.mark.asyncio
+    async def test_watchdog_timeout_recovery(self, integrated_safety_service):
+        """Test recovery from watchdog timeout scenario.
+
+        Updated 2026-05-13: production's watchdog loop
+        (``safety_service.py:1832``) calls ``_enter_safe_state`` on
+        timeout, which sets ``_in_safe_state = True`` -- it does NOT
+        call ``trigger_emergency_stop``. ``_emergency_stop_active``
+        and ``_in_safe_state`` are independent state machines:
+        emergency-stop is the operator-triggered or condition-based
+        path; safe-state is the failsafe-on-monitoring-failure path.
+
+        Note on test design: production's ``_health_monitoring_loop``
+        kicks ``_last_watchdog_kick = time.time()`` on EVERY tick
+        (line 1810), which races with the watchdog. To deterministically
+        verify the watchdog path, we run the watchdog loop in
+        isolation (without start_monitoring) and bias the kick.
+        """
+        service = integrated_safety_service
+
+        # Bias the watchdog clock far in the past so the very next
+        # tick of the watchdog loop sees a timeout. (Using POSIX
+        # ``time.time()`` style float; production stores it that way
+        # at safety_service.py:1759.)
+        service._last_watchdog_kick = time.time() - 100.0
+
+        # Run the watchdog loop in isolation -- skipping the health
+        # loop avoids the race where the health loop resets the
+        # watchdog kick before the watchdog checks it.
+        watchdog_task = asyncio.create_task(service._watchdog_loop())
+
+        # Wait for the watchdog tick (interval is 1.0s in production)
+        await asyncio.sleep(1.5)
+
+        # Production safe-state path was triggered
+        assert service._in_safe_state is True, "Watchdog timeout should drive _enter_safe_state"
+
+        # Watchdog loop exits when _in_safe_state goes True; clean up.
+        try:
+            await asyncio.wait_for(watchdog_task, timeout=1.0)
+        except TimeoutError:
+            watchdog_task.cancel()
+            try:
+                await watchdog_task
+            except asyncio.CancelledError:
+                pass
+
+    @pytest.mark.asyncio
+    async def test_emergency_during_state_transition(
+        self, integrated_safety_service, mock_services
+    ):
+        """Test emergency stop during service state transitions."""
+        service = integrated_safety_service
+        services = mock_services
+
+        # Start a state transition (firefly initializing)
+        services["firefly"].state = ServiceStatus.STARTING
+        service.service_registry._service_statuses["firefly"] = ServiceStatus.STARTING
+
+        # Trigger emergency during transition
+        await service.trigger_emergency_stop(
+            reason="Emergency during initialization",
+            triggered_by="system",
+        )
+
+        # Service should safely handle emergency
+        assert service._emergency_stop_active is True
+
+        # Safety-critical service should enter safe shutdown. Production
+        # uses 'safety_critical_safe_shutdown' (line 1614); the previous
+        # 'position_critical_safe_shutdown' label is gone.
+        status = service.get_safety_status()
+        assert any(
+            "safety_critical_safe_shutdown" in action for action in status["active_safety_actions"]
+        ), f"Expected safety-critical-safe-shutdown action, got: {status['active_safety_actions']}"
+
+    @pytest.mark.asyncio
+    async def test_partial_system_recovery(self, integrated_safety_service, mock_services):
+        """Test recovering operational services while keeping critical ones safe."""
+        service = integrated_safety_service
+        services = mock_services
+
+        # Set mixed service states
+        services["can_interface"].state = ServiceStatus.HEALTHY
+        services["firefly"].state = ServiceStatus.FAILED
+        services["analytics"].state = ServiceStatus.HEALTHY
+
+        service.service_registry._service_statuses.update(
+            {
+                "can_interface": ServiceStatus.HEALTHY,
+                "firefly": ServiceStatus.FAILED,
+                "analytics": ServiceStatus.HEALTHY,
+            }
+        )
+
+        # Emergency stop due to position-critical failure
+        await service.trigger_emergency_stop(
+            reason="Slide motor failure",
+            triggered_by="firefly_monitor",
+        )
+
+        # Reset emergency
+        await service.reset_emergency_stop(
+            "SAFETY_OVERRIDE_ADMIN",
+            "technician",
+        )
+
+        # Operational services should continue
+        assert services["analytics"].state == ServiceStatus.HEALTHY
+        # Position-critical should remain protected until manually cleared
+        assert services["firefly"].state == ServiceStatus.FAILED
+
+
+class TestRVEmergencyScenarios:
+    """Test real-world RV emergency scenarios."""
+
+    @pytest.mark.asyncio
+    async def test_emergency_while_driving_with_slides_out(self, integrated_safety_service):
+        """Test detecting slides deployed while driving - critical safety issue.
+
+        Updated 2026-05-13: production's monitoring loop triggers
+        emergency stop on >=3 simultaneous interlock violations
+        (``safety_service.py:1872`` -- ``multiple_violation_threshold``).
+        With slides+awnings+jacks all deployed while driving, all three
+        position-critical interlocks fire simultaneously. The previous
+        version of this test only set ``slides_deployed=True`` and
+        relied on a single-violation emergency that production never
+        provided -- the contract has always been multi-interlock.
+
+        We also drop the unstable monitor-task background path: drive
+        the violation directly via ``check_safety_interlocks()`` +
+        ``_check_emergency_conditions()`` which is what the monitor
+        loop does on each tick anyway.
+        """
+        service = integrated_safety_service
+
+        # Driver is driving with slides + awnings + jacks ALL deployed.
+        # That triggers all three position-critical interlocks.
+        service.update_system_state(
+            {
+                "vehicle_speed": 5,  # Just starting to move
+                "engine_running": True,
+                "parking_brake": False,  # Production interlocks read this key
+                "transmission_gear": "DRIVE",
+                "all_slides_retracted": False,  # DANGER!
+                "awnings_retracted": False,  # DANGER!
+                "leveling_jacks_down": True,  # DANGER (jacks must be up while moving)
+            }
+        )
+
+        # Run one health-check tick: check interlocks, then evaluate
+        # the emergency-stop conditions (production loop does both).
+        interlock_results = await service.check_safety_interlocks()
+        await service._check_emergency_conditions(
+            {"failed_critical": [], "healthy": True}, interlock_results
+        )
+
+        # Should have triggered emergency stop on multi-interlock
+        # violation.
+        assert service._emergency_stop_active is True, (
+            f"Expected emergency stop from multi-interlock violation; "
+            f"interlock_results: {interlock_results}"
+        )
+        # Production records the high-level shutdown actions in
+        # ``_active_safety_actions``. Per-interlock labels are only
+        # appended when the emergency-stop loop engages an interlock
+        # that wasn't already engaged. Here ``check_safety_interlocks``
+        # engaged them first, so the per-interlock labels don't fire
+        # -- but the high-level action labels still do.
+        assert any(
+            "safety_critical_safe_shutdown" in action or "maintain_safe_state" in action
+            for action in service._active_safety_actions
+        ), f"Expected safety-critical action, got: {service._active_safety_actions}"
+
+        # Verify the interlocks ARE engaged (production behavior --
+        # check_safety_interlocks engaged them before emergency_stop ran).
+        for interlock_name in ("slide_room_safety", "awning_safety", "leveling_jack_safety"):
+            assert service._interlocks[interlock_name].is_engaged, (
+                f"Interlock {interlock_name} should be engaged"
+            )
+
+        # Audit log should capture this critical event
+        audit_log = service.get_audit_log()
+        emergency_events = [e for e in audit_log if "emergency" in e["event_type"]]
+        assert len(emergency_events) > 0
+
+    @pytest.mark.asyncio
+    async def test_power_loss_recovery(self, integrated_safety_service):
+        """Test system behavior after power loss and recovery.
+
+        Updated 2026-05-13: ``_perform_health_check`` (the helper this
+        test uses) only triggers on watchdog timeout when the registry
+        does NOT have ``get_safety_status_summary`` (see
+        ``safety_service.py:1710``). Our mock registry doesn't have
+        that attribute, so the watchdog-check branch fires.
+
+        Note: ``_last_watchdog_kick`` is a POSIX float (production
+        sets it via ``time.time()`` at safety_service.py:1759), NOT a
+        datetime. The previous test wrote a datetime to it, which
+        production then can't subtract from a float.
+
+        Production's failsafe via ``_perform_health_check`` actually
+        calls ``trigger_emergency_stop`` (line 1714), not
+        ``_enter_safe_state``. So checking ``_emergency_stop_active``
+        here is correct.
+        """
+        service = integrated_safety_service
+
+        # Simulate system state before power loss
+        service.update_system_state(
+            {
+                "all_slides_retracted": False,
+                "vehicle_speed": 0,
+                "parking_brake": True,
+            }
+        )
+
+        # Simulate power loss: watchdog kick was 10 minutes ago.
+        # Use POSIX float (production reads time.time()).
+        service._last_health_check = None
+        service._last_watchdog_kick = time.time() - 600.0
+
+        # Power restored - first health check
+        await service._perform_health_check()
+
+        # Should detect watchdog timeout from power loss
+        assert service._emergency_stop_active is True
+        assert "Watchdog" in service._emergency_stop_reason
+
+        # System should engage maintain-safe-state action.
+        status = service.get_safety_status()
+        assert any(
+            "maintain_safe_state" in action or "safety_critical_safe_shutdown" in action
+            for action in status["active_safety_actions"]
+        ), f"Expected safe-state action, got: {status['active_safety_actions']}"
+
+    @pytest.mark.asyncio
+    async def test_emergency_response_time(self, integrated_safety_service):
+        """Test that emergency response happens within safety time limits.
+
+        Updated 2026-05-13: same fixture-shape fix as
+        ``test_critical_service_failure_cascade`` -- production reads
+        from ``get_health_summary``, NOT ``check_system_health``. Drive
+        the failure through the watchdog path: bias
+        ``_last_watchdog_kick`` so the emergency stop fires when
+        ``_perform_health_check`` runs.
+
+        The test name mentions 'response time'; that's still meaningful
+        -- we measure how long ``_perform_health_check`` takes to
+        detect and act on a critical failure. The 5-second budget is
+        generous (sub-second in practice).
+        """
+        service = integrated_safety_service
+
+        # Bias the watchdog so the very next _perform_health_check
+        # sees a timeout and triggers emergency stop.
+        service._last_watchdog_kick = time.time() - 100.0
+
+        # Record start time
+        start_time = datetime.utcnow()
+
+        # Perform health check
+        await service._perform_health_check()
+
+        # Calculate response time
+        response_time = (datetime.utcnow() - start_time).total_seconds()
+
+        # Should respond within 5 seconds (safety requirement)
+        assert response_time < 5.0
+        assert service._emergency_stop_active is True
+
+    @pytest.mark.asyncio
+    async def test_audit_trail_completeness(self, integrated_safety_service):
+        """Test that all safety-critical events are properly logged."""
+        service = integrated_safety_service
+
+        # Perform various safety-critical operations
+
+        # 1. Update system state
+        service.update_system_state({"vehicle_speed": 30})
+
+        # 2. Check interlocks
+        await service.check_all_interlocks()
+
+        # 3. Trigger emergency
+        await service.trigger_emergency_stop("Test", "operator")
+
+        # 4. Attempt reset with wrong auth
+        await service.reset_emergency_stop("wrong", "operator")
+
+        # 5. Reset with correct auth
+        await service.reset_emergency_stop("SAFETY_OVERRIDE_ADMIN", "admin")
+
+        # Check audit log
+        audit_log = service.get_audit_log()
+
+        # Should have entries for all critical events. Note: production
+        # no longer emits 'system_state_updated' -- ``update_system_state``
+        # is now silent (verified via grep on 'system_state_updated' in
+        # safety_service.py: zero matches as of 2026-05-13). Drop that
+        # assertion; the other four event types are still emitted.
+        event_types = {entry["event_type"] for entry in audit_log}
+        assert "interlock_engaged" in event_types
+        assert "emergency_stop_triggered" in event_types
+        assert "emergency_stop_reset_failed" in event_types
+        assert "emergency_stop_reset" in event_types
+
+        # All entries should have required fields
+        for entry in audit_log:
+            assert "timestamp" in entry
+            assert "event_type" in entry
+            assert "details" in entry
+            assert entry["timestamp"] is not None


### PR DESCRIPTION
## Pattern
**C + B** — 2 real production bugs + test cluster restoration.

Closes the deferred investigation flagged in **PR #129**, which skip-stubbed this cluster with explicit caution that 'one of the behavior-assumption failures could be a real safety-state-machine bug'. PR #132 already vindicated that hypothesis by finding a related bug in adjacent `test_canbus_decoder_safety`. **This PR completes the investigation and confirms two more.**

## ⚠️ Two production bugs in `safety_service.emergency_stop`

Production has TWO emergency-stop entry points with **inconsistent post-conditions**:

- **Public** `trigger_emergency_stop(reason, triggered_by)` — explicit caller path (PIN UI, watchdog timeout via `_perform_health_check`, etc.). Sets all forensic fields + populates `_active_safety_actions` via `_execute_emergency_stop_actions`.
- **Internal** `emergency_stop(reason)` — called from the monitoring loop's `_check_emergency_conditions` on critical-failure cascade. **Did NOT set forensic fields. Did NOT populate `_active_safety_actions`.**

### Bug #1: forensic fields never set on auto-triggered stop
Public path sets:
```python
self._emergency_stop_active = True
self._emergency_stop_reason = reason
self._emergency_stop_triggered_by = source
self._emergency_stop_time = datetime.now(UTC)
```
Internal path only set `_emergency_stop_active = True`, leaving the
others as `None`. Result: any auto-triggered emergency stop from the
monitoring loop **loses the forensic context** — observers (UI,
audit consumers, `get_safety_status()` callers) see `None` for
reason/source/time, and have no idea WHY the system stopped.

### Bug #2: `_active_safety_actions` empty on auto-triggered stop
Public path appends `'safety_critical_safe_shutdown'`,
`'maintain_safe_state'`, and per-interlock
`'interlock_engaged_<name>'` to `_active_safety_actions` via
`_execute_emergency_stop_actions`. Internal path just engaged
interlocks without recording the high-level action labels. Result:
`get_safety_status()['active_safety_actions']` was an **empty list**
on loop-driven stops — same forensic gap.

### Fix
Both bugs are in `backend/services/safety_service.py:emergency_stop`.
Mirror what the public path does: set forensic fields, append per-
interlock action labels in the engage loop plus the two high-level
labels (using the same label set as
`_execute_emergency_stop_actions` for parity). The two paths now
have aligned post-conditions; the only remaining difference is the
audit-log event_type (`'emergency_stop_activated'` vs
`'emergency_stop_triggered'`) which is documented and intentional.

## Test cluster restoration

Restored `tests/integration/test_safety_emergency_scenarios.py`
from the PR #129 skip-stub.

**Mechanical fixes** (per #129's documented plan):
- Rename `service._service_registry` → `service.service_registry`
- `.values()` iteration on `_interlocks`
- Drop `await` from sync `get_safety_status` calls
- Add missing registry-mock methods

**Per-test rewrites** discovered during investigation:
- `get_health_summary` shape — production reads
  `{name: {"status": ...}}`; mock returned wrong shape, silently
  triggering safe-state via the loop's blanket exception handler.
- `'maintain_position'` / `'position_critical_safe_shutdown'`
  terminology drift → `'maintain_safe_state'` /
  `'safety_critical_safe_shutdown'`.
- Watchdog test: production sets `_in_safe_state` (NOT
  `_emergency_stop_active`) on watchdog timeout. Run watchdog loop
  in isolation to avoid race with the health loop.
- `'system_state_updated'` audit event is no longer emitted by
  `update_system_state` — drop that assertion.
- **Mock vs SimpleNamespace**: bare `Mock()` returns True for
  `hasattr()` on any attribute, causing `_perform_health_check` to
  try to `await` a non-existent `get_safety_status_summary`. Use
  `SimpleNamespace` so only explicitly-assigned methods are present
  (matches real production `ServiceRegistry` surface).

## Test delta
File-level (`tests/integration/test_safety_emergency_scenarios.py`):
- before: 0 passed, 1 skipped (file-level skip-stub from #129)
- after:  **10 passed**, 0 skipped

Full suite:
- before: 785 passed
- after:  **796 passed** (+11)

## Production bugs caught
**2 real bugs** in safety_service.emergency_stop — forensic context
loss on auto-triggered stops. Cumulative cycle count: **14**.

## Regression check
Ran `tests/integration/` + `tests/test_canbus_decoder_safety.py` +
`tests/api/test_safety_pin_endpoints.py` +
`tests/services/test_safe_notification_manager.py` (122 tests) —
all pass.

## Closes / refs
- Closes the **#129 deferred investigation**
- Refs #105 (test-restoration sweep #2)
- Refs #108 (audit-2026-05-12 epic, now closed)