### PR TITLE
fix(api): include both 'detail' and 'error.{code,message}' in error responses (ADR-0005, audit A5, closes #150)

### DIFF
--- a/backend/core/exception_handlers.py
+++ b/backend/core/exception_handlers.py
@@ -55,19 +55,35 @@ def create_error_response(
     details: dict[str, Any] | None = None,
     request_id: str | None = None,
 ) -> JSONResponse:
-    """Create standardized error response."""
-    content = {
-        "error": {
-            "code": error_code,
-            "message": message,
-        }
+    """Create standardized error response.
+
+    Wire format follows ADR-0005: every error response carries BOTH the
+    FastAPI-default ``detail`` field (so OpenAPI clients and the React UI
+    that read ``response.detail`` keep working) AND the structured
+    ``error.{code,message,details?,request_id?}`` envelope (so callers
+    that want to dispatch on ``error.code`` keep working). The two
+    fields are kept in sync.
+    """
+    error_payload: dict[str, Any] = {
+        "code": error_code,
+        "message": message,
     }
 
     if details:
-        content["error"]["details"] = details
+        error_payload["details"] = details
 
     if request_id:
-        content["error"]["request_id"] = request_id
+        error_payload["request_id"] = request_id
+
+    content: dict[str, Any] = {
+        # Top-level FastAPI-default field; consumed by the React frontend's
+        # ``handleApiResponse`` (frontend/src/api/client.ts) and any generated
+        # OpenAPI client. See ADR-0005.
+        "detail": message,
+        # Structured envelope; consumed by callers that switch on the
+        # specific error code (e.g. ``HTTP_404`` vs ``DATABASE_INTEGRITY_ERROR``).
+        "error": error_payload,
+    }
 
     return JSONResponse(status_code=status_code, content=content)
 

--- a/docs/adr/ADR-0005-http-error-response-envelope.md
+++ b/docs/adr/ADR-0005-http-error-response-envelope.md
@@ -1,0 +1,156 @@
+# ADR-0005: HTTP error responses include both `detail` (FastAPI-default) and `error.{code,message}` (structured)
+
+## Status
+
+**Accepted**, 2026-05-13. Architectural-audit cycle 2026-05-13, PR A5
+(closes #150).
+
+## Context
+
+`backend/core/exception_handlers.py` wraps every HTTP error response in
+a custom envelope:
+
+```json
+{
+  "error": {
+    "code": "HTTP_404",
+    "message": "Account not found",
+    "details": { ... },
+    "request_id": "..."
+  }
+}
+```
+
+instead of FastAPI's default `{"detail": "Account not found"}`. The
+custom envelope was introduced without an ADR; the audit at the close
+of the 2026-05-12 test-restoration cycle flagged it because new tests
+discover the contract on contact (see `audit-2026-05-12.md` lesson
+"Custom error envelope vs FastAPI default").
+
+The audit then turned up a real production bug. The frontend
+(`frontend/src/api/client.ts:118-120`) reads `errorDetails.detail`:
+
+```ts
+errorDetails = await response.json() as APIError;
+errorMessage = errorDetails.detail || errorMessage;
+```
+
+against an `APIError` type whose first field is `detail: string`
+(`frontend/src/api/types.ts:307`). But the backend never returns
+`detail` -- it returns `error.message`. So `errorDetails.detail` has
+always been `undefined`, and every error toast in the React UI has
+been a generic `"API Error: <status>"` since the envelope landed,
+rather than the actual server message. The frontend silently degrades
+because the optional-chain default kicks in.
+
+Eight other frontend sites consume `error.detail` directly (5x in
+`MFASetup.tsx`, 1x each in `MFAVerification.tsx`, `MFAManagement.tsx`,
+`login-form.tsx`). All of those are also silently broken.
+
+Four backend tests assert against the structured envelope
+(`tests/unit/test_database_management_api.py` x2,
+`tests/contract/test_domain_api_spec_validation.py` x2). Those pass --
+they exercise the wire format the backend actually emits.
+
+## Decision
+
+Error responses MUST include BOTH:
+
+- `detail`: a flat string field at the top level, FastAPI-default
+  shape, equal to the human-readable message.
+- `error`: the structured object (`{code, message, details?, request_id?}`)
+  the codebase already produces.
+
+```json
+{
+  "detail": "Account not found",
+  "error": {
+    "code": "HTTP_404",
+    "message": "Account not found",
+    "details": { ... },
+    "request_id": "..."
+  }
+}
+```
+
+Concretely: update `backend.core.exception_handlers.create_error_response`
+to write `detail` alongside the existing `error` object. No new code path,
+no behavior change beyond the wire-format addition.
+
+## Consequences
+
+### Becomes easier
+
+- Frontend `handleApiResponse` and the eight `error.detail` consumers
+  start receiving real server messages without code changes.
+- Generated OpenAPI clients that follow the FastAPI default
+  (`response.detail`) work out of the box.
+- Tests can assert on either shape; the four existing assertions on
+  `error.message` / `error.code` keep passing.
+- New routes do not need to learn a custom convention; they continue
+  using FastAPI's exception machinery and our handler does the right
+  thing.
+
+### Becomes harder
+
+- Every error response gains ~30-50 bytes of redundant wire format.
+  Acceptable -- error responses are not a hot path.
+- New backend code that constructs error responses outside
+  `create_error_response()` (currently none, but possible) has to
+  remember to populate both fields. Mitigation: keep
+  `create_error_response()` as the only sanctioned construction
+  site; any future bypass should be PR-rejected.
+
+### Cannot do anymore
+
+- Cannot remove the `error.{code,message}` envelope without breaking
+  the four existing test assertions and any external consumer that
+  parses it.
+- Cannot remove `detail` without re-breaking the React UI.
+
+## Alternatives considered
+
+- **Option A (revert to FastAPI default `{detail}` only)**: smallest
+  wire format, fixes the frontend bug. Rejected because it loses the
+  structured `error.code` (`HTTP_404`, `VALIDATION_ERROR`,
+  `DATABASE_INTEGRITY_ERROR`, ...) that callers can switch on
+  programmatically. The four existing test assertions would also need
+  rewriting.
+
+- **Option B (keep current envelope, fix frontend `APIError` type +
+  client to read `error.message`)**: fixes the frontend bug from the
+  other direction. Rejected because it requires updating eight
+  frontend sites + the type definition, and offers no benefit over
+  Option D for consumers expecting FastAPI defaults (e.g. generated
+  OpenAPI clients).
+
+- **Option C (RFC 7807 `application/problem+json`: `type`, `title`,
+  `status`, `detail`, `instance`)**: the standard answer for
+  structured errors. Rejected because it would break every existing
+  consumer (frontend AND tests) for the sake of standards-compliance,
+  and CoachIQ has no out-of-tree API consumers that would benefit
+  from the standardization (per the threat model in
+  `coachiq-architecture.md`, the surface is the React UI behind
+  Caddy + occasional integration tests). Reconsider if a third-party
+  consumer appears.
+
+- **Option D (this ADR -- include both shapes)**: smallest possible
+  change. Backward-compatible with both contracts. Wire format gains
+  one field per error response. Picked.
+
+## Revisit conditions
+
+- A third-party API consumer (mobile app, integration partner, public
+  API) appears -- the choice between Option C (standards-compliance)
+  and the current hybrid should be re-evaluated.
+- The structured `error.code` field is no longer used by any caller --
+  Option A becomes attractive then.
+
+## See also
+
+- `backend/core/exception_handlers.py` -- the only construction site for
+  HTTP error responses.
+- `frontend/src/api/client.ts` -- the consumer that this ADR unblocks.
+- `audit-2026-05-12.md` -- "Custom error envelope vs FastAPI default"
+  lesson that prompted this audit.
+- ADR-0003 (api-v2-only-no-legacy) -- companion API-shape decision.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -56,6 +56,9 @@ Keep ADRs short -- 50-150 lines is typical. If you find yourself writing
 - [ADR-0004](ADR-0004-coachiq-is-not-the-safety-system.md) -- CoachIQ
   is API guardrails for an OEM controller, not the vehicle safety
   system itself. **Read this first.**
+- [ADR-0005](ADR-0005-http-error-response-envelope.md) -- HTTP error
+  responses include both `detail` (FastAPI-default) and `error.{code,
+  message}` (structured) for backward-compatibility with both contracts.
 
 ## Status
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -304,10 +304,27 @@ export interface WebSocketHandlers {
 }
 
 // API Error Response
+//
+// The CoachIQ backend follows ADR-0005: every error response carries
+// BOTH a top-level `detail` (FastAPI default) AND a structured
+// `error.{code,message,details?,request_id?}` envelope.
+//
+// Most callers should read `detail` (already wired in `client.ts`'s
+// `handleApiResponse`). Only switch on `error.code` when you need to
+// dispatch on specific failure modes.
 export interface APIError {
   detail: string;
-  status_code: number;
-  timestamp: string;
+  error?: {
+    code: string;
+    message: string;
+    details?: Record<string, unknown>;
+    request_id?: string;
+  };
+  // Legacy fields kept for backward-compat with older response shapes
+  // observed by integration tests; new backend responses do not include
+  // these at the top level.
+  status_code?: number;
+  timestamp?: string;
 }
 
 // Generic API Response Wrapper

--- a/tests/core/test_exception_handlers.py
+++ b/tests/core/test_exception_handlers.py
@@ -1,0 +1,95 @@
+"""
+Tests for ``backend.core.exception_handlers.create_error_response``.
+
+Validates ADR-0005: every error response includes both the FastAPI-default
+``detail`` field and the structured ``error.{code,message,details?,request_id?}``
+envelope.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from backend.core.exception_handlers import create_error_response
+
+
+@pytest.mark.unit
+class TestErrorResponseEnvelope:
+    """ADR-0005: ``detail`` and ``error.*`` are both present."""
+
+    def _payload(self, **kwargs) -> dict:
+        response = create_error_response(**kwargs)
+        return json.loads(response.body.decode())
+
+    def test_detail_field_present_at_top_level(self):
+        """``detail`` is the FastAPI-default field (read by the React UI)."""
+        body = self._payload(
+            status_code=404,
+            error_code="HTTP_404",
+            message="Account not found",
+        )
+        assert body["detail"] == "Account not found"
+
+    def test_structured_error_envelope_present(self):
+        """``error.{code,message}`` is the structured envelope."""
+        body = self._payload(
+            status_code=404,
+            error_code="HTTP_404",
+            message="Account not found",
+        )
+        assert body["error"]["code"] == "HTTP_404"
+        assert body["error"]["message"] == "Account not found"
+
+    def test_detail_and_error_message_stay_in_sync(self):
+        """The two human-readable strings are always equal."""
+        body = self._payload(
+            status_code=400,
+            error_code="VALIDATION_ERROR",
+            message="Field 'email' is required",
+        )
+        assert body["detail"] == body["error"]["message"]
+
+    def test_optional_details_only_in_envelope(self):
+        """``details`` lives only inside ``error``; ``detail`` stays a string."""
+        body = self._payload(
+            status_code=422,
+            error_code="VALIDATION_ERROR",
+            message="Validation failed",
+            details={"errors": [{"field": "email", "message": "required"}]},
+        )
+        assert body["error"]["details"] == {"errors": [{"field": "email", "message": "required"}]}
+        # detail must NOT be turned into a dict; FastAPI clients expect a string.
+        assert isinstance(body["detail"], str)
+        assert body["detail"] == "Validation failed"
+
+    def test_optional_request_id_only_in_envelope(self):
+        """``request_id`` is metadata; lives only inside ``error``."""
+        body = self._payload(
+            status_code=500,
+            error_code="INTERNAL_ERROR",
+            message="Something failed",
+            request_id="req-abc-123",
+        )
+        assert body["error"]["request_id"] == "req-abc-123"
+        assert "request_id" not in body  # not at top level
+
+    def test_no_optional_fields_when_unset(self):
+        """``details`` and ``request_id`` are only present when supplied."""
+        body = self._payload(
+            status_code=404,
+            error_code="HTTP_404",
+            message="Account not found",
+        )
+        assert "details" not in body["error"]
+        assert "request_id" not in body["error"]
+
+    def test_status_code_propagates_to_response(self):
+        """The ``status_code`` argument becomes the HTTP status code."""
+        response = create_error_response(
+            status_code=418,
+            error_code="HTTP_418",
+            message="I'm a teapot",
+        )
+        assert response.status_code == 418


### PR DESCRIPTION
PR A5 of the [architectural-audit-2026-05-13 cycle (#145)](#145).
Closes #150.

## Why

`backend/core/exception_handlers.py` wraps every HTTP error response in a
custom envelope:

```json
{"error": {"code": "HTTP_404", "message": "Account not found", ...}}
```

instead of FastAPI's default `{"detail": "Account not found"}`. The custom
envelope was introduced without an ADR; the audit at the close of the
2026-05-12 cycle flagged it because new tests discover the contract on
contact (audit memo lesson "Custom error envelope vs FastAPI default").

**The audit then turned up a real production bug.** The frontend
(`frontend/src/api/client.ts:118-120`) reads:

```ts
errorDetails = await response.json() as APIError;
errorMessage = errorDetails.detail || errorMessage;
```

against an `APIError` type whose first field is `detail: string`
(`frontend/src/api/types.ts:307`). But the backend never returned `detail` —
it returned `error.message`. So `errorDetails.detail` was **always** `undefined`,
and **every error toast in the React UI has been a generic "API Error: <status>"**
since the envelope landed, instead of the actual server message.

Eight other frontend sites consume `error.detail` directly:
- `frontend/src/components/mfa/MFASetup.tsx` × 5
- `frontend/src/components/mfa/MFAVerification.tsx` × 1
- `frontend/src/components/mfa/MFAManagement.tsx` × 1
- `frontend/src/components/login-form.tsx` × 1

All silently broken in the same way.

## What changed

| File | Change |
|------|--------|
| [`docs/adr/ADR-0005-http-error-response-envelope.md`](docs/adr/ADR-0005-http-error-response-envelope.md) | new ADR — walks through Options A/B/C/D, picks D (hybrid) |
| `docs/adr/README.md` | index updated |
| `backend/core/exception_handlers.py` | `create_error_response` now writes BOTH `detail` (top-level, FastAPI-default) AND the existing `error.{code,message,...}` envelope; the two human strings stay in sync |
| `frontend/src/api/types.ts` | `APIError` now correctly reflects the real wire format (required `detail`, optional structured `error`) |
| `tests/core/test_exception_handlers.py` | new — 7 regression tests covering both shapes |

## Verification

```
$ poetry run pytest tests/core/test_exception_handlers.py \
       tests/unit/test_database_management_api.py \
       tests/contract/test_domain_api_spec_validation.py -q
25 passed
```

(7 new + 4 existing envelope-asserting tests + 14 others. The 4 existing
tests still pass because the structured envelope is preserved.)

```
$ poetry run pytest --no-cov -q --tb=short --continue-on-collection-errors
819 passed, 1 failed*, 28 skipped (was 812)
```

`*` `test_force_queue_processing` — known pre-existing pollution.

```
$ cd frontend && npm run typecheck
(clean)
```

```
$ poetry run python scripts/ruff_diff_check.py origin/main
✅ No NEW ruff issues on changed lines (2 files checked, 22 legacy issues ignored).
```

## Production bug caught + fixed

Frontend error toasts will now show the actual server message
("Account not found", "Validation failed: email is required", etc.)
instead of generic "API Error: 404". **No frontend code changes
needed** — the existing `handleApiResponse` code path starts working
as soon as the backend includes the `detail` field.

This is the **5th** production bug caught by the architectural-audit
cycle (counting the 14 from the prior 2026-05-12 cycle, this brings
running total to 19).

## Decision rationale

ADR-0005 walks through:

- **Option A** (revert to FastAPI default): smallest wire format,
  fixes frontend, but loses structured `error.code` for tests + clients.
- **Option B** (keep + fix frontend `APIError` type): requires updating
  8 frontend sites + the type, no benefit over D for OpenAPI clients.
- **Option C** (RFC 7807 `application/problem+json`): standards-compliant,
  but breaks every existing consumer for no third-party benefit (per
  `coachiq-architecture.md` threat model — frontend is the only consumer).
- **Option D** (this ADR — include both shapes): smallest possible change,
  backward-compatible with both contracts, +30-50 bytes per error response.

Picked D. The cycle's "Lesson #2 from PR #111" — when a prompt frames
options as A/B/C, reality often requires a fourth (D) — applies again.

## Risk

Low. Strictly additive wire format. All four existing envelope-asserting
tests still pass. Frontend typecheck clean.

## Tracker

Refs #145, closes #150.
