### PR TITLE
refactor(config): A10 rename ConfigService->RVCConfigFacade, ConfigurationService->RVCSpecLoader

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -131,10 +131,12 @@ All backend code MUST access services via FastAPI dependency injection from `bac
 
 - **ServiceRegistry** (`backend/core/service_registry.py`): Central service lifecycle and dependency resolution.
 - **FeatureManager** (`backend/services/feature_manager.py`): YAML-driven feature flag system.
-- **ConfigService** (`backend/services/config_service.py`): Configuration access (use this rather than reading `Settings` directly).
+- **Settings** (`backend/core/config.py::get_settings`): Pydantic-validated app configuration -- this IS the canonical app config object. Most code should consume `Settings` directly via `get_settings()`.
+- **RVCConfigFacade** (`backend/services/rvc_config_facade.py`): Thin facade over `RVCConfigRepository` for PGN/coach metadata lookups. Use only for RV-C metadata, not general app config. Renamed from `ConfigService` in audit A10 (see ADR-0008).
+- **RVCSpecLoader** (`backend/integrations/rvc/spec_loader.py`): TTL-cached loader for RV-C spec/mapping files on disk. Used internally by the RV-C decoder; not a public service. Renamed from `ConfigurationService` in audit A10.
 - **DatabaseManager** (`backend/services/database_manager.py`): Async SQLAlchemy session management.
 - **PersistenceService** (`backend/services/persistence_service.py`): Backups and durable storage.
-- **AuthManager** / **AuthService** (`backend/services/auth_*.py`): Authentication, tokens, PIN/MFA.
+- **AuthManager** / **AuthService** (`backend/services/auth/`): Authentication, tokens, PIN/MFA (consolidated into a single package in audit A9, see ADR-0007).
 
 #### Domain Services (access via DI)
 
@@ -219,7 +221,7 @@ async def list_entities(
 - **Feature Registration**: ALL features must extend Feature base class and register with FeatureManager
 - **WebSockets**: Use WebSocketManager feature for client connections and broadcasting
 - **State management**: Use repositories and services via DI; do **not** reach for `app.state` or any global `AppState` (both removed).
-- **Configuration**: Use ConfigService for all configuration access
+- **Configuration**: Read Pydantic `Settings` directly via `backend.core.config.get_settings()`. `RVCConfigFacade` is only for RV-C *metadata* (PGN names, coach info), not for general app config (see ADR-0008).
 - **Database**: Use DatabaseManager and PersistenceService for data operations
 - **Error handling**: Structured exceptions with proper logging
 - **Testing**: pytest with mocked CANbus interfaces
@@ -252,11 +254,17 @@ All configuration uses the `COACHIQ_` prefix with hierarchical naming:
 ### Configuration Access
 
 ```python
-# ALWAYS use ConfigService for configuration
-from backend.core.dependencies import get_config_service
+# For general app configuration: read Pydantic Settings directly
+from backend.core.config import get_settings
 
-config_service: ConfigService = Depends(get_config_service)
-settings = await config_service.get_config_summary()
+settings = get_settings()
+port = settings.server.port
+
+# For RV-C metadata (PGN names, coach info): use RVCConfigFacade via DI
+from backend.core.dependencies import get_rvc_config_facade
+
+rvc_config: RVCConfigFacade = Depends(get_rvc_config_facade)
+coach = rvc_config.get_coach_info()
 ```
 
 ### Persistence Modes

--- a/.github/instructions/code-style.instructions.md
+++ b/.github/instructions/code-style.instructions.md
@@ -101,7 +101,7 @@ When dealing with import errors even with proper type stubs:
 ```python
 # CORRECT: Use dependency injection for all services
 from backend.core.dependencies import (
-    get_feature_manager, get_entity_manager, get_config_service
+    get_feature_manager, get_entity_manager, get_rvc_config_facade
 )
 
 @router.get("/status")
@@ -140,7 +140,7 @@ class NewFeature(Feature):
 
 - Find service patterns: `@context7 FeatureManager dependency injection`
 - Check entity operations: `@context7 EntityManager usage patterns`
-- Review configuration: `@context7 ConfigService implementation`
+- Review configuration: `@context7 RVCConfigFacade implementation`
 - Find database patterns: `@context7 DatabaseManager session handling`
 - Check coding patterns: `@context7 FastAPI route implementation`
 - Review API models: `@context7 Pydantic model for entities`

--- a/.github/instructions/project-overview.instructions.md
+++ b/.github/instructions/project-overview.instructions.md
@@ -69,8 +69,9 @@ All settings use the `COACHIQ_` prefix with hierarchical naming:
 - **`.env`**: Active configuration (not in version control)
 - **`backend/core/config.py`**: Pydantic Settings with type validation
 
