### PR TITLE
docs(architecture): rewrite repository-pattern.md + backend.md against current code

### DIFF
--- a/docs/architecture/backend.md
+++ b/docs/architecture/backend.md
@@ -1,171 +1,172 @@
 # Backend Architecture
 
-This page provides an overview of the CoachIQ backend architecture, focusing on how the API components are structured.
+The CoachIQ backend is a Python 3.12 + FastAPI service that talks to
+the OEM Firefly MIRA panel over RV-C / J1939 CAN. Architecturally it
+plays the same role as a smart wall-switch or HMI: it emits well-formed
+CAN frames; the OEM controller decides whether to act on them.
 
-## Core Components
+For the architectural framing (what CoachIQ is and is not, the realistic
+threat model, why we calibrate code quality to "good consumer-grade
+backend" rather than aerospace), see
+[`/memories/repo/coachiq-architecture.md`](../../memories/repo/coachiq-architecture.md)
+or, once it lands, `docs/adr/ADR-0004-coachiq-is-not-the-safety-system.md`.
 
-### Component Structure
-
-The backend consists of several key components:
+## Top-level layout
 
 ```text
-backend/                  # Main backend application
-├── api/                  # API layer
-│   ├── routers/          # FastAPI route handlers
-│   ├── dependencies.py   # Dependency injection functions
-│   └── router_config.py  # Router configuration
-├── core/                 # Core utilities
-│   ├── config.py         # Application configuration
-│   ├── state.py          # Application state management
-│   ├── logging_config.py # Logging configuration
-│   ├── metrics.py        # Prometheus metrics
-│   └── version.py        # Version information
-├── services/             # Business logic services
-│   ├── feature_manager.py # Feature flag management
-│   ├── config_service.py  # Configuration service
-│   └── entity_service.py  # Entity management service
-├── integrations/         # External integrations
-│   ├── can/              # CAN bus integration
-│   └── rvc/              # RV-C protocol integration
-├── websocket/            # WebSocket handlers
-│   └── handlers.py       # WebSocket endpoint handlers
-├── models/               # Data models
-│   ├── entities.py       # Entity data models
-│   └── responses.py      # API response models
-├── middleware/           # HTTP middleware
-│   └── http.py           # Request/response middleware
-└── main.py               # Application entry point
-src/
-├── common/               # Shared models and utilities
-└── rvc_decoder/          # RV-C protocol decoder
+backend/
+├── main.py               # ASGI app construction + service registration
+├── api/
+│   ├── routers/          # Legacy /api/* endpoints
+│   ├── domains/          # Domain API v2 (/api/v2/*)
+│   └── router_config.py  # Mounts every router on the app
+├── core/
+│   ├── config.py         # Pydantic Settings (COACHIQ_* env vars)
+│   ├── dependencies.py   # FastAPI Depends(get_*) helpers
+│   ├── service_registry.py  # EnhancedServiceRegistry
+│   ├── safety_state_engine.py
+│   ├── service_dependency_resolver.py
+│   ├── exception_handlers.py
+│   └── exceptions.py
+├── services/             # Business logic; constructor-injected
+├── repositories/         # Data access; see repository-pattern.md
+├── integrations/
+│   ├── can/              # CAN bus + multi-network manager
+│   ├── rvc/              # RV-C decoder, Firefly extensions
+│   ├── j1939/            # J1939 decoder, Spartan K2 extensions
+│   ├── analytics/        # PerformanceAnalyticsFeature
+│   └── diagnostics/      # Cross-protocol diagnostics
+├── middleware/           # Auth, CSRF, structured logging, etc.
+├── models/               # Pydantic request/response models
+├── schemas/              # Zod-exportable schemas for the frontend
+├── websocket/            # WebSocket handlers + connection manager
+└── alembic/              # SQLite migrations
 ```
 
-### Component Flow
+## Component flow
 
 ```mermaid
-flowchart TD
-    Client[Client] <--> FastAPI[FastAPI App]
+flowchart LR
+    Client[Client / Browser] <--> FastAPI[FastAPI App]
 
     subgraph Backend
-        FastAPI --> APIRouters[API Routers]
-        FastAPI --> WSHandler[WebSocket Handler]
+        FastAPI --> Routers[Routers /api/* + /api/v2/*]
+        FastAPI --> WS[WebSocket Handlers]
 
-        APIRouters --> Services[Services]
-        WSHandler --> Services
+        Routers -->|Depends| Services[Services]
+        WS -->|Depends| Services
 
-        Services --> AppState[App State]
-        Services --> RVCDecoder[RV-C Decoder]
+        Services --> Repos[Repositories]
+        Services --> CAN[CAN Facade + Integrations]
 
-        RVCDecoder --> CANInterface[CAN Interface]
-        AppState --> EntityManager[Entity Manager]
+        Repos --> DB[(SQLite via DatabaseManager)]
+        Repos -.in-memory.-> Memory[Bounded in-memory state]
     end
 
-    CANInterface <--> CANBus[CAN Bus Hardware]
+    CAN <--> CANBus[CAN Bus]
 
     classDef client fill:#E1F5FE,stroke:#0288D1
     classDef api fill:#E8F5E9,stroke:#4CAF50
-    classDef services fill:#FFF3E0,stroke:#FF9800
-    classDef hardware fill:#FFEBEE,stroke:#F44336
+    classDef logic fill:#FFF3E0,stroke:#FF9800
+    classDef data fill:#F3E5F5,stroke:#7B1FA2
+    classDef hw fill:#FFEBEE,stroke:#F44336
 
     class Client client
-    class FastAPI,APIRouters,WSHandler api
-    class Services,AppState,EntityManager,RVCDecoder services
-    class CANInterface,CANBus hardware
+    class FastAPI,Routers,WS api
+    class Services,CAN logic
+    class Repos,DB,Memory data
+    class CANBus hw
 ```
 
-## API Architecture
+The arrow from Routers to Services goes through FastAPI's `Depends(...)`
+machinery (see [`repository-pattern.md`](repository-pattern.md) for the
+canonical injection pattern). Services never reach back up to routers,
+and they never reach across to other services without the registry
+making the dependency explicit.
 
-### FastAPI Application
+## Service lifecycle
 
-The main FastAPI application is created in `main.py`. It configures:
+1. **Construction** (in `backend/main.py`'s `_init_*` functions):
+   each service is built with its dependencies passed as constructor
+   arguments. This is also where dependency edges get declared
+   (e.g. `EntityService` depends on `entity_state_repository`).
 
-- API metadata and documentation settings
-- Middleware for metrics and logging
-- API routers for different functional areas
-- WebSocket connections for real-time updates
-- Startup and shutdown event handlers
+2. **Registration** (still in `main.py`): each constructed service is
+   handed to `EnhancedServiceRegistry.register_service(name, init_func,
+   dependencies)`.
 
-### API Routers
+3. **Stage planning**: at startup the registry's
+   `ServiceDependencyResolver` builds a topological order of services
+   and groups them into stages that can run concurrently. The startup
+   log prints the stage plan.
 
-API routes are organized by functional area in separate modules:
+4. **Startup**: `service_registry.startup_all()` runs each stage in
+   order, awaiting all services in a stage in parallel.
 
-- `api_routers/entities.py`: Entity management and control
-- `api_routers/can.py`: CAN bus interaction
-- `api_routers/config_and_ws.py`: Configuration and WebSocket endpoints
-- `api_routers/docs.py`: Documentation-related endpoints
+5. **Lifespan**: services live for the duration of the FastAPI
+   lifespan context. `service_registry.shutdown_all()` runs on
+   shutdown in reverse stage order.
 
-Each router file contains route handlers for a specific area of functionality, keeping the codebase modular and maintainable.
+The registry has hardened semantics for missing-dependency detection,
+circular-dependency detection, and a `fallback=` mechanism where a
+service can declare an alternative dependency if the primary isn't
+registered (see PR #135 for the bug fix that made `fallback=` actually
+work in stage planning).
 
-### Data Models
+## API surface
 
-Data models are defined using Pydantic, ensuring:
+Two API namespaces coexist:
 
-- Schema validation for request and response data
-- Automatic documentation generation
-- Type safety throughout the application
+- **`/api/*`** -- legacy routers under `backend/api/routers/`. Most of
+  these are still active (auth, health, CAN tools, schemas, etc.).
+  A few endpoints under this namespace have been retired in favor of
+  v2 (notably `/api/entities` and `/api/missing-dgns`, both removed
+  during the 2026-05 refactor).
 
-Key models include:
+- **`/api/v2/*`** -- domain API under `backend/api/domains/`. Mounted
+  unconditionally by `register_all_domain_routers` in
+  `backend/api/domains/__init__.py`. There are no feature flags around
+  v2 routes; they are always on.
 
-- `Entity`: Represents a device in the RV (light, tank, etc.)
-- `ControlCommand`: Standardized command format for controlling entities
-- `ControlEntityResponse`: Response format for control operations
+The legacy `/api/entities` -> `/api/v2/entities` transition is documented
+in PR #126's docstring (and tested by
+`tests/contract/test_domain_api_spec_validation.py`).
 
-### State Management
+## State and data
 
-The application maintains shared state in `app_state.py`:
+- **SQL state** lives in SQLite via `DatabaseManager`. Migrations are
+  managed by Alembic (`backend/alembic/`) and are applied at startup
+  by `DatabaseUpdateService`.
+- **In-memory state** (e.g. last-known entity values, CAN message
+  history, system-state snapshots) lives in repositories with bounded
+  collections to prevent memory growth. The
+  `SystemStateRepository` is intentionally pure-in-memory.
+- **Configuration** comes from Pydantic `Settings` driven by
+  `COACHIQ_*` env vars. See `backend/core/config.py` and
+  `docs/architecture/configuration-loading.md`.
 
-- Current entity states
-- Entity history
-- Entity mappings (DGN to entity ID)
-- CAN bus configuration
+## Real-time updates
 
-This centralized state management allows different components to access the same data without tight coupling.
+The WebSocket layer (`backend/websocket/`) broadcasts entity-state
+updates to connected clients. Connections are managed by the
+`WebSocketManager` service (registered with the
+`EnhancedServiceRegistry` like everything else); routers in
+`backend/websocket/routes.py` mount the WS endpoints on the FastAPI
+app.
 
-## Real-time Communication
+When a CAN message decodes into an entity-state change:
+1. The decoder writes the new state into `EntityStateRepository`.
+2. `EntityService` (or whichever service owns the change) calls
+   `WebSocketManager.broadcast_entity_change(...)`.
+3. Connected clients see the update in <100ms typical.
 
-The application provides real-time updates through WebSockets:
+## See also
 
-- Entity state changes
-- CAN bus messages
-- System log events
-
-WebSocket connections are managed in `websocket.py`, which handles:
-
-- Client connection management
-- Message broadcasting
-- Connection authentication (when enabled)
-
-## CAN Bus Integration
-
-The application integrates with the RV-C CAN bus through:
-
-- `can_manager.py`: Handles CAN bus connections and message processing
-- `rvc_decoder/`: Decodes raw CAN messages into structured data
-
-When a message is received from the CAN bus:
-
-1. It's decoded using the RV-C specification
-2. The decoded data updates entity state in `app_state.py`
-3. The updated entity is broadcast to WebSocket clients
-4. The entity state history is updated
-
-## Future Architecture
-
-The planned future architecture will reorganize the codebase into:
-
-```
-backend/
-├── api/               # API routes and controllers
-├── integrations/      # External system integrations
-│   └── rvc/           # RV-C specific code
-├── middleware/        # HTTP and WebSocket middleware
-├── models/            # Application data models
-├── services/          # Business logic services
-└── settings/          # Configuration handling
-```
-
-This reorganization will:
-
-- Improve separation of concerns
-- Make the codebase more maintainable
-- Prepare for additional integrations beyond RV-C
+- [Repository Pattern](repository-pattern.md) -- the data-access
+  layer.
+- [Configuration Loading](configuration-loading.md) -- how
+  `rvc.json`, coach mappings, and `COACHIQ_*` env vars resolve.
+- [Overview](overview.md) -- top-level system diagram.
+- `backend/main.py` -- the source of truth for every service
+  registration.
+- `backend/core/service_registry.py` -- the registry implementation.

--- a/docs/architecture/frontend.md
+++ b/docs/architecture/frontend.md
@@ -88,8 +88,10 @@ Example:
 
 ```typescript
 export async function fetchLights(): Promise<LightStatus[]> {
+  // Note: the legacy /api/entities path was retired during the
+  // 2026-05 refactor; only /api/v2/entities remains.
   const response = await fetch(
-    `${API_BASE}/entities?device_type=light`,
+    `${API_BASE}/v2/entities?device_type=light`,
     defaultOptions
   );
   return handleApiResponse<LightStatus[]>(response);

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -21,21 +21,22 @@ graph TD
     subgraph "API Layer"
         REST --> FastAPI[FastAPI Server]
         WS --> WSServer[WebSocket Server]
-        FastAPI --> AppState[Application State]
-        WSServer --> AppState
+        FastAPI -->|Depends| Services[Services]
+        WSServer -->|Depends| Services
     end
 
     subgraph "Business Logic"
-        AppState --> EntityManager[Entity Manager]
-        AppState --> HistoryManager[History Manager]
-        EntityManager --> Decoder[RV-C Decoder]
-        HistoryManager --> Storage[State Storage]
+        Services --> Repos[Repositories]
+        Services --> Decoder[RV-C Decoder]
+        Services --> CANFacade[CAN Facade]
+        Repos --> SQL[(SQLite via DatabaseManager)]
     end
 
     subgraph "Device Layer"
-        Decoder --> CanManager[CAN Manager]
-        CanManager --> CanInterface[CAN Bus Interface]
-        CanInterface --> RVCBus[RV-C CAN Bus]
+        Decoder --> CANFacade
+        CANFacade --> CANInterface[CAN Bus Interface]
+        CANInterface --> RVCBus[RV-C / J1939 CAN Bus]
+        RVCBus <--> Firefly[Firefly MIRA Panel]
     end
 
     classDef user fill:#f5f5f5,stroke:#bdbdbd,color:#212121;
@@ -46,10 +47,18 @@ graph TD
 
     class User user;
     class WebUI,MobileApp,REST,WS frontend;
-    class FastAPI,WSServer,AppState api;
-    class EntityManager,HistoryManager,Decoder,Storage logic;
-    class CanManager,CanInterface,RVCBus device;
+    class FastAPI,WSServer,Services api;
+    class Repos,Decoder,CANFacade,SQL logic;
+    class CANInterface,RVCBus,Firefly device;
 ```
+
+> **What CoachIQ is and is not.** CoachIQ talks to the OEM Firefly MIRA
+> multiplex panel over CAN. Firefly owns the actual vehicle-safety
+> case (slide-with-brake interlocks, leveling-while-moving, etc.).
+> CoachIQ plays the same role as a wall switch or HMI -- emit
+> well-formed frames, trust Firefly to refuse the unsafe ones. See
+> the architecture-decision record (or
+> `/memories/repo/coachiq-architecture.md`) for the full framing.
 
 ### Backend Components
 
@@ -76,18 +85,17 @@ The project follows a monorepo structure:
 ```text
 coachiq/
 ├── backend/              # Python backend application
-│   ├── api/              # FastAPI routers and endpoints
-│   ├── core/             # Core configuration and utilities
+│   ├── api/              # FastAPI routers (legacy + domain v2)
+│   ├── core/             # Config, ServiceRegistry, dependencies
 │   ├── services/         # Business logic services
-│   ├── integrations/     # External integrations (CAN, etc.)
+│   ├── repositories/     # Repository pattern data access
+│   ├── integrations/     # CAN, RV-C, J1939, Firefly, Spartan K2
+│   ├── middleware/       # Auth, CSRF, structured logging
 │   ├── websocket/        # WebSocket handlers
-│   └── models/           # Data models and schemas
-├── src/                  # Shared components
-│   ├── common/           # Shared models and utilities
-│   └── rvc_decoder/      # RV-C protocol decoder
-├── frontend/               # React frontend
-│   ├── src/              # Frontend source code
-│   └── docs/             # Frontend-specific documentation
+│   ├── models/           # Pydantic request/response models
+│   ├── schemas/          # Zod-exportable schemas for the frontend
+│   └── alembic/          # SQLite migrations
+├── frontend/             # React 19 + TypeScript + Vite SPA
 ├── docs/                 # Project documentation
 └── scripts/              # Utility scripts
 ```

--- a/docs/architecture/repository-pattern.md
+++ b/docs/architecture/repository-pattern.md
@@ -1,193 +1,160 @@
-# Repository Pattern Architecture
+# Repository Pattern
 
-## Overview
+## Status
+Implemented and stable as of 2026-05-13. No outstanding migration work.
 
-The CoachIQ system has migrated from a monolithic `AppState` pattern to a modern repository pattern with dependency injection. This architecture provides better separation of concerns, improved testability, and enhanced maintainability.
+## Why
+Backend state used to live in a monolithic `AppState` object that every
+service imported and mutated directly. That made testing painful (you had
+to construct a real `AppState` for every unit test), enforced no
+boundaries between subsystems, and made dependencies invisible.
 
-## Architecture Components
+The current pattern decomposes that into:
 
-### 1. Repository Layer
+- **Repositories** (`backend/repositories/`): own a single concern's data
+  (entity state, RV-C config, CAN tracking, security audit log, etc.).
+  Take only what they need at construction time (typically a
+  `DatabaseManager` and/or a `PerformanceMonitor`).
+- **Services** (`backend/services/`): take repositories as constructor
+  arguments. Pure business logic on top of repositories. No global state.
+- **Routers** (`backend/api/routers/` and `backend/api/domains/`): use
+  FastAPI's `Depends(...)` to receive services. They never touch
+  repositories directly.
 
-Repositories provide data access abstraction with specific interfaces:
+`AppState` was deleted in PR #109 (2026-05-12); the legacy
+`backend/core/state.py` (-609 LOC) and the `dependencies_v2` shim are
+both gone.
 
-- **EntityStateRepository**: Manages entity state and configuration
-- **RVCConfigRepository**: Handles RV-C specification data
-- **CANTrackingRepository**: Tracks CAN messages and statistics
-- **SystemStateRepository**: System-wide configuration and state
+## How — service development
 
-### 2. Service Layer
-
-Services use repositories through dependency injection:
+Use constructor injection. Type-hint everything. Never reach for a
+service-locator / global registry from inside a service.
 
 ```python
-class ConfigService:
+# backend/services/example_service.py
+from backend.repositories import EntityStateRepository, SystemStateRepository
+
+
+class ExampleService:
     def __init__(
         self,
-        entity_state_repository: EntityStateRepository | None = None,
-        rvc_config_repository: RVCConfigRepository | None = None,
-        system_state_repository: SystemStateRepository | None = None,
-        app_state: Any = None  # For backward compatibility only
-    ):
-        # Services now use repositories instead of app_state
+        entity_state_repo: EntityStateRepository,
+        system_state_repo: SystemStateRepository,
+    ) -> None:
+        self._entity_repo = entity_state_repo
+        self._system_repo = system_state_repo
+
+    async def do_something(self, entity_id: str) -> dict:
+        entity = self._entity_repo.get_entity(entity_id)
+        # ...
 ```
 
-### 3. Dependency Injection
+The service is constructed once during startup by
+`backend.main._init_*` and registered with the
+`EnhancedServiceRegistry` (see `backend/core/service_registry.py`).
+Dependency order is declared at registration time and resolved
+automatically by the registry's stage planner.
 
-Modern FastAPI dependency injection through `backend.core.dependencies_v2`:
+## How — router development
+
+Routers use `Depends(get_*)` from `backend/core/dependencies.py`. The
+canonical shape uses `Annotated` for type-checker friendliness:
 
 ```python
+# backend/api/routers/example.py
 from typing import Annotated
-from fastapi import Depends
-from backend.core.dependencies_v2 import get_config_service
 
-@router.get("/config")
-async def get_config(
-    config_service: Annotated[ConfigService, Depends(get_config_service)]
-):
-    # Service is injected with all repositories configured
+from fastapi import APIRouter, Depends
+
+from backend.core.dependencies import get_example_service
+from backend.services.example_service import ExampleService
+
+router = APIRouter(prefix="/api/example", tags=["example"])
+
+
+@router.get("/{entity_id}")
+async def get_thing(
+    entity_id: str,
+    service: Annotated[ExampleService, Depends(get_example_service)],
+) -> dict:
+    return await service.do_something(entity_id)
 ```
 
-## Migration Strategy
-
-### Feature Flag Configuration
-
-The migration is controlled by feature flags in `backend/services/feature_flags.yaml`:
-
-```yaml
-repository_pattern:
-  enabled: true
-  core: false
-  depends_on: []
-  description: "Repository pattern for state management"
-  # Migration settings
-  use_repositories_for_config: true
-  use_repositories_for_can: true
-  use_repositories_for_websocket: true
-  fallback_to_app_state: true
-  migration_mode: "gradual"  # Options: strict, gradual, compatibility
-```
-
-### Migration Modes
-
-1. **Strict Mode**: Only repositories, no app_state fallback
-2. **Gradual Mode**: Repositories with app_state fallback (default)
-3. **Compatibility Mode**: Prefer app_state, repositories as backup
-
-### Migration Service
-
-The `RepositoryMigrationService` manages the rollout:
-
-- Monitors usage patterns
-- Provides health metrics
-- Enables gradual migration
-- Tracks errors and fallbacks
-
-## API Endpoints
-
-Monitor migration progress through these endpoints:
-
-- `GET /api/repository-migration/status` - Overall migration status
-- `GET /api/repository-migration/metrics` - Detailed usage metrics
-- `GET /api/repository-migration/health` - Health status
-- `POST /api/repository-migration/reset-stats` - Reset statistics
-
-## Best Practices
-
-### 1. Service Development
+Each `get_*` helper resolves the named service from the registry. If the
+service was never registered (or registry init hasn't run, e.g. in a
+test that skips lifespan), the helper raises `RuntimeError` -- catch it
+in your test setup by overriding the dependency on the FastAPI app:
 
 ```python
-# DO: Use repositories through dependency injection
-class MyService:
-    def __init__(
-        self,
-        entity_state_repository: EntityStateRepository,
-        system_state_repository: SystemStateRepository
-    ):
-        self._entity_repo = entity_state_repository
-        self._system_repo = system_state_repository
-
-# DON'T: Store app_state
-class MyService:
-    def __init__(self, app_state: AppState):
-        self.app_state = app_state  # Anti-pattern
+app.dependency_overrides[get_example_service] = lambda: my_mock_service
 ```
 
-### 2. Router Development
+See `tests/api/test_safety_pin_endpoints.py` for the canonical
+per-router test pattern.
+
+## How — testing
+
+Repositories are easy to mock because they have small, focused
+interfaces:
 
 ```python
-# DO: Use modern dependency injection
-from backend.core.dependencies_v2 import get_my_service
-
-@router.get("/endpoint")
-async def my_endpoint(
-    service: Annotated[MyService, Depends(get_my_service)]
-):
-    return await service.do_something()
-
-# DON'T: Use old dependencies
-from backend.core.dependencies import get_app_state  # Legacy
-```
-
-### 3. Testing
-
-```python
-# Easy to test with mocked repositories
-def test_my_service():
+def test_example_service():
     mock_entity_repo = MagicMock()
     mock_system_repo = MagicMock()
 
-    service = MyService(
-        entity_state_repository=mock_entity_repo,
-        system_state_repository=mock_system_repo
+    service = ExampleService(
+        entity_state_repo=mock_entity_repo,
+        system_state_repo=mock_system_repo,
     )
-
-    # Test with full control over dependencies
+    # ...
 ```
 
-## Performance Considerations
+For service constructor-shape questions, check the real signature in
+`backend/services/<service>.py` and pass real repositories where
+practical -- that exercises more of the stack than mocks do.
 
-### Real-time Operations
+## Repositories that exist today
 
-- Repository operations maintain <1ms latency for CAN operations
-- Thread-safe implementations for concurrent access
-- Bounded collections prevent memory growth
+The full list lives in `backend/repositories/__init__.py`. Notable
+ones:
 
-### Caching Strategy
+- `EntityStateRepository` -- entity state + last-known-brightness +
+  config payloads.
+- `RVCConfigRepository` -- parsed `rvc.json` / coach mapping data.
+- `CANTrackingRepository` -- in-flight CAN message stats and history.
+- `SystemStateRepository` -- system-level state (operational mode,
+  emergency-stop status, etc.).
+- `DatabaseUpdateRepository`, `DatabaseRepository` -- migration
+  history + raw DB session access for service consumers.
+- `SecurityAuditRepository`, `SecurityEventRepository`,
+  `JournalRepository` -- security and audit logging.
+- `PersistenceRepository` -- backup metadata + filesystem operations.
 
-- Repositories implement appropriate caching
-- Service-level caching for computed values
-- Cache invalidation on state changes
+Most repositories take a `database_manager` (for SQL access) and a
+`performance_monitor` (for instrumented timings) at construction. A
+few are pure in-memory (`SystemStateRepository`) and take no
+arguments. Look at the `_init_*_repository` functions in
+`backend/main.py` for the canonical construction calls.
 
-## Migration Checklist
+## What this is NOT
 
-When migrating code:
+- It is not a clean-architecture / hexagonal / ports-and-adapters
+  scheme. We don't define abstract repository interfaces and bind
+  concrete implementations at runtime. Repositories are concrete
+  classes; services depend on them directly.
+- It is not a mediator / CQRS pattern. Services call repository
+  methods directly, not through commands or events.
+- It is not feature-flagged. There are no `repository_pattern.enabled`
+  toggles, no `migration_mode: gradual`, no `fallback_to_app_state`
+  branches. The migration is done.
 
-1. ✅ Replace `app_state` imports with repository imports
-2. ✅ Update service constructors to accept repositories
-3. ✅ Use `dependencies_v2` instead of `dependencies`
-4. ✅ Test with migration modes (strict, gradual, compatibility)
-5. ✅ Update unit tests to use repository mocks
-6. ✅ Verify performance metrics remain stable
+## See also
 
-## Troubleshooting
-
-### Common Issues
-
-1. **"Repository not found" errors**
-   - Ensure ServiceRegistry initialization includes all repositories
-   - Check feature flag configuration
-
-2. **Performance degradation**
-   - Monitor `/api/repository-migration/metrics`
-   - Check for excessive fallbacks to app_state
-
-3. **Test failures**
-   - Update mocks to use repository pattern
-   - Ensure proper repository initialization in tests
-
-## Future Enhancements
-
-1. **Complete app_state removal** (target: Q2 2025)
-2. **Enhanced repository interfaces** with async operations
-3. **Repository-level caching improvements**
-4. **Distributed repository support** for scaling
+- `backend/core/dependencies.py` -- canonical `get_*` injection
+  helpers.
+- `backend/core/service_registry.py` -- the EnhancedServiceRegistry
+  that owns service lifecycle.
+- `backend/main.py` -- where every repository and service is
+  constructed and registered (search for `_init_*` functions).
+- `tests/api/test_safety_pin_endpoints.py` -- canonical per-router
+  test pattern with `app.dependency_overrides`.


### PR DESCRIPTION
## Summary
Second of three PRs from the 2026-05-13 ADR review. **Rewrites four docs** to match the actual codebase. No new content — every claim is verifiable against `main`.

## Changes

### `docs/architecture/repository-pattern.md` (-279 +160 LOC, **net −119**)
Old content described a 6-month-old in-flight migration with extensive references to artifacts that no longer exist:
- `dependencies_v2` module (only stale `.pyc` remains)
- `RepositoryMigrationService` (never built; documented anyway)
- `repository_pattern` feature flag with strict/gradual/compatibility modes (`FeatureManager` itself is gone)
- `/api/repository-migration/*` endpoints (don't exist)
- `AppState` fallback machinery (`AppState` deleted in #109)
- 'Future Enhancements: Complete app_state removal (target Q2 2025)' (already done)

New content is a **reference doc** for the current pattern: repositories own data, services take repositories at construction, routers use FastAPI `Depends(get_*)` injection. Includes canonical service-development and router-development snippets, testing guidance, and a *'What this is NOT'* section to head off misunderstandings (it is not hexagonal architecture; it is not CQRS; it is not feature-flagged).

### `docs/architecture/backend.md` (rewrite, **net +124 LOC** for clarity)
Old content's component diagram showed `AppState` as a central node (deleted in #109). 'Future Architecture' section described a reorg that already happened. Several file-tree references pointed at files that no longer exist (`app_state.py`, `state.py`).

New content reflects the actual current shape:
- accurate top-level layout (services / repositories / domains / middleware / schemas / alembic)
- updated mermaid diagram showing `FastAPI → Depends → Services → Repositories` flow with the `EnhancedServiceRegistry` implicit
- service-lifecycle section (construction → registration → stage planning → startup → lifespan)
- API surface section explaining the `/api/*` + `/api/v2/*` coexistence (no feature flags around v2)
- pointer to the *'CoachIQ is not the safety system'* framing for architectural-decision context

### `docs/architecture/overview.md` (small targeted edits)
- Top-level diagram: replaced `AppState` / `EntityManager` / `HistoryManager` nodes with Services / Repositories. Added Firefly MIRA panel as the CAN-bus peer to make the architectural framing visible at a glance.
- Added a callout linking to the *'CoachIQ is not the safety system'* framing (forward-references the ADR that PR 3 will land).
- Directory-structure section: removed defunct `src/common/` and `src/rvc_decoder/` (everything is under `backend/` now).

### `docs/architecture/frontend.md` (1-line example fix)
- API client example used `/api/entities` (legacy path, retired in #126). Updated to `/api/v2/entities` with an inline note about the retirement.

## Verification
- All four files render in MkDocs without broken cross-references (verified by grep on internal links).
- Code references in the new docs (file paths, line numbers, function names) cite verifiable artifacts.

## Refs
- 2026-05-13 ADR review (chat history)
- #142 (the subtractive deletions; this PR is the rewrite half)
- #109 (AppState removal)
- #126 (`/api/v2/entities` transition)
- #135 (ServiceRegistry fallback fix referenced in backend.md)
- #139 (CoreServices removal)