### PR TITLE
refactor(service-registry): collapse EnhancedServiceRegistry inheritance (audit A3, closes #148)

### DIFF
--- a/backend/api/routers/startup_monitoring.py
+++ b/backend/api/routers/startup_monitoring.py
@@ -14,7 +14,7 @@ from pydantic import BaseModel, Field
 from starlette.requests import Request
 
 from backend.core.dependencies import get_service_registry
-from backend.core.service_registry import EnhancedServiceRegistry
+from backend.core.service_registry import ServiceRegistry
 from backend.middleware.startup_monitoring import get_startup_monitor
 
 logger = logging.getLogger(__name__)
@@ -91,7 +91,7 @@ def _calculate_performance_grade(startup_time_ms: float, baseline_ms: float = 50
     description="Get overall startup health validation status and basic metrics.",
 )
 async def get_startup_health(
-    service_registry: Annotated[EnhancedServiceRegistry, Depends(get_service_registry)],
+    service_registry: Annotated[ServiceRegistry, Depends(get_service_registry)],
     request: Request,
 ) -> StartupHealthStatus:
     """
@@ -170,7 +170,7 @@ async def get_startup_health(
     description="Get comprehensive startup performance metrics and analysis.",
 )
 async def get_startup_metrics(
-    service_registry: Annotated[EnhancedServiceRegistry, Depends(get_service_registry)],
+    service_registry: Annotated[ServiceRegistry, Depends(get_service_registry)],
     request: Request,
 ) -> StartupPerformanceReport:
     """
@@ -285,7 +285,7 @@ async def get_startup_metrics(
     description="Get detailed timing information for all services.",
 )
 async def get_service_timings(
-    service_registry: Annotated[EnhancedServiceRegistry, Depends(get_service_registry)],
+    service_registry: Annotated[ServiceRegistry, Depends(get_service_registry)],
     request: Request,
 ) -> list[ServiceTimingInfo]:
     """

--- a/backend/core/dependencies.py
+++ b/backend/core/dependencies.py
@@ -10,7 +10,7 @@ from typing import Annotated, Any, TypeVar
 
 from fastapi import Depends, Header, HTTPException, status
 
-from backend.core.service_registry import EnhancedServiceRegistry
+from backend.core.service_registry import ServiceRegistry as _ServiceRegistryClass
 
 logger = logging.getLogger(__name__)
 
@@ -18,10 +18,10 @@ logger = logging.getLogger(__name__)
 T = TypeVar("T")
 
 # Module-level service registry instance
-_service_registry: EnhancedServiceRegistry | None = None
+_service_registry: _ServiceRegistryClass | None = None
 
 
-def initialize_service_registry(registry: EnhancedServiceRegistry) -> None:
+def initialize_service_registry(registry: _ServiceRegistryClass) -> None:
     """
     Initialize the module-level service registry.
 
@@ -35,7 +35,7 @@ def initialize_service_registry(registry: EnhancedServiceRegistry) -> None:
     logger.info("Service registry initialized for dependency injection")
 
 
-def get_service_registry() -> EnhancedServiceRegistry:
+def get_service_registry() -> _ServiceRegistryClass:
     """
     Get the service registry instance.
 
@@ -414,7 +414,7 @@ MigrationSafetyValidator = Annotated[Any, Depends(get_migration_safety_validator
 # Predictive maintenance
 PredictiveMaintenanceService = Annotated[Any, Depends(get_predictive_maintenance_service)]
 
-ServiceRegistry = Annotated[EnhancedServiceRegistry, Depends(get_service_registry)]
+ServiceRegistry = Annotated[_ServiceRegistryClass, Depends(get_service_registry)]
 
 
 # ==================================================================================

--- a/backend/core/safety_registry.py
+++ b/backend/core/safety_registry.py
@@ -15,12 +15,12 @@ from typing import Any, Dict, List, Optional, Set
 
 from backend.core.safety_interfaces import SafetyCapable, SafetyClassification, SafetyStatus
 from backend.core.service_dependency_resolver import DependencyType, ServiceDependency
-from backend.core.service_registry import EnhancedServiceRegistry
+from backend.core.service_registry import ServiceRegistry
 
 logger = logging.getLogger(__name__)
 
 
-class SafetyServiceRegistry(EnhancedServiceRegistry):
+class SafetyServiceRegistry(ServiceRegistry):
     """
     ServiceRegistry with safety-specific extensions for vehicle control systems.
 

--- a/backend/core/service_registration_database_update.py
+++ b/backend/core/service_registration_database_update.py
@@ -4,12 +4,12 @@ import logging
 from typing import Any
 
 from backend.core.service_dependency_resolver import DependencyType, ServiceDependency
-from backend.core.service_registry import EnhancedServiceRegistry
+from backend.core.service_registry import ServiceRegistry
 
 logger = logging.getLogger(__name__)
 
 
-def register_database_update_services(service_registry: EnhancedServiceRegistry) -> None:
+def register_database_update_services(service_registry: ServiceRegistry) -> None:
     """
     Register database update services - TARGET PATTERN ONLY.
 

--- a/backend/core/service_registry.py
+++ b/backend/core/service_registry.py
@@ -58,164 +58,98 @@ class ServiceStatus(Enum):
     STOPPED = "STOPPED"
 
 
+logger = logging.getLogger(__name__)
+
+
+class ServiceDefinition:
+    """Enhanced service definition with dependency metadata."""
+
+    def __init__(  # noqa: PLR0913 -- intentional rich-metadata constructor
+        self,
+        name: str,
+        init_func: Callable[[], Any],
+        dependencies: list[str | ServiceDependency] | None = None,
+        tags: set[str] | None = None,
+        description: str | None = None,
+        health_check: Callable[[], bool] | None = None,
+    ):
+        self.name = name
+        self.init_func = init_func
+        self.tags = tags or set()
+        self.description = description
+        self.health_check = health_check
+
+        # Convert simple string dependencies to ServiceDependency objects
+        self.dependencies: list[ServiceDependency] = []
+        if dependencies:
+            for dep in dependencies:
+                if isinstance(dep, str):
+                    self.dependencies.append(ServiceDependency(name=dep))
+                else:
+                    self.dependencies.append(dep)
+
+
 class ServiceRegistry:
     """
-    Centralized service registry with dependency management and lifecycle orchestration.
+    Centralized service registry with dependency management and lifecycle
+    orchestration.
 
-    Replaces the service locator pattern with explicit dependency injection
-    and provides structured startup/shutdown for safety-critical systems.
+    Resolves a directed-acyclic dependency graph between services, brings
+    them up in topologically-correct stages with parallel execution within
+    each stage, monitors health, and orchestrates ordered shutdown.
+
+    Improvements over the bare service-locator pattern:
+    - Advanced dependency resolver with circular detection
+    - Better error messages with available services
+    - Dependency visualization and reporting
+    - Runtime dependency validation
+    - Service tagging and categorization
+
+    Used to be split into a base ``ServiceRegistry`` (legacy
+    ``register_startup_stage`` API) and a subclass
+    ``EnhancedServiceRegistry``. The base had no remaining callers and
+    its startup methods were silently inert when the subclass was used,
+    so the two were collapsed (audit cycle 2026-05-13, PR A3).
     """
 
     def __init__(self):
+        # Inlined from the former base ``ServiceRegistry`` class.
         self._services: dict[str, Any] = {}
         self._service_status: dict[str, ServiceStatus] = {}
         self._background_tasks: set[asyncio.Task] = set()
-        self._startup_stages: list[list[tuple[str, Callable[[], Any], list[str]]]] = []
         self._startup_time: float | None = None
         self._shutdown_complete: bool = False
 
-    def register_startup_stage(self, services: list[tuple[str, Callable[[], Any], list[str]]]):
-        """
-        Register a startup stage with services and their dependencies.
+        # Enhanced-specific state.
+        self._resolver = ServiceDependencyResolver()
+        self._service_definitions: dict[str, ServiceDefinition] = {}
+        self._startup_errors: dict[str, Exception] = {}
+        self._dependency_report: str | None = None
+        self._lifecycle_manager = ServiceLifecycleManager()
+        self._service_timings: dict[str, float] = {}  # Track individual service startup times
 
-        Args:
-            services: List of (service_name, init_function, dependencies) tuples
-        """
-        self._startup_stages.append(services)
+    # ------------------------------------------------------------------ #
+    # Service-instance accessors (inlined from the former base class).
+    # ------------------------------------------------------------------ #
 
-    async def startup(self):
-        """
-        Execute orchestrated startup with dependency resolution and parallel execution.
+    def has_service(self, service_name: str) -> bool:
+        """Check if a service is registered and healthy."""
+        return (
+            service_name in self._services
+            and self._service_status.get(service_name) == ServiceStatus.HEALTHY
+        )
 
-        Raises:
-            RuntimeError: If any service fails to initialize
-        """
-        start_time = time.perf_counter()
+    def get_service(self, service_name: str) -> Any:
+        """Get a service by name. Raises if not registered + healthy."""
+        if not self.has_service(service_name):
+            msg = f"Service '{service_name}' not available"
+            raise RuntimeError(msg)
+        return self._services[service_name]
 
-        try:
-            total_services = sum(len(stage) for stage in self._startup_stages)
-
-            for stage_num, services_in_stage in enumerate(self._startup_stages):
-                await self._execute_startup_stage(stage_num, services_in_stage)
-
-            self._startup_time = time.perf_counter() - start_time
-
-        except Exception as e:
-            # Attempt cleanup of partially initialized services
-            await self._emergency_cleanup()
-            raise
-
-    async def _execute_startup_stage(
-        self, stage_num: int, services_in_stage: list[tuple[str, Callable, list[str]]]
-    ):
-        """Execute a single startup stage with dependency resolution."""
-        if not services_in_stage:
-            return
-
-        # Build dependency graph for this stage
-        sorter = TopologicalSorter()
-        stage_services = {}
-
-        for name, init_func, deps in services_in_stage:
-            # Validate dependencies are available
-            for dep in deps:
-                if (
-                    dep not in self._services
-                    or self._service_status.get(dep) != ServiceStatus.HEALTHY
-                ):
-                    raise RuntimeError(
-                        f"Service '{name}' dependency '{dep}' not available or not healthy"
-                    )
-
-            sorter.add(name, *deps)
-            stage_services[name] = init_func
-            self._service_status[name] = ServiceStatus.PENDING
-
-        # Execute in dependency order with parallelization
-        sorter.prepare()
-        while sorter.is_active():
-            ready_services = sorter.get_ready()
-            if ready_services:
-                # Start ready services in parallel
-                tasks = [self._start_service(name, stage_services[name]) for name in ready_services]
-                await asyncio.gather(*tasks)
-                sorter.done(*ready_services)
-
-    async def _start_service(self, name: str, init_func: Callable[[], Any]):
-        """
-        Start individual service with proper error handling and background task management.
-
-        Args:
-            name: Service name
-            init_func: Service initialization function
-
-        Raises:
-            Exception: Re-raises any initialization errors for fail-fast behavior
-        """
-        try:
-            self._service_status[name] = ServiceStatus.STARTING
-
-            # Initialize the service
-            if asyncio.iscoroutinefunction(init_func):
-                service = await init_func()
-            else:
-                service = init_func()
-
-            self._services[name] = service
-
-            # Start background tasks if service supports them
-            if hasattr(service, "start_background_tasks"):
-                task = asyncio.create_task(
-                    service.start_background_tasks(), name=f"{name}_background_tasks"
-                )
-                self._background_tasks.add(task)
-                task.add_done_callback(self._background_tasks.discard)
-
-            self._service_status[name] = ServiceStatus.HEALTHY
-
-        except Exception as e:
-            self._service_status[name] = ServiceStatus.FAILED
-            raise  # Fail-fast for startup errors
-
-    async def shutdown(self):
-        """
-        Graceful shutdown in reverse order of startup.
-
-        Cancels background tasks first, then shuts down services in reverse order.
-        """
-        if self._shutdown_complete:
-            return
-
-        shutdown_start = time.perf_counter()
-
-        try:
-            # Cancel background tasks first
-            if self._background_tasks:
-                for task in self._background_tasks:
-                    if not task.done():
-                        task.cancel()
-
-                # Wait for tasks to complete/cancel with timeout
-                try:
-                    await asyncio.wait_for(
-                        asyncio.gather(*self._background_tasks, return_exceptions=True), timeout=5.0
-                    )
-                except TimeoutError:
-                    pass
-
-            # Shutdown services in reverse order of startup
-            for stage in reversed(self._startup_stages):
-                await self._shutdown_stage(stage)
-
-            self._shutdown_complete = True
-
-        except Exception as e:
-            pass
-
-    async def _shutdown_stage(self, services_in_stage: list[tuple[str, Callable, list[str]]]):
-        """Shutdown services in a stage."""
-        for service_name, _, _ in reversed(services_in_stage):
-            await self._shutdown_service(service_name)
+    # ------------------------------------------------------------------ #
+    # Per-service shutdown helpers used by ``shutdown_all`` and
+    # ``stop_service`` below. Inlined from the former base class.
+    # ------------------------------------------------------------------ #
 
     async def _shutdown_service(self, name: str):
         """Shutdown individual service.
@@ -252,71 +186,9 @@ class ServiceRegistry:
             except Exception:
                 pass
 
-    def has_service(self, service_name: str) -> bool:
-        """Check if a service is registered and healthy."""
-        return (
-            service_name in self._services
-            and self._service_status.get(service_name) == ServiceStatus.HEALTHY
-        )
-
-    def get_service(self, service_name: str) -> Any:
-        """Get a service by name."""
-        if not self.has_service(service_name):
-            raise RuntimeError(f"Service '{service_name}' not available")
-        return self._services[service_name]
-
-
-logger = logging.getLogger(__name__)
-
-
-class ServiceDefinition:
-    """Enhanced service definition with dependency metadata."""
-
-    def __init__(
-        self,
-        name: str,
-        init_func: Callable[[], Any],
-        dependencies: list[str | ServiceDependency] | None = None,
-        tags: set[str] | None = None,
-        description: str | None = None,
-        health_check: Callable[[], bool] | None = None,
-    ):
-        self.name = name
-        self.init_func = init_func
-        self.tags = tags or set()
-        self.description = description
-        self.health_check = health_check
-
-        # Convert simple string dependencies to ServiceDependency objects
-        self.dependencies: list[ServiceDependency] = []
-        if dependencies:
-            for dep in dependencies:
-                if isinstance(dep, str):
-                    self.dependencies.append(ServiceDependency(name=dep))
-                else:
-                    self.dependencies.append(dep)
-
-
-class EnhancedServiceRegistry(ServiceRegistry):
-    """
-    ServiceRegistry with enhanced dependency resolution capabilities.
-
-    Improvements:
-    - Advanced dependency resolver with circular detection
-    - Better error messages with available services
-    - Dependency visualization and reporting
-    - Runtime dependency validation
-    - Service tagging and categorization
-    """
-
-    def __init__(self):
-        super().__init__()
-        self._resolver = ServiceDependencyResolver()
-        self._service_definitions: dict[str, ServiceDefinition] = {}
-        self._startup_errors: dict[str, Exception] = {}
-        self._dependency_report: str | None = None
-        self._lifecycle_manager = ServiceLifecycleManager()
-        self._service_timings: dict[str, float] = {}  # Track individual service startup times
+    # ------------------------------------------------------------------ #
+    # Enhanced registration + startup surface.
+    # ------------------------------------------------------------------ #
 
     def register_service(
         self,
@@ -909,26 +781,13 @@ class EnhancedServiceRegistry(ServiceRegistry):
             raise
 
     # ------------------------------------------------------------------ #
-    # Lifecycle + health surface for ESR-registered services.
-    #
-    # The base ``ServiceRegistry`` operates on the legacy
-    # ``register_startup_stage`` model and stores services in
-    # ``_startup_stages``. ``EnhancedServiceRegistry`` registers via
-    # ``register_service`` into ``_service_definitions`` and resolves
-    # stages on demand inside ``startup_all`` -- so the inherited
-    # ``shutdown()`` (which iterates ``_startup_stages``) is a silent
-    # no-op for ESR users. Likewise ``SafetyService._health_monitoring_loop``
-    # calls ``service_registry.get_health_summary()`` which previously
-    # only existed on ``backend/monitoring/health_probe_metrics.py`` --
-    # the safety monitor would crash on its first iteration in any
-    # ESR-based deployment.
-    #
-    # The four methods below close those gaps. Names match what the rest
-    # of the codebase (and the integration tests) already expect.
+    # Lifecycle + health surface used by SafetyService and external
+    # health-probe consumers (``SafetyService._health_monitoring_loop``
+    # calls ``service_registry.get_health_summary()`` on every tick).
     # ------------------------------------------------------------------ #
 
     async def shutdown_all(self) -> None:
-        """Graceful shutdown of all ESR-registered services in reverse stage order.
+        """Graceful shutdown of all registered services in reverse stage order.
 
         Cancels background tasks first, then walks the resolved
         dependency stages back-to-front (latest started, first stopped).
@@ -939,7 +798,7 @@ class EnhancedServiceRegistry(ServiceRegistry):
         if self._shutdown_complete:
             return
 
-        # Cancel background tasks first (mirror the base class behaviour).
+        # Cancel background tasks first.
         if self._background_tasks:
             for task in self._background_tasks:
                 if not task.done():

--- a/backend/main.py
+++ b/backend/main.py
@@ -126,7 +126,7 @@ SERVER_START_TIME = time.time()
 
 async def _configure_service_startup_stages(service_registry):
     """
-    Configure EnhancedServiceRegistry with rich service definitions and dependencies.
+    Configure ServiceRegistry with rich service definitions and dependencies.
 
     This function uses the enhanced service registry features to provide:
     - Automatic dependency resolution and stage calculation
@@ -135,7 +135,7 @@ async def _configure_service_startup_stages(service_registry):
     - Better error messages and circular dependency detection
     """
 
-    # Define services with rich metadata using EnhancedServiceRegistry
+    # Define services with rich metadata using ServiceRegistry
     # The registry will automatically calculate stages based on dependencies
 
     # Core Configuration Services
@@ -1490,9 +1490,9 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     """
     logger.info("Starting coachiq backend application")
 
-    # Initialize EnhancedServiceRegistry for advanced dependency management
-    # Use SafetyServiceRegistry for guardrail-tier classification + emergency stop
-    # ("safety" naming is historical -- see ADR-0004)
+    # Initialize ServiceRegistry for advanced dependency management.
+    # Use SafetyServiceRegistry for guardrail-tier classification + emergency
+    # stop ("safety" naming is historical -- see ADR-0004).
     service_registry = SafetyServiceRegistry()
 
     # Initialize the module-level service registry for dependency injection
@@ -1507,7 +1507,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         # Configure service startup stages with explicit dependencies
         await _configure_service_startup_stages(service_registry)
 
-        # Execute orchestrated startup via EnhancedServiceRegistry
+        # Execute orchestrated startup via ServiceRegistry
         await service_registry.startup_all()
 
         # CRITICAL: Inject service_registry into safety_service after startup to avoid circular dependency

--- a/backend/repositories/service_registration.py
+++ b/backend/repositories/service_registration.py
@@ -3,7 +3,7 @@ Repository Service Registration
 
 Factory functions and registration helpers that register the
 repositories (which replaced the removed ``AppState`` monolith) with
-the ``EnhancedServiceRegistry``.
+the ``ServiceRegistry``.
 """
 
 import logging
@@ -158,7 +158,7 @@ def register_repositories_with_service_registry(service_registry: Any) -> None:
     ``AppState`` class.
 
     Args:
-        service_registry: The EnhancedServiceRegistry instance
+        service_registry: The ServiceRegistry instance
     """
 
     # Register EntityStateRepository

--- a/backend/test_service_startup.py
+++ b/backend/test_service_startup.py
@@ -7,7 +7,7 @@ import asyncio
 import logging
 
 from backend.core.service_dependency_resolver import DependencyType, ServiceDependency
-from backend.core.service_registry import EnhancedServiceRegistry
+from backend.core.service_registry import ServiceRegistry
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 async def test_basic_startup():
     """Test basic service startup."""
-    registry = EnhancedServiceRegistry()
+    registry = ServiceRegistry()
 
     # Register a simple service with no dependencies
     def create_simple_service():
@@ -46,7 +46,7 @@ async def test_basic_startup():
 
 async def test_app_state_service():
     """Test registering app_state_service specifically."""
-    registry = EnhancedServiceRegistry()
+    registry = ServiceRegistry()
 
     # Mock dependencies
     def create_mock_repo(name):

--- a/scripts/ci-quality-gate.sh
+++ b/scripts/ci-quality-gate.sh
@@ -19,7 +19,7 @@ RESET="\033[0m"
 # gate's job is to stop the count from going UP (a ratchet); fixing actual
 # pyright errors lower the count and the script will print a green message
 # nudging you to update the baseline downward.
-EXPECTED_PYRIGHT_ERRORS=1447  # Ratcheted 2026-05-13 (PR A2, audit cycle 2026-05-13). Dead-code removal of backend/services/brake_safety_monitor.py (-311 LOC) shed 5 pyright errors. Hardened ratchet (#117) caught the drop -- working as designed.
+EXPECTED_PYRIGHT_ERRORS=1446  # Ratcheted 2026-05-14 (PR A3 on top of A2, audit cycle 2026-05-13). A2 took the baseline 1452->1447 by deleting brake_safety_monitor.py; A3's collapse of EnhancedServiceRegistry inheritance sheds 1 more error -> 1446. Hardened ratchet (#117) catches the drop -- working as designed.
 EXPECTED_FRONTEND_TS_ERRORS=0  # Ratcheted 2026-05-12 to 0 by PR #110 (DatabaseManagementTab + can-sniffer + useCANScanWebSocket generic). Any new TS error is a hard fail.
 EXPECTED_FRONTEND_ESLINT_ERRORS=648  # Captured 2026-05-12 by PR #117. Whole-project ESLint baseline; the diff-aware gate (eslint_diff_check.py in Stage 1) catches NEW issues per-line, this baseline is the project-wide ratchet.
 

--- a/tests/safety_validation_test.py
+++ b/tests/safety_validation_test.py
@@ -13,7 +13,7 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 
 from backend.core.config import get_settings
-from backend.core.service_registry import EnhancedServiceRegistry
+from backend.core.service_registry import ServiceRegistry
 from backend.middleware.validation import RuntimeValidationMiddleware, SchemaValidationMixin
 from backend.schemas import BulkOperationSchemaV2, ControlCommandSchemaV2, EntitySchemaV2
 from backend.schemas.schema_exporter import ZodSchemaExporter
@@ -32,7 +32,7 @@ class TestSafetySystemValidation:
 
         os.environ["COACHIQ_FEATURES__DOMAIN_API_V2"] = "true"
 
-        service_registry = EnhancedServiceRegistry()
+        service_registry = ServiceRegistry()
         # For testing, we'll mock the services
         return service_registry
 

--- a/tests/test_safety_integration.py
+++ b/tests/test_safety_integration.py
@@ -16,7 +16,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from backend.core.service_registry import EnhancedServiceRegistry, ServiceStatus
+from backend.core.service_registry import ServiceRegistry, ServiceStatus
 from backend.services.safety_service import SafetyInterlock, SafetyService
 
 
@@ -235,7 +235,7 @@ def rv_system_config():
 def integrated_system(rv_system_config):
     """Create integrated RV system for testing.
 
-    NOTE: ``EnhancedServiceRegistry.register_service`` takes
+    NOTE: ``ServiceRegistry.register_service`` takes
     ``init_func`` (callable that returns the service) and ``tags``
     (set of strings), NOT the legacy ``service`` / ``is_critical``
     kwargs the previous fixture passed. Pre-instantiate each
@@ -246,7 +246,7 @@ def integrated_system(rv_system_config):
     late-binding closure trap (otherwise every lambda would
     capture the loop variable and return the *last* service).
     """
-    service_registry = EnhancedServiceRegistry()
+    service_registry = ServiceRegistry()
 
     services: dict[str, RealWorldService] = {}
     for name, config in rv_system_config.items():
@@ -312,7 +312,7 @@ class TestSystemStartupShutdown:
     async def test_startup_with_failure_recovery(self, integrated_system):
         """Test startup with service failure and recovery.
 
-        ``EnhancedServiceRegistry.startup_all`` aborts the whole startup
+        ``ServiceRegistry.startup_all`` aborts the whole startup
         sweep on any service failure (the registry can't reason about
         whether a downstream consumer of a failed service can cope).
         That's the right behaviour for a multiplex orchestration layer:
@@ -351,7 +351,7 @@ class TestSystemStartupShutdown:
             )
 
         # Verify failed service was actually attempted (its startup() raised
-        # the exception we expected). Note: ``EnhancedServiceRegistry``'s
+        # the exception we expected). Note: ``ServiceRegistry``'s
         # ``_emergency_cleanup`` walks every instantiated service after the
         # abort, calling ``_shutdown_service`` which overwrites the FAILED
         # status on the failed entry to STOPPED. The failure signal is


### PR DESCRIPTION
PR A3 of the [architectural-audit-2026-05-13 cycle (#145)](#145).
Closes #148.

## Why

`backend/core/service_registry.py` defined two registry classes via inheritance:

- `class ServiceRegistry` (lines 56–263, ~210 LOC) — old `register_startup_stage` /
  `_startup_stages` model. **No live instantiation in the repo.**
- `class EnhancedServiceRegistry(ServiceRegistry)` (lines 295–1037) — the class
  everyone actually uses: `register_service` / `_service_definitions` /
  on-demand stage resolution via `startup_all()`.

The base class's startup methods were inert when the subclass took over —
the file's own block comment admitted as much. The "Enhanced" prefix was a
refactoring leftover.

## What changed

- Deleted the entire base class.
- Inlined the still-used base methods into the subclass: `__init__` state
  (`_services`, `_service_status`, `_background_tasks`, `_startup_time`,
  `_shutdown_complete`), `has_service`, `get_service`, `_shutdown_service`,
  `_emergency_cleanup`.
- Renamed `EnhancedServiceRegistry` → `ServiceRegistry`.
- Removed the "ESR vs base" commentary block (no longer relevant).

## Importer updates (9 files)

```
backend/main.py
backend/test_service_startup.py
backend/api/routers/startup_monitoring.py
backend/repositories/service_registration.py
backend/core/safety_registry.py            (SafetyServiceRegistry parent)
backend/core/service_registration_database_update.py
backend/core/dependencies.py               (special-cased -- see below)
tests/safety_validation_test.py
tests/test_safety_integration.py
```

### Special case

`backend/core/dependencies.py` defined a type alias

```python
ServiceRegistry = Annotated[EnhancedServiceRegistry, Depends(get_service_registry)]
```

which would have collided with the renamed class. Resolved by importing the
class as `_ServiceRegistryClass` and keeping the public type-alias name
(which two routers — `protocols.py`, `main.py` — consume).

## Verification

```
$ python -c "from backend.core.service_registry import ServiceRegistry; r = ServiceRegistry(); print(hasattr(r, 'register_service'), hasattr(r, 'shutdown_all'))"
True True

$ poetry run pytest --no-cov -q
812 passed, 1 failed*, 28 skipped
```

`*` `test_force_queue_processing` — known pre-existing pollution (same as
A1/A2).

```
$ grep -rn EnhancedServiceRegistry backend/ tests/ --include='*.py' | grep -v __pycache__
backend/core/service_registry.py:105: ``EnhancedServiceRegistry``. The base had no remaining...
```

Only the historical-note docstring inside the new class remains — that
intentionally explains the rename for future readers.

## LOC delta

| File | Before | After | Δ |
|------|-------:|------:|--:|
| `backend/core/service_registry.py` | 1037 | 909 | **−128** |
| Net across all 10 files | | | **−141** |

## Risk

Low. Mechanical inline + rename. No behavior change. Tests prove it.

## Tracker

Refs #145, closes #148.