-### Management Services for Configuration
-- **ConfigService**: ALWAYS use for configuration access
+### Configuration Access
+- **Settings** is the canonical app-config object (`backend.core.config.get_settings()`). Read it directly.
+- **RVCConfigFacade**: ONLY for RV-C metadata (PGN names, coach info), not general app config. See ADR-0008.
 - **Environment variable priority**: Overrides .env file values
 - **Persistence modes**: Memory-only, development, or production
 - **Feature flags**: Enable/disable features via `COACHIQ_FEATURES__*`

--- a/backend/api/routers/config.py
+++ b/backend/api/routers/config.py
@@ -27,14 +27,14 @@ from fastapi.responses import PlainTextResponse
 from backend.core.config import get_settings
 from backend.core.dependencies import (
     create_service_dependency,
-    get_config_service,
     get_entity_state_repository,
+    get_rvc_config_facade,
 )
 from backend.models.github_update import GitHubUpdateStatus
 from backend.repositories.can_tracking_repository import CANTrackingRepository
 from backend.repositories.entity_state_repository import EntityStateRepository
-from backend.services.config_service import ConfigService
 from backend.services.github_update_checker import GitHubUpdateChecker
+from backend.services.rvc_config_facade import RVCConfigFacade
 
 # Create missing dependencies
 get_can_interface_service = create_service_dependency("can_interface_service")
@@ -57,7 +57,7 @@ SERVER_START_TIME = time.time()
     description="Returns the current device mapping configuration file content.",
 )
 async def get_device_mapping_config(
-    config_service: Annotated[ConfigService, Depends(get_config_service)],
+    config_service: Annotated[RVCConfigFacade, Depends(get_rvc_config_facade)],
 ) -> PlainTextResponse:
     """Get device mapping configuration content."""
     logger.info("GET /config/device_mapping - Retrieving device mapping configuration")
@@ -84,7 +84,7 @@ async def get_device_mapping_config(
     description="Returns the current RV-C specification file content.",
 )
 async def get_spec_config(
-    config_service: Annotated[ConfigService, Depends(get_config_service)],
+    config_service: Annotated[RVCConfigFacade, Depends(get_rvc_config_facade)],
 ) -> PlainTextResponse:
     """Get RV-C specification configuration content."""
     logger.info("GET /config/spec - Retrieving RV-C specification configuration")
@@ -140,7 +140,7 @@ async def get_server_status() -> dict[str, Any]:
     description="Returns application-specific status information including configuration and entity counts.",
 )
 async def get_application_status(
-    config_service: Annotated[ConfigService, Depends(get_config_service)],
+    config_service: Annotated[RVCConfigFacade, Depends(get_rvc_config_facade)],
     entity_state_repo: Annotated[EntityStateRepository, Depends(get_entity_state_repository)],
     can_tracking_repo: Annotated[CANTrackingRepository, Depends(get_can_tracking_repository)],
 ) -> dict[str, Any]:
@@ -568,7 +568,7 @@ async def get_coach_interface_requirements():
 
 @router.get("/config/coach/metadata")
 async def get_coach_mapping_metadata(
-    config_service: Annotated[ConfigService, Depends(get_config_service)],
+    config_service: Annotated[RVCConfigFacade, Depends(get_rvc_config_facade)],
 ):
     """Get complete coach mapping metadata including interface analysis."""
     # This endpoint provides backwards compatibility

