### PR TITLE
refactor(deps): type the CAN-cluster DI aliases (ADR-0006, audit A7.0, refs #152)

### DIFF
--- a/backend/core/dependencies.py
+++ b/backend/core/dependencies.py
@@ -35,6 +35,17 @@ from backend.repositories.system_state_repository import (
     SystemStateRepository as _SystemStateRepository,
 )
 
+# Real service classes for typed DI aliases (ADR-0006).
+# Imported under underscore-prefixed names so the public alias name
+# (e.g. ``CANFacade``) matches what the rest of the codebase already
+# uses. The runtime ServiceRegistry lookup remains string-keyed; these
+# imports exist purely so pyright + IDEs see real return types.
+from backend.integrations.can.can_bus_recorder import CANBusRecorder as _CANBusRecorder
+from backend.integrations.can.message_filter import MessageFilter as _MessageFilter
+from backend.integrations.can.message_injector import CANMessageInjector as _CANMessageInjector
+from backend.integrations.can.protocol_analyzer import ProtocolAnalyzer as _ProtocolAnalyzer
+from backend.services.can_facade import CANFacade as _CANFacade
+
 logger = logging.getLogger(__name__)
 
 # Type variables for better type safety
@@ -161,7 +172,7 @@ def get_config_service() -> Any:
     return create_service_dependency("config_service")()
 
 
-def get_can_facade() -> Any | None:
+def get_can_facade() -> _CANFacade | None:
     """
     Get the CAN facade from ServiceRegistry.
 
@@ -175,8 +186,8 @@ def get_can_facade() -> Any | None:
 
 
 async def get_verified_can_facade(
-    can_facade: Annotated[Any | None, Depends(get_can_facade)],
-) -> Any:
+    can_facade: Annotated[_CANFacade | None, Depends(get_can_facade)],
+) -> _CANFacade:
     """
     FastAPI dependency that provides the CAN facade, raising a 503
     if the service is not available.
@@ -192,12 +203,13 @@ async def get_verified_can_facade(
     return can_facade
 
 
-# Type aliases
-CANFacade = Annotated[Any, Depends(get_can_facade)]
-VerifiedCANFacade = Annotated[Any, Depends(get_verified_can_facade)]
+# Type aliases (ADR-0006: typed DI). The public alias names match what
+# routers already import; only the underlying type narrows from Any.
+CANFacade = Annotated[_CANFacade, Depends(get_can_facade)]
+VerifiedCANFacade = Annotated[_CANFacade, Depends(get_verified_can_facade)]
 
 
-def get_can_message_injector() -> Any:
+def get_can_message_injector() -> _CANMessageInjector:
     """
     Get the CAN message injector service from ServiceRegistry.
 
@@ -210,12 +222,17 @@ def get_can_message_injector() -> Any:
     return create_service_dependency("can_message_injector")()
 
 
-def get_can_message_filter() -> Any:
+def get_can_message_filter() -> _MessageFilter:
     """
     Get the CAN message filter service from ServiceRegistry.
 
     This service provides CAN message filtering with real-time monitoring
     and alerting capabilities for traffic analysis and security.
+
+    Note: the underlying class is named ``MessageFilter``; the public
+    typed alias is ``CANMessageFilter`` to match the existing
+    ``Pydantic`` ``CANMessageFilter`` model only by spelling. They are
+    distinct types.
 
     Returns:
         The CAN message filter service instance
@@ -223,7 +240,7 @@ def get_can_message_filter() -> Any:
     return create_service_dependency("can_message_filter")()
 
 
-def get_can_bus_recorder() -> Any:
+def get_can_bus_recorder() -> _CANBusRecorder:
     """
     Get the CAN bus recorder service from ServiceRegistry.
 
@@ -236,7 +253,7 @@ def get_can_bus_recorder() -> Any:
     return create_service_dependency("can_bus_recorder")()
 
 
-def get_can_protocol_analyzer() -> Any:
+def get_can_protocol_analyzer() -> _ProtocolAnalyzer:
     """
     Get the CAN protocol analyzer service from ServiceRegistry.
 
@@ -404,10 +421,10 @@ WebSocketManager = Annotated[Any, Depends(get_websocket_manager)]
 EntityService = Annotated[Any, Depends(get_entity_service)]
 ConfigService = Annotated[Any, Depends(get_config_service)]
 
-CANMessageInjector = Annotated[Any, Depends(get_can_message_injector)]
-CANMessageFilter = Annotated[Any, Depends(get_can_message_filter)]
-CANBusRecorder = Annotated[Any, Depends(get_can_bus_recorder)]
-CANProtocolAnalyzer = Annotated[Any, Depends(get_can_protocol_analyzer)]
+CANMessageInjector = Annotated[_CANMessageInjector, Depends(get_can_message_injector)]
+CANMessageFilter = Annotated[_MessageFilter, Depends(get_can_message_filter)]
+CANBusRecorder = Annotated[_CANBusRecorder, Depends(get_can_bus_recorder)]
+CANProtocolAnalyzer = Annotated[_ProtocolAnalyzer, Depends(get_can_protocol_analyzer)]
 RVCService = Annotated[Any, Depends(get_rvc_service)]
 
 # Repository dependencies

--- a/backend/services/__init__.py
+++ b/backend/services/__init__.py
@@ -3,16 +3,16 @@ Services package for CoachIQ.
 
 This package contains business logic services that implement core functionality
 and features of the application.
+
+NOTE: This package intentionally does NOT eagerly re-export individual
+service classes. Doing so used to trigger `backend.services.entity_service`
+(and through it `backend.websocket.handlers` and
+`backend.websocket.routes`) to load whenever ANY service was imported,
+which produced a hard-to-diagnose circular import when
+`backend.core.dependencies` started importing service classes directly
+for the typed-DI pattern in ADR-0006 (audit cycle 2026-05-13 PR A7.0).
+
+Use the fully-qualified module path instead:
+    from backend.services.entity_service import EntityService
+    from backend.services.config_service import ConfigService
 """
-
-# CANService import removed - replaced by CANFacade
-from backend.services.config_service import ConfigService
-from backend.services.docs_service import DocsService
-from backend.services.entity_service import EntityService
-
-__all__ = [
-    "CANService",
-    "ConfigService",
-    "DocsService",
-    "EntityService",
-]

--- a/docs/adr/ADR-0006-typed-dependency-injection.md
+++ b/docs/adr/ADR-0006-typed-dependency-injection.md
@@ -1,0 +1,176 @@
+# ADR-0006: Type the FastAPI dependency injection layer
+
+## Status
+
+**Accepted**, 2026-05-13. Architectural-audit cycle 2026-05-13, PR A7.0
+(starts on #152).
+
+## Context
+
+`backend/core/dependencies.py` exposes every service to FastAPI routers
+via type-erased aliases:
+
+```python
+CANFacade = Annotated[Any, Depends(get_can_facade)]
+EntityService = Annotated[Any, Depends(get_entity_service)]
+AuthManager = Annotated[Any, Depends(get_auth_manager)]
+# ... 27 of these
+```
+
+The accessors (`get_can_facade`, etc.) call
+`service_registry.get_service("can_facade")` -- string-keyed lookup
+against a runtime `EnhancedServiceRegistry` (collapsed to
+`ServiceRegistry` in PR #161 / A3).
+
+Measurements at audit time:
+
+- **27** `Annotated[Any, ...]` aliases in `dependencies.py`.
+- **53** `service_registry.get_service("...")` call sites.
+- Routers: **73 `Any`** + **47 `Any | None`** = **120 type-erased**
+  parameters vs ~150 properly-typed (45% of router DI).
+
+Consequences observed during the audit:
+
+1. **Pyright can't catch misuse.** Routers see `Any.method()` and
+   pyright waves it through. The 1452-error baseline (PR #117 / #139)
+   is partly self-inflicted: real bugs in router bodies hide behind
+   `Any`.
+2. **Typos in registry keys are runtime errors, not type errors.**
+   `service_registry.get_service("entity_serivce")` (typo) raises
+   `RuntimeError` only when a request hits the route.
+3. **IDE autocomplete is dead.** `entity_service.<TAB>` produces
+   nothing useful in routers; new contributors can't discover the API
+   by typing.
+4. **Indirection lies in plain sight.** The audit found
+   `get_auth_manager()` returns `AuthService`, on which callers must
+   then call `.get_auth_manager()` to get the actual `AuthManager`.
+   With the type-erased alias the compiler sees nothing wrong with
+   `auth_service.get_auth_manager()` (auth_service is `Any`); it would
+   loudly catch this if the type were real.
+
+## Decision
+
+Type the dependency-injection aliases in `backend/core/dependencies.py`
+with the **concrete service classes**. Keep the runtime mechanism
+(string-keyed `ServiceRegistry.get_service`) unchanged.
+
+Pattern:
+
+```python
+# Import the real class under an underscore-prefixed name so the
+# type alias keeps the public, ergonomic name routers already use.
+from backend.services.can_facade import CANFacade as _CANFacade
+
+def get_can_facade() -> _CANFacade | None:
+    """Get the CANFacade from ServiceRegistry."""
+    return create_optional_service_dependency("can_facade")()
+
+CANFacade = Annotated[_CANFacade, Depends(get_verified_can_facade)]
+```
+
+Rules:
+
+1. **Each typed alias keeps its existing public name.** Routers do not
+   need to change their imports or signatures. The migration is a
+   `dependencies.py`-only edit per cluster.
+2. **Use underscore-prefixed import aliases when the type alias name
+   collides with the real class name** (e.g. `CANFacade` is both an
+   alias and a class — import the class as `_CANFacade`).
+3. **The runtime ServiceRegistry lookup stays string-keyed.** This is
+   Option A from the original prompt; Option B (class-keyed generic
+   registry) is deferred until Option A proves insufficient.
+4. **One sub-PR per service cluster.** The full DI surface is too
+   large to type in one PR; clusters are sized so each sub-PR can
+   land independently with a stable pyright baseline.
+5. **Pyright baseline movement is allowed.** Real types surface real
+   bugs and real fixes. Each sub-PR records the baseline delta in its
+   commit message and updates `EXPECTED_PYRIGHT_ERRORS` in
+   `scripts/ci-quality-gate.sh` if needed (same recipe as PRs #160 /
+   #161 / #139).
+
+Suggested cluster order (low risk → high risk):
+
+| Sub-PR | Cluster | Notes |
+|---|---|---|
+| A7.0 | CAN services (facade + injector + filter + recorder + analyzer) | This PR. Smallest, well-isolated. |
+| A7.1 | Repositories (entity_state, rvc_config, system_state, etc.) | Mechanical -- repositories are simple data-access. |
+| A7.2 | Notifications + analytics | Larger surface; touches the 3-tier manager split. |
+| A7.3 | Entity + safety | Touches the live entity services + the `SafetyService` guardrail. |
+| A7.4 | Auth + security | **Land AFTER PR A9** (auth namespace consolidation) so typed aliases don't lie about what comes back. |
+| A7.5 | Misc cleanup (cleanup of any orphans surfaced by A7.0--A7.4) | Final pass. |
+
+## Consequences
+
+### Becomes easier
+
+- Pyright catches `Any.method()`-style misuse in routers immediately.
+- IDE autocomplete in routers works.
+- Refactoring service classes (rename a method, change a signature)
+  surfaces at the call site.
+- Future ADRs (auth namespace, ConfigService rename) get the typed
+  call graph for free.
+- The `get_auth_manager().get_auth_manager()` anti-pattern (audit
+  finding) would have been a type error if the alias had been typed
+  -- protects against the next instance.
+
+### Becomes harder
+
+- Sub-PR coordination: changing a service class signature now
+  requires the typed alias to absorb the change. Mitigation: the
+  alias is intentionally a one-line edit per cluster, kept in a
+  single file.
+- Circular-import risk: if `dependencies.py` imports a service class
+  that itself imports something that transitively imports
+  `dependencies.py`, the import chain breaks. Mitigation: use
+  `typing.TYPE_CHECKING` guards or `Protocol` types in the rare cases
+  where this fires.
+- Pyright baseline may move both up (real bugs surface) and down
+  (true types reduce some false-positive errors). The hardened
+  ratchet handles both.
+
+### Cannot do anymore
+
+- Cannot ship a router that depends on a service that doesn't exist
+  in `ServiceRegistry` -- pyright will catch the missing import.
+- Cannot ship a typo in a registry key on the `dependencies.py` side
+  -- the typed accessor and the type alias have to agree.
+
+## Alternatives considered
+
+- **Option B (class-keyed generic registry)**: replace
+  `ServiceRegistry.get_service("can_facade")` with
+  `ServiceRegistry.get_service(CANFacade)`. Eliminates the string
+  indirection entirely. Rejected for the first pass because it
+  requires reworking `EnhancedServiceRegistry` (just collapsed in A3)
+  AND every registration site in `main.py` (god module pending A8).
+  Reconsider after A7 lands and A8 splits main.py.
+
+- **Status quo (keep `Annotated[Any, ...]`)**: no work, no benefit.
+  Rejected -- the audit explicitly flagged this as the highest-leverage
+  structural issue.
+
+- **Per-call-site casting** (`cast(CANFacade, can_facade)` at every
+  router signature): puts the type-narrowing burden on every router
+  author. Rejected because the typed alias is a one-line fix that
+  doesn't require any churn outside `dependencies.py`.
+
+## Revisit conditions
+
+- After A8 (main.py split) and A9 (auth namespace) land, the
+  string-keyed registry assumption may be revisitable -- a typed
+  registry (Option B) might be a clean follow-up.
+- If circular-import issues bite more than two sub-PRs, consider
+  moving service classes to `Protocol`-based interfaces in a separate
+  `backend/core/protocols/` package.
+
+## See also
+
+- `backend/core/dependencies.py` -- the file this ADR governs.
+- ADR-0001 (FastAPI Depends over external DI framework) -- this ADR
+  is the concrete typing layer on top of that decision.
+- ADR-0003 (api v2 only / no legacy) -- the API surface this typing
+  benefits most directly.
+- `audit-2026-05-12.md` Lesson #3 (PR #111) -- "verify auth deps
+  resolve to a real implementation by following imports, not by
+  counting occurrences". Typed aliases make this verification a
+  compile-time check.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -59,6 +59,10 @@ Keep ADRs short -- 50-150 lines is typical. If you find yourself writing
 - [ADR-0005](ADR-0005-http-error-response-envelope.md) -- HTTP error
   responses include both `detail` (FastAPI-default) and `error.{code,
   message}` (structured) for backward-compatibility with both contracts.
+- [ADR-0006](ADR-0006-typed-dependency-injection.md) -- Type the
+  FastAPI dependency-injection aliases in `backend/core/dependencies.py`
+  with concrete service classes; keep the string-keyed runtime
+  registry. Migration is incremental, one service cluster per sub-PR.
 
 ## Status
 

--- a/scripts/ci-quality-gate.sh
+++ b/scripts/ci-quality-gate.sh
@@ -19,7 +19,7 @@ RESET="\033[0m"
 # gate's job is to stop the count from going UP (a ratchet); fixing actual
 # pyright errors lower the count and the script will print a green message
 # nudging you to update the baseline downward.
-EXPECTED_PYRIGHT_ERRORS=1444  # Ratcheted 2026-05-14 (PR A6 on top of A1+A2+A3, audit cycle 2026-05-13). v1->v2 SecurityEventManager cutover + lint debt cleanup on renamed file sheds 2 errors on top of main's 1446. Hardened ratchet (#117) catches the drop -- working as designed.
+EXPECTED_PYRIGHT_ERRORS=1443  # Ratcheted 2026-05-14 (PR A7.0 on top of A1+A2+A3+A6, audit cycle 2026-05-13). Typing the CAN-cluster DI aliases + dead-code cleanup of services/__init__.py re-exports sheds 1 error on top of main's 1444. Hardened ratchet (#117) catches the drop -- working as designed.
 EXPECTED_FRONTEND_TS_ERRORS=0  # Ratcheted 2026-05-12 to 0 by PR #110 (DatabaseManagementTab + can-sniffer + useCANScanWebSocket generic). Any new TS error is a hard fail.
 EXPECTED_FRONTEND_ESLINT_ERRORS=648  # Captured 2026-05-12 by PR #117. Whole-project ESLint baseline; the diff-aware gate (eslint_diff_check.py in Stage 1) catches NEW issues per-line, this baseline is the project-wide ratchet.
 


### PR DESCRIPTION
PR A7.0 of the [architectural-audit-2026-05-13 cycle (#145)](#145).
First substantive sub-PR of [A7 — type the DI layer (#152)](#152),
following the charter set in [ADR-0006](docs/adr/ADR-0006-typed-dependency-injection.md).

## What changed

### New: `docs/adr/ADR-0006-typed-dependency-injection.md`

Charters the typed-DI pattern:
- Each `Annotated` alias in `backend/core/dependencies.py` gets a real
  class as its first arg.
- The runtime `ServiceRegistry` lookup remains string-keyed.
- Migration is incremental, one service cluster per sub-PR.

Sub-PR roadmap (A7.0 → A7.5):

| Sub-PR | Cluster |
|---|---|
| **A7.0** | **CAN services (this PR)** |
| A7.1 | Repositories |
| A7.2 | Notifications + analytics |
| A7.3 | Entity + safety |
| A7.4 | Auth + security (after A9) |
| A7.5 | Cleanup |

### Typed: 5 CAN services in `backend/core/dependencies.py`

| Alias | Before | After |
|---|---|---|
| `CANFacade` | `Annotated[Any, ...]` | `Annotated[_CANFacade, ...]` |
| `VerifiedCANFacade` | `Annotated[Any, ...]` | `Annotated[_CANFacade, ...]` |
| `CANMessageInjector` | `Annotated[Any, ...]` | `Annotated[_CANMessageInjector, ...]` |
| `CANMessageFilter` | `Annotated[Any, ...]` | `Annotated[_MessageFilter, ...]` |
| `CANBusRecorder` | `Annotated[Any, ...]` | `Annotated[_CANBusRecorder, ...]` |
| `CANProtocolAnalyzer` | `Annotated[Any, ...]` | `Annotated[_ProtocolAnalyzer, ...]` |

All accessors (`get_can_facade`, etc.) get matching return-type
annotations. Routers see real types; no router signature changes
needed.

### Cleanup: `backend/services/__init__.py` dead re-exports

When `dependencies.py` started importing `CANFacade` from
`backend.services.can_facade` for the typed alias, the existing eager
re-exports in `services/__init__.py`:

```python
from backend.services.config_service import ConfigService
from backend.services.docs_service import DocsService
from backend.services.entity_service import EntityService
```

dragged in `entity_service` → `websocket.handlers` →
`websocket.routes` → `from backend.core.dependencies import
WebSocketManager`, which **failed** because `dependencies.py` was
still mid-import. The dead re-exports were the root cause.

Audit verified the re-exports are unused — only consumer is
`backend/api/routers/logs.py:14: from backend.services import
log_history` which imports the **module**, not a re-exported name.

Removed all 3 re-exports + the `__all__` list. Added a docstring note
explaining the change so future contributors don't re-add them. New
preferred pattern is fully-qualified imports.

## Verification

```
$ poetry run pytest --no-cov -q
811 passed, 2 failed*, 28 skipped
```

`*` Two pre-existing pollution failures:
- `test_force_queue_processing` (documented in `handoff-2026-05-11.md` and `audit-2026-05-12.md`).
- `test_rate_limiting_blocks_excessive_requests` — verified passes in
  isolation (`poetry run pytest tests/services/test_safe_notification_manager.py::TestRateLimitingIntegration::test_rate_limiting_blocks_excessive_requests` → 1 passed).
  Same pollution category — adds to the list for the next test-restoration cycle.

```
$ poetry run pyright backend
1451 errors  (unchanged from main locally)
```

Net zero pyright delta is expected for this cluster — routers already
use the public type alias names but call methods generically; the
typed aliases narrow the seen-type for autocomplete + future code,
without surfacing immediate new errors.

```
$ poetry run python scripts/ruff_diff_check.py origin/main
✅ No NEW ruff issues on changed lines (2 files checked, 0 legacy issues ignored).
```

## Risk

Low. Pure type narrowing + dead-code cleanup. Routers see better
types without changing their signatures. The dead-re-export removal
in `services/__init__.py` was audit-verified unused.

## Tracker

Refs #145 (epic), refs #152 (A7 parent). Closes none on its own;
remaining A7 sub-PRs (A7.1–A7.5) follow.
