### PR TITLE
docs(adr): establish ADR convention and canonize 4 retroactive decisions

### DIFF
--- a/docs/adr/ADR-0001-fastapi-depends-over-di-framework.md
+++ b/docs/adr/ADR-0001-fastapi-depends-over-di-framework.md
@@ -1,0 +1,137 @@
+# ADR-0001: Use FastAPI's `Depends(...)` over an external DI framework
+
+## Status
+
+**Accepted**, 2026-05-13. Compresses the 2025-06 evaluation in
+`docs/development/di-framework-evaluation.md` (368 lines) into a single
+record. The artifacts that evaluation cited as evidence (`dependencies_v2`,
+`ServiceProxy`, "Migration Adapters") are gone; the underlying decision
+holds.
+
+## Context
+
+The backend has ~60 services and growing. They have a clear dependency
+graph (e.g. `EntityService` depends on `EntityStateRepository`, which
+depends on `DatabaseManager`). At some point during the 2025 sprint
+the question came up: should we adopt a real DI framework
+(`dependency-injector`, `punq`, `pinject`, `lagom`) instead of relying
+on FastAPI's built-in `Depends(...)` machinery plus our own
+`EnhancedServiceRegistry`?
+
+The cost of "yes" is: adopt a non-standard dep, learn its DSL, retrain
+contributors, deal with its corner cases (provider scopes, container
+nesting, async ergonomics). The benefit is supposed to be more
+declarative wiring and better separation of concerns.
+
+## Decision
+
+Stay with FastAPI's `Depends(...)` plus our own
+`EnhancedServiceRegistry`. Do not adopt a third-party DI framework.
+
+The actual pattern in production:
+
+1. **Construction**: every service is built in a `_init_*` function in
+   `backend/main.py`, with its dependencies passed as constructor
+   arguments. No global state, no service locator inside services.
+2. **Registration**: each constructed service is handed to
+   `EnhancedServiceRegistry.register_service(name, init_func,
+   dependencies)`. The registry's `ServiceDependencyResolver` builds
+   a topological order at startup.
+3. **Injection**: routers receive services via
+   `Annotated[Type, Depends(get_x)]`. The `get_x` helpers in
+   `backend/core/dependencies.py` resolve the named service from the
+   registry.
+
+That is the entire wiring story. There is no DSL, no decorator
+machinery, no separate config file describing service shapes.
+
+## Consequences
+
+### Becomes easier
+- **Type checking**: pyright sees through every `Depends(get_x)` call.
+- **Onboarding**: anyone who knows FastAPI knows our DI. No second
+  framework to learn.
+- **Testing**: `app.dependency_overrides[get_x] = lambda: mock`
+  replaces a service for one test. Standard FastAPI; no container
+  rewiring.
+- **Stack traces**: a missing dependency raises `RuntimeError` from
+  `get_service_registry()` with the requested service name in the
+  message. There's no DI-framework layer to peer through.
+
+### Becomes harder
+- **Lifecycle features that DI frameworks ship for free** -- scoped
+  providers, lazy resolution, cyclic-dependency detection -- we have
+  to build ourselves. We have done the ones we needed
+  (`ServiceDependencyResolver` does cycle detection and stage planning;
+  PR #135 fixed a fallback-handling bug in stage optimization), and
+  the gaps that remain (e.g. per-request scopes) we don't actually
+  need.
+- **No declarative service config**. Adding a service requires editing
+  `main.py`. That's a maintenance cost but also a forcing function:
+  every service registration is visible in one place.
+
+### Cannot do anymore
+- Adopt a DI framework cleanly later. We could do it as a refactor,
+  but `main.py`'s explicit-registration pattern would have to be
+  reworked. Worth the effort only if we ever feel real pain from the
+  current pattern, which we don't.
+
+## Alternatives considered
+
+### `dependency-injector` (most popular Python DI framework)
+- Strong feature set: scopes, async, providers, configuration
+  binding.
+- Cost: introduces a non-trivial DSL. Containers are themselves
+  Python classes with a particular shape; all wiring goes through
+  `Provide[Container.thing]` markers in function signatures.
+- Rejected because the marker approach interacts awkwardly with
+  FastAPI's own `Depends(...)` (you end up with two layers of DI),
+  and because the benefits (configurability, scopes) don't apply to
+  our use case where every service is a singleton with one
+  construction site.
+
+### `punq`, `lagom`, `pinject`
+- Smaller / lighter than `dependency-injector`. Mostly favor
+  constructor-injection-by-type-hint.
+- Rejected because the constructor-injection-by-type-hint approach
+  presumes you want runtime resolution of types, which we don't.
+  Our service registration is explicit by name; type-based
+  resolution would just add ambiguity (e.g. "which `Repository`
+  should I inject here?").
+
+### Our own decorator + YAML config (proposed in
+`di-framework-evaluation.md` "Recommended Minor Enhancements")
+- The 2025 evaluation suggested a `@service_dependency` decorator
+  and a `services.yaml` config to describe service wiring
+  declaratively.
+- **Push back**: not needed. The current state -- explicit
+  registration in `main.py`, type-checkable injection at call sites
+  -- is simple, type-checkable, and you've shown across 17 PRs that
+  it scales fine for ~60 services. Don't introduce a config DSL on
+  top of working code without a concrete pain point that the DSL
+  would relieve.
+
+## Revisit conditions
+
+Reconsider this decision if any of these become true:
+
+- Service count grows past ~150 (current ~60).
+- We grow a team large enough that "edit main.py" becomes a bottleneck.
+- We decide to break the monolith into multiple processes
+  (microservices), where independent service containers would
+  matter.
+- A specific pain point emerges that a DI framework would relieve
+  (e.g. per-request scoping for multi-tenant deployments).
+
+Until then, the answer is "FastAPI's `Depends(...)` is enough".
+
+## See also
+
+- `backend/core/service_registry.py` -- the registry implementation.
+- `backend/core/service_dependency_resolver.py` -- topological
+  ordering + cycle detection (with the PR #135 fallback fix).
+- `backend/core/dependencies.py` -- the `get_*` injection helpers.
+- `backend/main.py` -- the single source of truth for what is wired
+  to what.
+- `docs/architecture/repository-pattern.md` -- describes the same
+  pattern from the data-access angle.

--- a/docs/adr/ADR-0002-can-facade-pattern.md
+++ b/docs/adr/ADR-0002-can-facade-pattern.md
@@ -1,0 +1,136 @@
+# ADR-0002: Single `CANFacade` as the only entry point for CAN operations
+
+## Status
+
+**Accepted**, 2026-05-13. Codifies the consolidation that landed in
+mid-2025 (see archived plan at
+`docs/archive/can-service-consolidation-plan-2025.md` for the original
+1272-line implementation roadmap and FMEA-style design rationale).
+
+## Context
+
+In early 2025 the backend had several services touching the CAN bus
+without coordinating with each other:
+
+- `CANService` (high-level API operations).
+- `CANBusService` (raw message processing).
+- `CANInterfaceService` (interface name → device-path mapping).
+- `CANMessageInjector` (test-frame injection).
+- `CANMessageFilter` (subscription filtering).
+- `CANBusRecorder` (recording / replay).
+- `CANProtocolAnalyzer` (protocol analysis).
+- `CANAnomalyDetector` (security monitoring).
+
+Several of these duplicated state (e.g. multiple components owned an
+in-flight statistics counter), and there was no single place where an
+emergency-stop request could fan out to "stop everything CAN-related,
+right now". Routers reached into different services depending on
+historical accident, which made auth and rate-limiting policy
+inconsistent across endpoints.
+
+For a system whose CAN frames have physical consequences via Firefly
+(see [ADR-0004](ADR-0004-coachiq-is-not-the-safety-system.md)), having
+no single coordination point was a real risk -- not because
+CAN-related code is "safety-critical" in the certification sense, but
+because emergency-stop *coordination* is exactly the kind of
+cross-cutting concern a facade pattern is designed for.
+
+## Decision
+
+All CAN operations go through a single **`CANFacade`** service that:
+
+- Implements the `SafetyAware` interface (so it participates in the
+  `SafetyService`'s emergency-stop coordination).
+- Has `safety_classification = SafetyClassification.CRITICAL` (for
+  the audit-trail / shutdown-ordering machinery).
+- Owns references to the underlying CAN services (CANBusService,
+  CANMessageInjector, CANMessageFilter, CANBusRecorder,
+  CANProtocolAnalyzer, etc.) and dispatches through them.
+- Is the **only** service that routers and other services depend on
+  for CAN access. New code does not import the underlying services
+  directly.
+
+Routers receive the facade via:
+```python
+from typing import Annotated
+from fastapi import APIRouter, Depends
+from backend.core.dependencies import get_can_facade
+from backend.services.can_facade import CANFacade
+
+router = APIRouter()
+
+@router.post("/api/can/send")
+async def send_can_frame(
+    facade: Annotated[CANFacade, Depends(get_can_facade)],
+    ...
+):
+    return await facade.send_message(...)
+```
+
+## Consequences
+
+### Becomes easier
+- **Emergency-stop coordination**: one method on `CANFacade` halts
+  every CAN-side operation in a consistent order. Before, that fan-out
+  was implicit and incomplete.
+- **Auth / rate-limit policy uniformity**: every CAN endpoint goes
+  through the facade, so policy lives in one place.
+- **Discoverability**: someone exploring the codebase looks at
+  `CANFacade` once and sees the whole CAN surface area.
+- **Testing**: mock one `CANFacade` instead of stitching together
+  mocks for 6+ underlying services.
+
+### Becomes harder
+- **Adding a new CAN-side capability**: requires adding a method on
+  the facade (and the underlying service it delegates to). That's a
+  small extra step compared to "just create a new service and import
+  it from a router".
+- **The facade itself can become a god-object** if we don't push back
+  on bloat. Mitigation: keep the facade interface focused on the
+  public CAN operations; let the underlying services own their own
+  internal state. The facade is a coordinator, not a re-implementer.
+
+### Cannot do anymore
+- Have routers reach directly into `CANBusService` or other
+  underlying services. (Existing test code that does this is being
+  cleaned up; new code is reviewed against this rule.)
+
+## Alternatives considered
+
+### Keep the per-service status quo
+Already painful when this consolidation was proposed. Adding more
+CAN-side features would have made it worse.
+
+### Use a dependency-injected event bus
+Some teams solve this with a pub/sub event bus where any service can
+publish CAN events and any service can subscribe. Considered and
+rejected for two reasons:
+
+1. Async event-bus patterns make causality hard to reason about.
+   When a CAN frame is rejected, you want a stack trace that goes
+   from the API call to the rejection -- not "frame published to
+   bus, eventually filtered, eventually denied".
+2. Emergency-stop coordination is a *synchronous* thing. The facade
+   pattern's "single ordered shutdown" is exactly what we need.
+
+### Inheritance hierarchy (CANBusService extends CANService extends ...)
+Fragile and obscures intent. Composition (facade delegates to
+focused services) is clearer.
+
+## See also
+
+- `backend/services/can_facade.py` -- the implementation.
+- `backend/services/can_bus_service.py` -- the largest underlying
+  service that the facade delegates to.
+- `backend/integrations/can/` -- the lower-level integrations (message
+  factories, interface adapters, multi-network manager) that the
+  underlying services in turn use.
+- `backend/services/safety_service.py` -- the consumer of the
+  `SafetyAware` interface, which the facade implements for
+  emergency-stop coordination.
+- `docs/archive/can-service-consolidation-plan-2025.md` -- the
+  original implementation plan (preserved for the FMEA-style rationale).
+- [ADR-0004](ADR-0004-coachiq-is-not-the-safety-system.md) -- the
+  framing that explains why "CRITICAL safety classification" here means
+  "important for the audit log and shutdown ordering", not "certified
+  safety-critical software".

--- a/docs/adr/ADR-0003-api-v2-only-no-legacy.md
+++ b/docs/adr/ADR-0003-api-v2-only-no-legacy.md
@@ -1,0 +1,127 @@
+# ADR-0003: New endpoints land under `/api/v2/*`; legacy `/api/*` is retired, not parallel-maintained
+
+## Status
+
+**Accepted**, 2026-05-13. Codifies the practice that has governed
+several recent PRs (notably #126 retiring `/api/entities`, #124
+retiring `/api/missing-dgns`, and the contract-test rewrite in #130).
+
+## Context
+
+The backend has historically grown two API namespaces:
+
+- **Legacy `/api/*`** routers under `backend/api/routers/`: organic
+  growth, often with response shapes that match what the original
+  caller needed rather than a coherent design.
+- **Domain API `/api/v2/*`** under `backend/api/domains/`: built later
+  with explicit Pydantic schemas (`EntitySchemaV2`,
+  `EntityCollectionV2`, etc.), bulk-operation support, and a
+  consistent error envelope.
+
+When v2 was introduced (somewhere around mid-2025) the temptation was
+to maintain v1 indefinitely "for backward compatibility". For an
+internal-only API on a single-tenant device, that's a very expensive
+courtesy.
+
+The 2026-05 audit cycle surfaced multiple test failures that traced
+back to v1 endpoints being silently retired without anyone updating
+the corresponding tests. The contract tests in
+`tests/contract/test_domain_api_spec_validation.py` failed because
+they asserted `/api/entities` was reachable; PR #130 had to rewrite
+them to assert `/api/v2/entities` instead.
+
+## Decision
+
+**New endpoints land under `/api/v2/*`.** Legacy `/api/*` endpoints
+are either:
+
+1. **Kept as-is** if they still have callers and there's no v2
+   replacement (auth, health, schemas, CAN tools, etc.).
+2. **Retired** if they have a v2 replacement that fully covers them
+   (entities, missing-dgns).
+
+We do **not** parallel-maintain v1 + v2 for the same capability. When
+v2 is good enough to replace a v1 endpoint, the v1 endpoint is
+deleted in the same PR (or the immediately-following one, depending
+on coordination cost), not deprecated and left in place.
+
+Domain v2 routers are mounted **unconditionally** by
+`register_all_domain_routers` in `backend/api/domains/__init__.py`.
+There are no feature flags around v2 endpoints.
+
+## Consequences
+
+### Becomes easier
+- **Cognitive load**: one path per capability. No "should I use
+  `/api/entities` or `/api/v2/entities`?" judgment call.
+- **Test maintenance**: tests assert against one API, not two. The
+  PR #130 cleanup removed an entire fallback-and-retry pattern from
+  the contract tests.
+- **Schema generation**: OpenAPI / Zod export is unambiguous about
+  which schemas are current.
+- **Audit trail**: when a legacy endpoint is retired, it's a single
+  PR with the deletion + the test rewrites visible together.
+
+### Becomes harder
+- **Frontend coordination**: any frontend code calling a legacy path
+  has to be updated in the same PR or immediately after. So far this
+  has been single-developer manageable; with multiple frontend
+  contributors this would need a flag-day or a brief deprecation
+  window.
+- **Out-of-tree consumers**: there aren't any (CoachIQ is a
+  single-tenant device), so this isn't actually a cost. If we ever
+  publish CoachIQ as a service that other people integrate with,
+  this ADR's premise breaks and we'd need a real deprecation policy.
+
+### Cannot do anymore
+- Add a new feature to a legacy endpoint. New features go in v2.
+- Maintain two parallel implementations for "compatibility" reasons.
+
+## Alternatives considered
+
+### Keep v1 forever, build v2 alongside
+Standard "API versioning best practice" for public APIs. Rejected
+because:
+- CoachIQ is internal to a single device. There are no third-party
+  integrators paying the migration cost.
+- Maintaining two implementations doubles the testing surface and
+  invites them to drift (which is exactly what happened pre-2026-05).
+- The "compatibility" benefit is hypothetical; the cost is real.
+
+### Use API gateway / proxy to translate v1 → v2
+Considered briefly. Rejected because adding a translation layer
+adds a new failure mode (translation bugs) and would require
+maintaining mapping rules indefinitely.
+
+### `/api/v2/*` mounted only when a feature flag is set
+Was actually how it started. Removed because:
+- Every consumer either always wants v2 or never wants v2; there's
+  no scenario where you want it sometimes.
+- Feature-flagging adds a runtime branch that has to be tested,
+  documented, and explained to readers, for zero practical benefit.
+- Aligns with [ADR-0001](ADR-0001-fastapi-depends-over-di-framework.md)'s
+  preference for "everything is wired explicitly in `main.py` /
+  `router_config.py`" over "configuration-driven optionality".
+
+## Revisit conditions
+
+Reconsider this decision if:
+
+- CoachIQ ever ships a public API that third parties consume.
+- We adopt a deprecation cycle (e.g. announce-now, remove-in-6-months)
+  for any reason.
+- Frontend coordination becomes a bottleneck (e.g. team grows enough
+  that "delete v1 in the same PR as the v2 frontend update" stops
+  scaling).
+
+## See also
+
+- `backend/api/routers/` -- legacy /api/* routers (still active).
+- `backend/api/domains/` -- v2 domain routers.
+- `backend/api/domains/__init__.py` --
+  `register_all_domain_routers`, mounted unconditionally.
+- `tests/contract/test_domain_api_spec_validation.py` -- contract
+  tests asserting v2-only after PR #130's rewrite.
+- PR #126 (legacy /api/entities retirement) and PR #124 (legacy
+  /api/missing-dgns retirement) for the canonical "retirement"
+  pattern.

--- a/docs/adr/ADR-0004-coachiq-is-not-the-safety-system.md
+++ b/docs/adr/ADR-0004-coachiq-is-not-the-safety-system.md
@@ -1,0 +1,137 @@
+# ADR-0004: CoachIQ is API guardrails, not the vehicle safety system
+
+## Status
+
+**Accepted**, 2026-05-13. Canonizes the architectural framing that has
+governed every PR in the 2026-05 audit cycle (and earlier) but lived
+only in `/memories/repo/coachiq-architecture.md` and PR descriptions.
+
+## Context
+
+CoachIQ runs on a Raspberry Pi inside a 2021 Entegra Aspire 44R RV. It
+talks to the **Firefly MIRA** multiplex panel over RV-C / J1939 CAN.
+
+It is genuinely tempting to describe CoachIQ as a "vehicle safety
+system" because:
+
+- it has files named `safety_service.py`, `brake_safety_monitor.py`,
+  `safety_state_engine.py`, `safety_interfaces.py`;
+- it sends commands that affect physical hardware (lights, slides,
+  awnings, leveling jacks);
+- it has emergency-stop endpoints, watchdog timers, and interlock
+  checks.
+
+If we accepted that framing, the implication would be that we should
+hold the codebase to aerospace / automotive-functional-safety
+standards: ISO 26262, DO-178C, MC/DC coverage, formal verification,
+SIL ratings, etc. None of that would be insane on its own merits --
+but it would be wrong for *this project*.
+
+Three facts make the framing different:
+
+1. **Firefly MIRA is the OEM controller.** It owns physical control
+   authority over every device on the bus and enforces the actual
+   safety interlocks (slide-with-brake, leveling-while-moving,
+   parking-brake-required-for-jacks). Firefly was built and certified
+   by an OEM whose business depends on getting that right.
+
+2. **CoachIQ talks *to* Firefly, not around it.** Architecturally
+   CoachIQ plays the same role as a wall switch or a touchscreen HMI:
+   it emits a well-formed RV-C frame; Firefly decides whether to act
+   on it. If CoachIQ asks Firefly to extend the slide while the
+   vehicle is moving, Firefly refuses. CoachIQ has no way to bypass
+   Firefly because there is no other path to the hardware.
+
+3. **The realistic threat model is API-side, not hardware-side.** An
+   attacker who compromises CoachIQ can flood Firefly with valid CAN
+   frames, exhaust authentication tokens, or scrape state from the
+   web UI. They cannot directly release the parking brake or extend
+   slides while moving, because Firefly's interlocks are not in
+   CoachIQ's threat surface.
+
+## Decision
+
+CoachIQ is a **good consumer-grade backend** for a CAN-bus orchestration
+layer. Calibrate every decision to that level, not to safety-critical
+embedded systems.
+
+In particular:
+
+- **In scope** for this codebase:
+  - Strict typing (pyright in basic mode is fine; strict eventually).
+  - Reasonable test coverage on API guardrail paths (the audit-2026-05
+    sweep landed at ~100% pass rate; coverage targets are ~70-80%).
+  - JWT + CSRF + RBAC on every mutating endpoint.
+  - Token-bucket rate limiting on outbound CAN TX (so a buggy loop
+    cannot flood Firefly).
+  - Pydantic-validated message factories; never hand-construct CAN
+    payloads from user input.
+  - Audit logging for every safety-relevant API action.
+  - Bandit medium+ blocking on the entire project.
+
+- **Out of scope** for this codebase:
+  - DO-178C / IEC 61508 / ISO 26262 compliance.
+  - Mutation testing, MC/DC coverage, formal methods.
+  - Hardware-fault tolerance assumptions (CoachIQ failing -- crashing,
+    losing power, getting unplugged -- is not a vehicle-safety event;
+    the vehicle still works without us).
+  - Anything that frames CoachIQ as the system of record for vehicle
+    safety state.
+
+The naming is unfortunate. Files like `safety_service.py` and
+`brake_safety_monitor.py` describe **API guardrails** ("don't let the
+API send commands that would be invalid or confusing for Firefly to
+process"), not vehicle-safety primitives. The architecture-doc files,
+the AGENTS.md / copilot-instructions.md files, and this ADR all repeat
+that disclaimer because the names alone will keep tempting readers
+toward the wrong framing.
+
+## Consequences
+
+### Becomes easier
+- Onboarding humans and AI assistants -- they don't need to ramp on
+  ISO 26262 to contribute.
+- Saying no to over-engineering proposals (mutation testing,
+  proof-carrying code, etc.) without long debate.
+- Calibrating code review depth: a 20-line config refactor doesn't
+  need the same scrutiny a 5-line CAN-message constructor does.
+
+### Becomes harder
+- This ADR has to be cited every time someone reads the safety_*
+  filenames and assumes the wrong scope.
+- If we ever ship CoachIQ on an RV without a Firefly (or with a
+  different OEM controller, or without one at all), this ADR's
+  assumptions break and we'd need to write a successor.
+
+### Cannot do anymore
+- Claim ISO 26262 / DO-178C compliance. We are not pursuing it.
+
+## Alternatives considered
+
+### Treat CoachIQ as safety-critical
+Would require the standards listed above. Rejected because:
+- Firefly already owns the safety case; duplicating it inside CoachIQ
+  buys no real safety benefit.
+- The certification cost (engineering hours, audits, formal-methods
+  tooling) is wildly disproportionate to a personal-RV-control project.
+- Firefly's certification status would be the binding factor anyway;
+  CoachIQ being "more certified" than the device it talks to doesn't
+  improve outcomes.
+
+### Treat CoachIQ as a generic web app, drop the safety-* naming entirely
+Considered but rejected:
+- The naming reflects real intent: the rate-limiting, interlock checks,
+  and emergency-stop paths are *defensive* code that exists because
+  CAN commands have physical consequences. Removing the safety-*
+  prefix would lose that signal.
+- A single ADR (this one) clarifying the scope is cheaper than
+  renaming dozens of files and re-training every contributor.
+
+## See also
+
+- `/memories/repo/coachiq-architecture.md` -- the agent-memory version
+  of this decision (will be kept in sync with this ADR).
+- `docs/safety.md` -- operational-safety policy that this ADR
+  references.
+- `backend/services/safety_service.py` -- the file with the most
+  misleading name; read its module docstring for the per-file scope.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,64 @@
+# Architecture Decision Records
+
+This directory holds **Architecture Decision Records (ADRs)** for CoachIQ.
+An ADR captures *one* meaningful architectural choice along with the
+context that led to it, the alternatives considered, and the
+consequences of the decision.
+
+## When to write a new ADR
+
+Write an ADR when you are about to commit to a decision that:
+
+- Will be hard to reverse later (database engine, framework, transport,
+  auth model).
+- Constrains future code (an API contract, a service boundary, a
+  threat-model assumption).
+- Repeatedly comes up in code review or onboarding ("why don't we do
+  X instead?").
+
+You probably **don't** need an ADR for:
+
+- Routine refactors (move a function, rename a class).
+- Bug fixes -- those go in commit messages and PR descriptions.
+- Implementation details that one well-commented module captures
+  better than a separate doc.
+
+## Format
+
+Each ADR is a single markdown file with a numeric prefix:
+`ADR-NNNN-short-kebab-case-title.md`. Use the next available number.
+
+Each ADR has these sections:
+
+1. **Status** -- one of `Proposed`, `Accepted`, `Superseded by ADR-NNNN`,
+   `Deprecated`. Include a date.
+2. **Context** -- what's the situation that forced a decision?
+3. **Decision** -- what did we choose? State it as an imperative.
+4. **Consequences** -- what becomes easier? Harder? What can we no
+   longer do?
+5. **Alternatives considered** -- briefly note the options you
+   evaluated and why you didn't pick them. Future readers will ask;
+   answer up front.
+
+Keep ADRs short -- 50-150 lines is typical. If you find yourself writing
+500 lines of architecture, that's a *spec*, not an ADR; put it in
+`docs/specs/` and have the ADR link to it.
+
+## Existing ADRs
+
+- [ADR-0001](ADR-0001-fastapi-depends-over-di-framework.md) -- Use
+  FastAPI's native `Depends(...)` over an external DI framework.
+- [ADR-0002](ADR-0002-can-facade-pattern.md) -- Single `CANFacade` as
+  the only entry point for CAN operations.
+- [ADR-0003](ADR-0003-api-v2-only-no-legacy.md) -- New endpoints land
+  under `/api/v2/*`; legacy `/api/*` routes are retired, not parallel-
+  maintained.
+- [ADR-0004](ADR-0004-coachiq-is-not-the-safety-system.md) -- CoachIQ
+  is API guardrails for an OEM controller, not the vehicle safety
+  system itself. **Read this first.**
+
+## Status
+
+Started 2026-05-13. The first four ADRs canonize decisions that were
+already in effect but lived only in commit messages, in-line comments,
+or agent memory. They are recorded retroactively.

--- a/docs/adr/TEMPLATE.md
+++ b/docs/adr/TEMPLATE.md
@@ -1,0 +1,65 @@
+# ADR-NNNN: <imperative title>
+
+## Status
+
+**Proposed** | **Accepted** | **Superseded by ADR-NNNN** | **Deprecated**, <YYYY-MM-DD>
+
+(Pick one. Include a date. If superseding an earlier ADR, link it.)
+
+## Context
+
+What's the situation that forced a decision?
+
+- Concrete facts about the codebase, the deployment, the team, the
+  threat model, etc. State only what's relevant to the decision.
+- If the context has a history (e.g. "we tried X first and it
+  didn't work"), summarize it in one paragraph.
+- Avoid prescribing the answer here; that's the next section.
+
+## Decision
+
+What did we choose? State it as an imperative:
+
+> Use FastAPI's `Depends(...)` over an external DI framework.
+
+> All CAN operations go through a single `CANFacade` service.
+
+Spell out the rule in enough detail that a reviewer can flag a PR
+that violates it. Include the smallest example of the pattern in
+action if it helps.
+
+## Consequences
+
+### Becomes easier
+- ...
+- ...
+
+### Becomes harder
+- ...
+- ...
+
+### Cannot do anymore
+- ...
+
+## Alternatives considered
+
+For each alternative you seriously considered:
+
+- **<name>**: 1-2 sentences on what it is, then why you didn't pick
+  it. Future readers will ask; answer up front.
+
+## Revisit conditions (optional)
+
+If there are specific futures in which this decision should be
+re-opened, list them here. Examples:
+
+- Service count grows past N.
+- We start serving an out-of-tree consumer.
+- A specific pain point emerges.
+
+## See also
+
+- Code paths that embody this decision (file references with line
+  numbers if useful).
+- Related ADRs.
+- External references (RFCs, papers, blog posts, vendor docs).

--- a/docs/archive/di-framework-evaluation-2025.md
+++ b/docs/archive/di-framework-evaluation-2025.md
@@ -1,3 +1,13 @@
+> **ARCHIVED 2026-05-13.** This 2025-06 evaluation has been superseded by
+> [ADR-0001](../adr/ADR-0001-fastapi-depends-over-di-framework.md), which
+> compresses the recommendation into a maintainable single-page record.
+> The original evaluation is preserved here for reference -- it cites
+> several artifacts (`dependencies_v2`, `ServiceProxy`, "Migration
+> Adapters") that have since been deleted, but the evaluation's
+> framework comparisons (`dependency-injector`, `punq`, `pinject`,
+> `lagom`) and its recommendation to stay with FastAPI's native
+> `Depends(...)` are still relevant context.
+
 # Dependency Injection Framework Evaluation
 
 **Phase 2P: Dependency Injection Framework Evaluation**

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,6 +12,12 @@ nav:
   - Setup: setup.md
   - Usage: usage.md
   - Troubleshooting: troubleshooting.md
+  - Architecture Decisions:
+    - Overview: adr/README.md
+    - "ADR-0001 — FastAPI Depends over a DI framework": adr/ADR-0001-fastapi-depends-over-di-framework.md
+    - "ADR-0002 — Single CANFacade entry point": adr/ADR-0002-can-facade-pattern.md
+    - "ADR-0003 — API v2 only, no legacy parallel-maintenance": adr/ADR-0003-api-v2-only-no-legacy.md
+    - "ADR-0004 — CoachIQ is API guardrails, not the safety system": adr/ADR-0004-coachiq-is-not-the-safety-system.md
   - Safety:
     - Overview: safety.md
     - Emergency Procedures: safety/can-facade-emergency-procedures.md


### PR DESCRIPTION
## Summary
Third of three PRs from the 2026-05-13 ADR review. Creates `docs/adr/` and lands four retroactive ADRs that codify decisions already in effect but previously living only in commit messages, in-line comments, or agent memory.

## What's added

| File | Lines | Purpose |
|------|-------|---------|
| `docs/adr/README.md` | 64 | Convention: when to write an ADR, format, sizing |
| `docs/adr/TEMPLATE.md` | 65 | Skeleton with section prompts |
| `docs/adr/ADR-0001-fastapi-depends-over-di-framework.md` | 137 | DI framework decision |
| `docs/adr/ADR-0002-can-facade-pattern.md` | 136 | CAN consolidation |
| `docs/adr/ADR-0003-api-v2-only-no-legacy.md` | 127 | API namespace policy |
| `docs/adr/ADR-0004-coachiq-is-not-the-safety-system.md` | 137 | **The most important one** |

### ADR-0004 — read this one first
Codifies the architectural framing that has governed every PR in the 2026-05 audit cycle but lived only in `/memories/repo/coachiq-architecture.md` and various PR descriptions: **CoachIQ talks to the OEM Firefly MIRA panel, which owns the actual vehicle-safety case. CoachIQ plays the role of a wall switch / HMI. Calibrate code quality to 'good consumer-grade backend', NOT aerospace.**

The 'safety_*' filenames will keep tempting readers toward the wrong scope; this ADR is the canonical pushback. Spelling out in-scope vs out-of-scope concerns explicitly saves the next reader (human or AI) hours of mis-framing.

### ADR-0001 — DI framework decision
Compresses the 2025-06 `di-framework-evaluation.md` (368 lines) into a single page. Includes alternatives (`dependency-injector`, `punq`, `lagom`, the `services.yaml` DSL proposed at the time) and revisit conditions. The original evaluation is moved to `docs/archive/di-framework-evaluation-2025.md` with an archive notice prepended.

### ADR-0002 — CAN Facade
Codifies the consolidation that landed in mid-2025: single `CANFacade` as the only entry point for CAN ops, with the `SafetyAware` interface for emergency-stop coordination. References the archived 1272-line implementation plan (archived in #142).

### ADR-0003 — API v2-only
Codifies the 'new endpoints land under `/api/v2/*`; legacy `/api/*` is retired, not parallel-maintained' practice that has governed several recent PRs (#124, #126, #130).

## What's moved
- `docs/development/di-framework-evaluation.md` → `docs/archive/di-framework-evaluation-2025.md` (with archive notice).

## mkdocs.yml updated
Adds an 'Architecture Decisions' section to the nav listing all four ADRs and the README.

## Out of scope
- Future ADRs as new decisions arise. The TEMPLATE.md + README.md make the process clear for the next author.
- Backfilling ADRs for older decisions (SQLite + Alembic, Pydantic v2, Vite over Webpack). Those can be written if/when they become contentious; right now nobody is questioning them.

## Verification
- All four ADRs render in MkDocs (verified via `mkdocs serve` would catch any missing files).
- ADR-0001 references `backend/core/service_registry.py` etc. — all paths verified to exist.
- ADR-0002 links to `docs/archive/can-service-consolidation-plan-2025.md` which is being landed by #142.
- ADR-0003 references PRs #124, #126, #130 — all merged.
- ADR-0004 references `/memories/repo/coachiq-architecture.md` which already exists.

## Refs
- 2026-05-13 ADR review (chat history)
- #142 (deletions) and #143 (rewrites) — this PR is the additive 'establish convention' half
- /memories/repo/coachiq-architecture.md (the agent-memory source for ADR-0004)