--- a/backend/core/dependencies.py
+++ b/backend/core/dependencies.py
@@ -85,7 +85,7 @@ from backend.services.predictive_maintenance_service import (
 # ``backend.websocket.handlers`` -> ``backend.websocket.routes`` ->
 # ``backend.core.dependencies.WebSocketManager``. Tracked separately;
 # fix likely requires making entity_service's websocket import lazy.
-from backend.services.config_service import ConfigService as _ConfigService
+from backend.services.rvc_config_facade import RVCConfigFacade as _RVCConfigFacade
 from backend.services.rvc_service import RVCService as _RVCService
 from backend.services.safety_service import SafetyService as _SafetyService
 
@@ -205,14 +205,13 @@ def get_entity_service() -> Any:
     return create_service_dependency("entity_service")()
 
 
-def get_config_service() -> _ConfigService:
-    """
-    Get the config service from ServiceRegistry.
+def get_rvc_config_facade() -> _RVCConfigFacade:
+    """Get the RV-C config facade from ServiceRegistry.
 
     Returns:
-        The config service instance
+        The RVCConfigFacade instance
     """
-    return create_service_dependency("config_service")()
+    return create_service_dependency("rvc_config_facade")()
 
 
 def get_can_facade() -> _CANFacade | None:
@@ -462,7 +461,7 @@ def get_predictive_maintenance_service() -> _PredictiveMaintenanceService:
 # Modern typed dependencies using Annotated
 WebSocketManager = Annotated[Any, Depends(get_websocket_manager)]
 EntityService = Annotated[Any, Depends(get_entity_service)]
-ConfigService = Annotated[_ConfigService, Depends(get_config_service)]
+RVCConfigFacade = Annotated[_RVCConfigFacade, Depends(get_rvc_config_facade)]
 
 CANMessageInjector = Annotated[_CANMessageInjector, Depends(get_can_message_injector)]
 CANMessageFilter = Annotated[_MessageFilter, Depends(get_can_message_filter)]

--- a/backend/core/registrations/core_startup.py
+++ b/backend/core/registrations/core_startup.py
@@ -31,9 +31,9 @@ from backend.core.config import get_settings
 from backend.core.performance import PerformanceMonitor
 from backend.core.safety_registry import SafetyServiceRegistry
 from backend.core.service_dependency_resolver import DependencyType, ServiceDependency
-from backend.services.config_service import ConfigService
 from backend.services.edge_proxy_monitor_service import EdgeProxyMonitorService
 from backend.services.pin_manager import PINConfig, PINManager
+from backend.services.rvc_config_facade import RVCConfigFacade
 from backend.services.security_audit_service import RateLimitConfig, SecurityAuditService
 from backend.services.security_config_service import SecurityConfigService
 
@@ -235,18 +235,18 @@ async def configure(service_registry: SafetyServiceRegistry) -> None:
     register_repositories_with_service_registry(service_registry)
     logger.info("Repositories registered with ServiceRegistry")
 
-    # Register ConfigService after repositories are available
-    def _init_config_service(rvc_config_repository):
-        """Initialize ConfigService with RVCConfigRepository dependency."""
-        return ConfigService(rvc_config_repository)
+    # Register RVCConfigFacade after repositories are available
+    def _init_rvc_config_facade(rvc_config_repository):
+        """Initialize RVCConfigFacade with RVCConfigRepository dependency."""
+        return RVCConfigFacade(rvc_config_repository)
 
     service_registry.register_service(
-        name="config_service",
-        init_func=_init_config_service,
+        name="rvc_config_facade",
+        init_func=_init_rvc_config_facade,
         dependencies=[
             ServiceDependency("rvc_config_repository", DependencyType.REQUIRED),
         ],
-        description="Configuration service for RV-C and coach info management",
+        description="RV-C config facade for PGN/coach metadata lookups",
         tags={"service", "configuration", "rvc"},
         health_check=lambda cs: cs.get_health_status()
         if hasattr(cs, "get_health_status")

--- a/backend/core/registrations/group2_services.py
+++ b/backend/core/registrations/group2_services.py
@@ -280,19 +280,19 @@ def register(service_registry: SafetyServiceRegistry) -> None:
 
     service_registry.register_service(
         name="entity_domain_service",
-        init_func=lambda config_service,
+        init_func=lambda rvc_config_facade,
         auth_manager,
         entity_service,
         websocket_manager,
         entity_manager_service: EntityDomainService(
-            config_service=config_service,
+            config_service=rvc_config_facade,
             auth_manager=auth_manager,
             entity_service=entity_service,
             websocket_manager=websocket_manager,
             entity_manager=entity_manager_service,
         ),
         dependencies=[
-            ServiceDependency("config_service", DependencyType.REQUIRED),
+            ServiceDependency("rvc_config_facade", DependencyType.REQUIRED),
             ServiceDependency("auth_manager", DependencyType.REQUIRED),
             ServiceDependency("entity_service", DependencyType.REQUIRED),
             ServiceDependency("websocket_manager", DependencyType.REQUIRED),

--- a/backend/integrations/rvc/spec_loader.py
+++ b/backend/integrations/rvc/spec_loader.py
@@ -1,8 +1,12 @@
-"""
-Configuration Service for RV-C decoder with TTL caching and hot-reload capabilities.
+"""RV-C spec/mapping file loader (renamed from ConfigurationService in audit A10).
 
-This module provides centralized configuration management for DGN specifications,
-device mappings, and protocol settings with caching for optimal performance.
+Provides TTL-cached loading of RV-C DGN specifications, coach mappings, and
+protocol settings from disk with hot-reload support.
+
+Renamed from ``ConfigurationService`` -> ``RVCSpecLoader`` in audit cycle
+2026-05-13 PR A10 to clarify that this is a *spec-file loader*, not the
+application configuration object (which is Pydantic ``Settings``). See
+ADR-0008 for the three-tier config layering rationale.
 """
 
 import json
@@ -18,11 +22,11 @@ from cachetools import TTLCache
 logger = logging.getLogger(__name__)
 
 
-class ConfigurationLoadError(Exception):
+class RVCSpecLoadError(Exception):
     """Raised when configuration loading fails."""
 
 
-class ConfigurationService:
+class RVCSpecLoader:
     """
     Centralized configuration service with TTL caching and hot-reload support.
 
@@ -65,7 +69,7 @@ class ConfigurationService:
         # Validate configuration directory exists
         if not self.config_dir.exists():
             msg = f"Configuration directory does not exist: {self.config_dir}"
-            raise ConfigurationLoadError(msg)
+            raise RVCSpecLoadError(msg)
 
     def get_dgn_spec(self, dgn: int) -> dict[str, Any] | None:
         """

--- a/backend/services/__init__.py
+++ b/backend/services/__init__.py
@@ -15,5 +15,5 @@ A7.0--A7.3).
 
 Use the fully-qualified module path instead:
     from backend.services.entity_service import EntityService
