### PR TITLE
refactor(deps): type the repository-cluster DI aliases (ADR-0006, audit A7.1, refs #152)

### DIFF
--- a/backend/core/dependencies.py
+++ b/backend/core/dependencies.py
@@ -12,6 +12,29 @@ from fastapi import Depends, Header, HTTPException, status
 
 from backend.core.service_registry import ServiceRegistry as _ServiceRegistryClass
 
+# Real repository classes for typed DI aliases (ADR-0006).
+# Imported under underscore-prefixed names so the public alias name
+# matches what the rest of the codebase already uses. The runtime
+# ServiceRegistry lookup remains string-keyed; these imports exist
+# purely so pyright + IDEs see real return types.
+#
+# NOTE: ``EntityStateRepository`` exists in TWO files under the same
+# class name -- the canonical one (re-exported by
+# ``backend/repositories/__init__.py`` and registered by
+# ``backend/repositories/service_registration.py``) AND a competing
+# subclass in ``backend/repositories/entity_repository.py`` that
+# main.py registers later (overriding the first registration with a
+# different constructor signature). Tracked as #167. The typed alias
+# here points at the canonical one; if #167 picks the other class,
+# this single import is the one-line update.
+from backend.repositories.entity_state_repository import (
+    EntityStateRepository as _EntityStateRepository,
+)
+from backend.repositories.rvc_config_repository import RVCConfigRepository as _RVCConfigRepository
+from backend.repositories.system_state_repository import (
+    SystemStateRepository as _SystemStateRepository,
+)
+
 logger = logging.getLogger(__name__)
 
 # Type variables for better type safety
@@ -260,7 +283,7 @@ def get_rvc_service() -> Any:
 # ==================================================================================
 
 
-def get_entity_state_repository() -> Any:
+def get_entity_state_repository() -> _EntityStateRepository:
     """
     Get the entity state repository from ServiceRegistry.
 
@@ -270,7 +293,7 @@ def get_entity_state_repository() -> Any:
     return create_service_dependency("entity_state_repository")()
 
 
-def get_rvc_config_repository() -> Any:
+def get_rvc_config_repository() -> _RVCConfigRepository:
     """
     Get the RVC config repository from ServiceRegistry.
 
@@ -280,7 +303,7 @@ def get_rvc_config_repository() -> Any:
     return create_service_dependency("rvc_config_repository")()
 
 
-def get_system_state_repository() -> Any:
+def get_system_state_repository() -> _SystemStateRepository:
     """
     Get the system state repository from ServiceRegistry.
 
@@ -388,9 +411,9 @@ CANProtocolAnalyzer = Annotated[Any, Depends(get_can_protocol_analyzer)]
 RVCService = Annotated[Any, Depends(get_rvc_service)]
 
 # Repository dependencies
-EntityStateRepository = Annotated[Any, Depends(get_entity_state_repository)]
-RVCConfigRepository = Annotated[Any, Depends(get_rvc_config_repository)]
-SystemStateRepository = Annotated[Any, Depends(get_system_state_repository)]
+EntityStateRepository = Annotated[_EntityStateRepository, Depends(get_entity_state_repository)]
+RVCConfigRepository = Annotated[_RVCConfigRepository, Depends(get_rvc_config_repository)]
+SystemStateRepository = Annotated[_SystemStateRepository, Depends(get_system_state_repository)]
 
 # Analytics dependencies
 AnalyticsDashboardService = Annotated[Any, Depends(get_analytics_dashboard_service)]


### PR DESCRIPTION
PR A7.1 of the [architectural-audit-2026-05-13 cycle (#145)](#145).
Second sub-PR of [A7 — type the DI layer (#152)](#152), following the
charter set in [ADR-0006](docs/adr/ADR-0006-typed-dependency-injection.md)
(landing in PR #166 / A7.0).

This PR is independent of #166 and can land in any order.

## What changed

### Typed: 3 repository services in `backend/core/dependencies.py`

| Alias | Before | After |
|---|---|---|
| `EntityStateRepository` | `Annotated[Any, ...]` | `Annotated[_EntityStateRepository, ...]` |
| `RVCConfigRepository` | `Annotated[Any, ...]` | `Annotated[_RVCConfigRepository, ...]` |
| `SystemStateRepository` | `Annotated[Any, ...]` | `Annotated[_SystemStateRepository, ...]` |

All accessors get matching return-type annotations.

## Production bug found (deferred to #167)

While doing the typed-alias work, audit discovered that the
ServiceRegistry key `"entity_state_repository"` is **registered twice**
with two different `EntityStateRepository` classes:

- `main.py:614-625` registers it with `EntityStateRepository` imported
  from `backend.repositories.entity_repository:118` (a
  `MonitoredRepository` subclass).
- `backend/repositories/service_registration.py:165` (called from
  `main.py:317`) registers it again with `EntityStateRepository`
  imported via `backend.repositories.__init__:12` from
  `backend.repositories.entity_state_repository:22` (a standalone
  class with a **different constructor signature**).

`main.py`'s explicit registration runs **later**, so class #1 wins at
runtime. But consumers that import `EntityStateRepository` directly
get **class #2** from the `__init__.py` re-export. The two classes
are not interchangeable.

Tracked as **#167**. This PR types the alias against the canonical
class (#2 — what `__init__.py` re-exports); if #167 chooses the other
class, the single import in `dependencies.py` is the one-line update.

## Verification

```
$ python -c 'from backend.core.dependencies import \
                EntityStateRepository, RVCConfigRepository, \
                SystemStateRepository'
OK

$ poetry run pytest --no-cov -q
811 passed, 2 failed*, 28 skipped
```

`*` Two pre-existing pollution failures (same as A7.0):
- `test_force_queue_processing` (documented).
- `test_rate_limiting_blocks_excessive_requests` (documented in PR A7.0; passes in isolation).

```
$ poetry run python scripts/ruff_diff_check.py origin/main
✅ No NEW ruff issues on changed lines (1 files checked, 0 legacy issues ignored).
```

## Risk

Low. Pure type narrowing. No runtime change. The repository
class duplication (#167) predates this PR and is documented but
not fixed here.

## Tracker

Refs #145 (epic), refs #152 (A7 parent), refs #167 (deferred bug).
Closes none on its own; remaining A7 sub-PRs (A7.2–A7.5) follow.
