### PR TITLE
chore(ci): ratchet pyright baseline 1443 -> 1441 (A10 follow-up)

### DIFF
--- a/scripts/ci-quality-gate.sh
+++ b/scripts/ci-quality-gate.sh
@@ -19,7 +19,7 @@ RESET="\033[0m"
 # gate's job is to stop the count from going UP (a ratchet); fixing actual
 # pyright errors lower the count and the script will print a green message
 # nudging you to update the baseline downward.
-EXPECTED_PYRIGHT_ERRORS=1443  # Ratcheted 2026-05-14 (PR A7.3 on top of A1+A2+A3+A6+A7.0+A7.2, audit cycle 2026-05-13). Typing entity + safety + config + rvc DI accessors is no-op for pyright count locally (1443 -> 1443). Hardened ratchet (#117) catches drops -- working as designed.
+EXPECTED_PYRIGHT_ERRORS=1441  # Ratcheted 2026-05-14 (PR A10 #175, audit cycle 2026-05-13). Rename ConfigService->RVCConfigFacade dropped 2 type errors (1443 -> 1441).
 EXPECTED_FRONTEND_TS_ERRORS=0  # Ratcheted 2026-05-12 to 0 by PR #110 (DatabaseManagementTab + can-sniffer + useCANScanWebSocket generic). Any new TS error is a hard fail.
 EXPECTED_FRONTEND_ESLINT_ERRORS=648  # Captured 2026-05-12 by PR #117. Whole-project ESLint baseline; the diff-aware gate (eslint_diff_check.py in Stage 1) catches NEW issues per-line, this baseline is the project-wide ratchet.
 


### PR DESCRIPTION
Mechanical follow-up to PR #175 (A10).

A10's rename of `ConfigService` -> `RVCConfigFacade` dropped 2 type errors that the hardened ratchet flagged on the merged commit. This commit updates the baseline so CI on main goes green again.

No code changes -- just `scripts/ci-quality-gate.sh` baseline update from 1443 -> 1441.