-    from backend.services.config_service import ConfigService
+    from backend.services.rvc_config_facade import RVCConfigFacade
 """

--- a/backend/services/entity_domain_service.py
+++ b/backend/services/entity_domain_service.py
@@ -25,7 +25,7 @@ from pydantic import BaseModel, Field
 from backend.core.entity_manager import EntityManager
 from backend.models.entity import ControlCommand
 from backend.services.auth.manager import AuthManager
-from backend.services.config_service import ConfigService
+from backend.services.rvc_config_facade import RVCConfigFacade
 from backend.services.entity_service import EntityService
 from backend.websocket.handlers import WebSocketManager
 
@@ -111,7 +111,7 @@ class EntityDomainService:
 
     def __init__(
         self,
-        config_service: ConfigService,
+        config_service: RVCConfigFacade,
         auth_manager: AuthManager,
         entity_service: EntityService,
         websocket_manager: WebSocketManager,

--- a/backend/services/rvc_config_facade.py
+++ b/backend/services/rvc_config_facade.py
@@ -1,12 +1,17 @@
-"""
-Config Service - Repository Pattern Implementation
+"""RV-C configuration facade (renamed from ConfigService in audit A10).
 
-Service for configuration management using clean repository pattern
-with no legacy AppState dependencies.
+Thin wrapper over :class:`backend.repositories.RVCConfigRepository`
+exposing PGN/coach metadata lookups to the rest of the application.
+
+Renamed from ``ConfigService`` -> ``RVCConfigFacade`` in audit cycle
+2026-05-13 PR A10 to disambiguate from Pydantic ``Settings`` (the
+canonical app-config object) and from the spec-file loader, now called
+``RVCSpecLoader`` (see ``backend/integrations/rvc/spec_loader.py``).
+See ADR-0008 for the three-tier config layering rationale.
 """
 
 import logging
-from typing import Any, Dict, Optional
+from typing import Any
 
 from backend.models.common import CoachInfo
 from backend.repositories import RVCConfigRepository
@@ -14,12 +19,13 @@ from backend.repositories import RVCConfigRepository
 logger = logging.getLogger(__name__)
 
 
-class ConfigService:
-    """
-    Configuration service that uses RVCConfigRepository directly.
+class RVCConfigFacade:
+    """RV-C configuration facade backed by :class:`RVCConfigRepository`.
 
-    This is an example of the target architecture where services
-    depend on specific repositories rather than the monolithic AppState.
+    This is the request-time read API for RV-C metadata (PGN names,
+    coach info, command/status DGN pairs). It is *not* the canonical
+    app-configuration source -- that role belongs to Pydantic
+    ``Settings`` (``backend.core.config.get_settings``).
     """
 
     def __init__(self, rvc_config_repository: RVCConfigRepository):
@@ -30,7 +36,7 @@ class ConfigService:
             rvc_config_repository: The RVC configuration repository
         """
         self._rvc_config_repo = rvc_config_repository
-        logger.info("ConfigService initialized with RVCConfigRepository")
+        logger.info("RVCConfigFacade initialized with RVCConfigRepository")
 
     def get_coach_info(self) -> CoachInfo | None:
         """Get coach information."""
@@ -57,7 +63,7 @@ class ConfigService:
         repo_health = self._rvc_config_repo.get_health_status()
 
         return {
-            "service": "ConfigService",
+            "service": "RVCConfigFacade",
             "healthy": repo_health.get("healthy", False),
             "repository_health": repo_health,
             "configuration_loaded": self.is_configuration_loaded(),
@@ -85,15 +91,12 @@ class ConfigService:
 
 
 # Example factory function for ServiceRegistry registration
-def create_config_service() -> ConfigService:
-    """
-    Factory function for creating ConfigService with dependencies.
+def create_rvc_config_facade() -> RVCConfigFacade:
+    """Factory function for creating RVCConfigFacade with dependencies.
 
     This would be registered with ServiceRegistry and automatically
     get the RVCConfigRepository injected.
     """
-    # In real usage, this would get the repository from ServiceRegistry
-    # For now, we'll document the pattern
     raise NotImplementedError(
         "This factory should be registered with ServiceRegistry "
         "to get automatic dependency injection of RVCConfigRepository"

--- a/docs/adr/ADR-0008-rvc-config-facade-naming.md
+++ b/docs/adr/ADR-0008-rvc-config-facade-naming.md
@@ -1,0 +1,99 @@
+# ADR-0008: Rename `ConfigService` and `ConfigurationService` to clarify the three-tier config layering
+
+## Status
+
+**Accepted**, 2026-05-14. Architectural-audit cycle 2026-05-13, PR A10
+(closes #155).
+
+## Context
+
+Before this ADR, the codebase had three different things all called
+"configuration", and the names hid which one was which:
+
+| Class | File | What it actually did |
+|---|---|---|
+| `Settings` | `backend/core/config.py` | Pydantic-validated app configuration (server port, feature flags, persistence mode, etc.) |
+| `ConfigService` | `backend/services/config_service.py` | Thin facade over `RVCConfigRepository` for PGN names and coach info |
+| `ConfigurationService` | `backend/core/configuration_service.py` | TTL-cached YAML/JSON loader for RV-C spec and mapping files on disk |
+
+Two specific bits of wreckage flowed from this naming:
+
+1. **`copilot-instructions.md` told contributors "ConfigService: ALWAYS
+   use for configuration access."** That was wrong. `Settings` is the
+   canonical app-configuration object, and most code already read
+   `Settings` directly via `get_settings()`. `ConfigService` only knows
+   about RV-C metadata; using it for a general app setting would
+   crash. The instruction was steering humans and Copilot toward the
+   wrong abstraction.
+2. **`ConfigService` vs `ConfigurationService` were undistinguishable
+   by name.** One was a request-time read API for parsed RV-C data;
+   the other was a file-system spec loader with a TTL cache. Both
+   answered to "the config service" in code review.
+
+This was a maintenance hazard, not a runtime bug: the wiring was
+correct, only the names were lying.
+
+## Decision
+
+1. **Three tiers, three distinct names**:
+
+   | Tier | Class | New module | Role |
+   |---|---|---|---|
+   | App config | `Settings` | `backend.core.config` | Canonical app configuration, read via `get_settings()`. **No rename** -- this layer was already right. |
+   | RV-C metadata facade | `RVCConfigFacade` (was `ConfigService`) | `backend.services.rvc_config_facade` | Thin request-time read API over `RVCConfigRepository` for PGN names and coach info. |
+   | Spec-file loader | `RVCSpecLoader` (was `ConfigurationService`) | `backend.integrations.rvc.spec_loader` | TTL-cached loader for `rvc.json` / `coach_mapping.yml` / DGN spec files. Internal to the RV-C decoder; not a public service. |
+
+2. **Renames are mechanical**: every call site moved from
+   `ConfigService` -> `RVCConfigFacade` and from `ConfigurationService`
+   -> `RVCSpecLoader`. The `ConfigurationLoadError` exception was
+   renamed to `RVCSpecLoadError` for symmetry. The `ServiceRegistry`
+   key `"config_service"` became `"rvc_config_facade"`.
+
+3. **Public DI exports follow the rename**: `get_config_service` ->
+   `get_rvc_config_facade`, and the typed alias `ConfigService` (which
+   was actually `Annotated[ConfigService, Depends(...)]`) was replaced
+   with `RVCConfigFacade`. There is no back-compat alias.
+
+4. **`copilot-instructions.md` was rewritten** to drop the misleading
+   "ALWAYS use ConfigService" guidance and to document the three
+   tiers explicitly.
+
+## Out of scope (deferred)
+
+- `RVCSpecLoader` was, in production code, only imported by tests at
+  the time of this rename -- it had been replaced earlier by a
+  repository-backed path. Auditing whether `RVCSpecLoader` is dead
+  code worth deleting is a separate cleanup; this ADR only handles
+  the rename.
+- The `CONFIGURATION_SERVICE = "configuration_service"` enum value in
+  `backend/integrations/can/performance_monitor.py` is a string
+  category label, not a service-registry key, and is left as-is.
+- The environment variable
+  `COACHIQ_CANBUS_DECODER_V2__ENABLE_CONFIGURATION_SERVICE` is a
+  feature-flag name distinct from a class name. It is left as-is to
+  avoid breaking external NixOS deployments.
+- A handful of cosmetic strings in tests (test class names like
+  `TestConfigServiceConstruction`, docstring labels) still mention the
+  old names. These were intentionally not renamed: they are local
+  test labels, not API surface.
+
+## Consequences
+
+- **Positive**: The three "configuration" concepts now have distinct
+  names that match their roles. Reading `Settings` directly is the
+  obvious path for app config, and `RVCConfigFacade` cannot be
+  mistaken for the canonical config object.
+- **Positive**: The docs no longer steer contributors at the wrong
+  abstraction.
+- **Cost**: ~10 backend call sites + 3 test files were updated. All
+  changes were mechanical; no behavior changed.
+
+## References
+
+- Issue #155: A10 -- Rename `ConfigService` and `ConfigurationService`
+- Audit prompt:
+  `.github/prompts/audit-2026-05-13-A10-config-service-rename.prompt.md`
+- ADR-0006: Typed dependency injection (the tier-distinguishing
+  pattern this rename reinforces)
+- ADR-0007: Auth service namespace (sibling rename in the same audit
+  cycle)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -68,6 +68,11 @@ Keep ADRs short -- 50-150 lines is typical. If you find yourself writing
   `backend/services/auth/` package, split `auth_services.py` per
   class, and keep `AuthManager` (policy engine) and `AuthService`
   (request-time facade) intentionally separate.
+- [ADR-0008](ADR-0008-rvc-config-facade-naming.md) -- Rename
+  `ConfigService` -> `RVCConfigFacade` and `ConfigurationService` ->
+  `RVCSpecLoader` so the three "configuration" tiers (Pydantic
+  `Settings`, RV-C metadata facade, RV-C spec-file loader) have
+  distinct names.
 
 ## Status
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,7 +29,7 @@ from httpx import AsyncClient
 
 from backend.core.dependencies import (
     get_can_facade,
-    get_config_service,
+    get_rvc_config_facade,
     get_entity_service,
 )
 
@@ -385,7 +385,7 @@ def override_config_service(mock_config_service: Mock) -> Generator[Mock, None, 
     Override the config_service dependency with a mock.
     Use this when testing endpoints that depend on configuration.
     """
-    app.dependency_overrides[get_config_service] = lambda: mock_config_service  # type: ignore[attr-defined]
+    app.dependency_overrides[get_rvc_config_facade] = lambda: mock_config_service  # type: ignore[attr-defined]
     yield mock_config_service
     app.dependency_overrides.clear()  # type: ignore[attr-defined]
 
@@ -417,7 +417,7 @@ def override_all_services(
         {
             get_entity_service: lambda: mock_entity_service,
             get_can_facade: lambda: mock_can_service,
-            get_config_service: lambda: mock_config_service,
+            get_rvc_config_facade: lambda: mock_config_service,
         }
     )  # type: ignore[attr-defined]
     app.state.service_registry = mock_service_registry

--- a/tests/integration/test_canbus_decoder_integration.py
+++ b/tests/integration/test_canbus_decoder_integration.py
@@ -21,7 +21,7 @@ from unittest.mock import Mock
 
 import pytest
 
-from backend.core.configuration_service import ConfigurationService
+from backend.integrations.rvc.spec_loader import RVCSpecLoader
 from backend.core.safety_state_engine import SafetyEvent, SafetyStateEngine
 from backend.integrations.can.performance_monitor import ComponentType, PerformanceMonitor
 from backend.integrations.can.protocol_router import (
@@ -71,7 +71,7 @@ class IntegratedCANDecoder:
 
     def __init__(self, config_dir: Path):
         # Initialize all components
-        self.config_service = ConfigurationService(config_dir, cache_ttl=60, max_cache_size=100)
+        self.config_service = RVCSpecLoader(config_dir, cache_ttl=60, max_cache_size=100)
         self.safety_engine = SafetyStateEngine()
         # Use basic security manager for protocol router
         self.basic_security_manager = SecurityManager()
@@ -278,10 +278,10 @@ _MOVING_SPEED_THRESHOLD_MPH = 0.5
 def temp_config_dir(tmp_path: Path) -> Path:
     """Create a temporary RV-C configuration directory.
 
-    ``ConfigurationService._load_full_spec`` reads ``rvc.json`` at the
+    ``RVCSpecLoader._load_full_spec`` reads ``rvc.json`` at the
     config-dir root and looks up DGN entries via ``full_spec["dgns"][hex]``
     (uppercase hex, no ``0x`` prefix). The previous fixture wrote a
-    ``dgn_specs/<dgn>.yaml`` file that ConfigurationService never reads,
+    ``dgn_specs/<dgn>.yaml`` file that RVCSpecLoader never reads,
     so ``get_dgn_spec`` always returned None and the cache stayed empty,
     breaking ``test_configuration_service_integration``.
     """

--- a/tests/services/test_config_service.py
+++ b/tests/services/test_config_service.py
@@ -1,7 +1,7 @@
 """
-Tests for the ConfigService.
+Tests for the RVCConfigFacade.
 
-ConfigService is a thin facade over RVCConfigRepository that exposes
+RVCConfigFacade is a thin facade over RVCConfigRepository that exposes
 sync queries for coach info / PGN names / DGN command-status pairs and
 a few async wrappers for raw config content. Tests fully mock the
 repository.
@@ -13,7 +13,7 @@ import pytest
 
 from backend.models.common import CoachInfo
 from backend.repositories import RVCConfigRepository
-from backend.services.config_service import ConfigService
+from backend.services.rvc_config_facade import RVCConfigFacade
 
 
 @pytest.fixture
@@ -38,14 +38,14 @@ def mock_repository() -> MagicMock:
 
 
 @pytest.fixture
-def config_service(mock_repository) -> ConfigService:
-    """Create ConfigService instance for testing."""
-    return ConfigService(rvc_config_repository=mock_repository)
+def config_service(mock_repository) -> RVCConfigFacade:
+    """Create RVCConfigFacade instance for testing."""
+    return RVCConfigFacade(rvc_config_repository=mock_repository)
 
 
 class TestConfigServiceConstruction:
     def test_init_stores_repository(self, mock_repository):
-        service = ConfigService(rvc_config_repository=mock_repository)
+        service = RVCConfigFacade(rvc_config_repository=mock_repository)
         assert service._rvc_config_repo is mock_repository
 
 
@@ -118,7 +118,7 @@ class TestConfigServiceHealth:
 
         health = config_service.get_health_status()
 
-        assert health["service"] == "ConfigService"
+        assert health["service"] == "RVCConfigFacade"
         assert health["healthy"] is True
         assert health["configuration_loaded"] is True
         assert health["repository_health"] == {"healthy": True, "items": 100}
@@ -132,7 +132,7 @@ class TestConfigServiceHealth:
 
         health = config_service.get_health_status()
 
-        assert health["service"] == "ConfigService"
+        assert health["service"] == "RVCConfigFacade"
         assert health["healthy"] is False
         assert health["configuration_loaded"] is False
         assert health["repository_health"]["reason"] == "config file missing"
@@ -178,7 +178,7 @@ class TestConfigServiceAsyncContent:
 
         assert status["loaded"] is True
         assert status["summary"]["pgn_count"] == 50
-        assert status["health"]["service"] == "ConfigService"
+        assert status["health"]["service"] == "RVCConfigFacade"
         assert status["health"]["healthy"] is True
 
 
@@ -186,7 +186,7 @@ class TestCreateConfigServiceFactory:
     """The factory function is documented as not-yet-wired."""
 
     def test_factory_raises_until_wired_to_service_registry(self):
-        from backend.services.config_service import create_config_service
+        from backend.services.rvc_config_facade import create_rvc_config_facade
 
         with pytest.raises(NotImplementedError, match="ServiceRegistry"):
-            create_config_service()
+            create_rvc_config_facade()

--- a/tests/unit/test_configuration_service.py
+++ b/tests/unit/test_configuration_service.py
@@ -1,9 +1,9 @@
 """
-Unit Tests for ConfigurationService
+Unit Tests for RVCSpecLoader
 
 Tests TTL caching behavior, thread safety, and hot-reload functionality
 for the centralized configuration service in
-``backend/core/configuration_service.py``.
+``backend/integrations/rvc/spec_loader.py``.
 
 Filesystem layout
 -----------------
@@ -31,9 +31,9 @@ from pathlib import Path
 import pytest
 import yaml
 
-from backend.core.configuration_service import (
-    ConfigurationLoadError,
-    ConfigurationService,
+from backend.integrations.rvc.spec_loader import (
+    RVCSpecLoadError,
+    RVCSpecLoader,
 )
 
 # ----------------------------------------------------------------------------
@@ -51,7 +51,7 @@ def temp_config_dir():
 @pytest.fixture
 def config_service(temp_config_dir):
     """Create a configuration service instance with short TTL for testing."""
-    return ConfigurationService(temp_config_dir, cache_ttl=1, max_cache_size=10)
+    return RVCSpecLoader(temp_config_dir, cache_ttl=1, max_cache_size=10)
 
 
 def _write_rvc_json(config_dir: Path, dgns: dict[str, dict]) -> Path:
@@ -93,7 +93,7 @@ class TestInitialization:
 
     def test_initialization(self, temp_config_dir):
         """Custom cache_ttl + max_cache_size are propagated to the dgn_cache."""
-        service = ConfigurationService(temp_config_dir, cache_ttl=300, max_cache_size=1000)
+        service = RVCSpecLoader(temp_config_dir, cache_ttl=300, max_cache_size=1000)
 
         assert service.config_dir == temp_config_dir
         # Only the dgn_cache uses the user-supplied max_cache_size; the other
@@ -107,8 +107,8 @@ class TestInitialization:
     def test_missing_config_dir_raises(self, tmp_path):
         """Pointing the service at a nonexistent directory must error fast."""
         nonexistent = tmp_path / "does_not_exist"
-        with pytest.raises(ConfigurationLoadError):
-            ConfigurationService(nonexistent)
+        with pytest.raises(RVCSpecLoadError):
+            RVCSpecLoader(nonexistent)
 
 
 # ----------------------------------------------------------------------------
@@ -165,7 +165,7 @@ class TestDgnSpec:
 
     def test_dgn_spec_cache_size_limit(self, temp_config_dir):
         """``max_cache_size`` is enforced by the underlying TTLCache."""
-        service = ConfigurationService(temp_config_dir, cache_ttl=300, max_cache_size=2)
+        service = RVCSpecLoader(temp_config_dir, cache_ttl=300, max_cache_size=2)
 
         # Populate rvc.json with several DGNs so all lookups hit the cache.
         _write_rvc_json(
@@ -182,7 +182,7 @@ class TestDgnSpec:
         """Cached DGN is reloaded after TTL expires."""
         # Use very short TTL; cachetools' TTLCache uses time.monotonic() and
         # a >TTL sleep is enough to evict the entry on the next access.
-        service = ConfigurationService(temp_config_dir, cache_ttl=1, max_cache_size=10)
+        service = RVCSpecLoader(temp_config_dir, cache_ttl=1, max_cache_size=10)
 
         _write_rvc_json(temp_config_dir, {"1FED1": {"name": "Cached"}})
         service.get_dgn_spec(0x1FED1)


### PR DESCRIPTION
## Summary

Disambiguates three different configuration concepts in the codebase that were all called variants of "config". Closes #155.

## Problem

The codebase had three things all called "configuration", and the names hid what each one actually did:

| Class | File | What it actually did |
|---|---|---|
| `Settings` | `backend/core/config.py` | Pydantic-validated app config (server port, feature flags, persistence mode, ...) |
| `ConfigService` | `backend/services/config_service.py` | Thin facade over `RVCConfigRepository` for PGN names and coach info |
| `ConfigurationService` | `backend/core/configuration_service.py` | TTL-cached YAML/JSON loader for RV-C spec/mapping files |

Worse, `copilot-instructions.md` told contributors **"ConfigService: ALWAYS use for configuration access"** -- which was wrong. `Settings` is the canonical app-configuration object. `ConfigService` only knows about RV-C metadata.

## Solution

Three tiers, three distinct names:

| Tier | Class | Module | Role |
|---|---|---|---|
| App config | `Settings` | `backend.core.config` | Canonical, read via `get_settings()`. **No rename**. |
| RV-C metadata facade | `RVCConfigFacade` (was `ConfigService`) | `backend.services.rvc_config_facade` | Request-time read API over `RVCConfigRepository`. |
| Spec-file loader | `RVCSpecLoader` (was `ConfigurationService`) | `backend.integrations.rvc.spec_loader` | TTL-cached YAML/JSON loader. |

### Mechanical changes

- `backend/services/config_service.py` -> `backend/services/rvc_config_facade.py`
- `backend/core/configuration_service.py` -> `backend/integrations/rvc/spec_loader.py`
- `ConfigurationLoadError` -> `RVCSpecLoadError`
- ServiceRegistry key `"config_service"` -> `"rvc_config_facade"`
- `get_config_service()` -> `get_rvc_config_facade()`; typed alias renamed
- All ~10 backend callsites + 3 test files updated
- `copilot-instructions.md` rewritten to drop misleading guidance and document the three tiers
- ADR-0008 documents the layering rationale

## Verification

- `from backend.main import create_app; app = create_app()` -> 315 routes
- `pytest`: 828 passed, 28 skipped, 0 failures
- `pyright`: 1441 errors (baseline 1443, dropped by 2)
- `ruff_diff_check.py origin/main`: ✅ no NEW issues on changed lines

## Out of scope

- `COACHIQ_CANBUS_DECODER_V2__ENABLE_CONFIGURATION_SERVICE` env var: left as-is (feature-flag name, not class name)
- `CONFIGURATION_SERVICE = "configuration_service"` enum value: left as-is (category label)
- Cosmetic test class names (`TestConfigServiceConstruction`) left as-is
- Whether `RVCSpecLoader` is dead code (no production importer found) -- separate audit task

## Audit trail

- Issue: #155
- Audit prompt: `.github/prompts/audit-2026-05-13-A10-config-service-rename.prompt.md`
- ADR: `docs/adr/ADR-0008-rvc-config-facade-naming.md`
- Cycle: architectural-audit-2026-05-13 (sibling PRs: #173 A8, #174 A9)