### PR TITLE
fix(ci): repair backend test stage and the live-route 500s it exposed

### DIFF
--- a/backend/api/routers/startup_monitoring.py
+++ b/backend/api/routers/startup_monitoring.py
@@ -20,6 +20,9 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/startup", tags=["startup_monitoring"])
 
+# Services starting slower than this are reported as bottlenecks.
+SLOW_SERVICE_THRESHOLD_MS = 200
+
 
 # Response Models
 
@@ -224,7 +227,9 @@ async def get_startup_metrics(
             "performance_grade": _calculate_performance_grade(total_time),
             "efficiency_score": min(100, max(0, 100 - (total_time - 500) / 10)),
             "bottlenecks": [
-                service["name"] for service in slowest_services if service.startup_time_ms > 200
+                service.name
+                for service in slowest_services
+                if service.startup_time_ms > SLOW_SERVICE_THRESHOLD_MS
             ],
             "optimization_suggestions": [],
         }
@@ -235,7 +240,7 @@ async def get_startup_metrics(
                 "Consider optimizing service initialization order"
             )
 
-        if len([s for s in slowest_services if s.startup_time_ms > 200]) > 0:
+        if len([s for s in slowest_services if s.startup_time_ms > SLOW_SERVICE_THRESHOLD_MS]) > 0:
             performance_analysis["optimization_suggestions"].append(
                 "Review slow service initialization functions"
             )

--- a/backend/core/dependencies.py
+++ b/backend/core/dependencies.py
@@ -135,6 +135,21 @@ def initialize_composition_root(composition_root: _CompositionRootClass) -> None
     logger.info("Composition root initialized for dependency injection")
 
 
+def reset_composition_root(composition_root: _CompositionRootClass | None = None) -> None:
+    """Clear the module-level composition root.
+
+    Called from the application lifespan's shutdown path so that a process
+    can start a second app instance (each ``TestClient(app)`` enter/exit
+    cycle boots the lifespan again). When ``composition_root`` is given,
+    only clears the global if it still points at that root, so a stale
+    shutdown can't clobber a newer app's root.
+    """
+    global _composition_root  # noqa: PLW0603 - intentional module-level state
+    if composition_root is not None and _composition_root is not composition_root:
+        return
+    _composition_root = None
+
+
 def get_composition_root() -> _CompositionRootClass:
     """Get the composition root instance."""
     if _composition_root is None:

--- a/backend/integrations/can/can_bus_recorder.py
+++ b/backend/integrations/can/can_bus_recorder.py
@@ -833,6 +833,16 @@ class CANBusRecorder(GuardrailParticipant):
             },
         }
 
+    async def get_recent_messages(self, limit: int = 100) -> list[dict[str, Any]]:
+        """Get the most recent messages from the in-memory buffer.
+
+        Returns up to ``limit`` messages in chronological order (oldest first).
+        """
+        if limit <= 0:
+            return []
+        recent = list(self.message_buffer)[-limit:]
+        return [message.to_dict() for message in recent]
+
     async def list_recordings(self) -> list[dict[str, Any]]:
         """List all available recordings."""
         recordings = []

--- a/backend/main.py
+++ b/backend/main.py
@@ -191,7 +191,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     router_sidecar_server = None
 
     # Initialize the module-level composition root for dependency injection.
-    from backend.core.dependencies import initialize_composition_root
+    from backend.core.dependencies import initialize_composition_root, reset_composition_root
 
     initialize_composition_root(composition_root)
 
@@ -344,6 +344,10 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             # Feature manager removed - all services managed by composition root
 
             # CoreServices removed - individual services shutdown by composition root
+        finally:
+            # Allow this process to boot another app instance (TestClient
+            # enters/exits the lifespan once per test).
+            reset_composition_root(composition_root)
 
         logger.info("Backend services stopped")
 

--- a/backend/services/can/can_facade.py
+++ b/backend/services/can/can_facade.py
@@ -372,7 +372,7 @@ class CANFacade(GuardrailParticipant):
         stats = {
             "interfaces": await self._interface_service.get_interface_stats(),
             "queue": await self.get_queue_status(),
-            "analyzer": await self._analyzer.get_statistics(),
+            "analyzer": self._analyzer.get_statistics(),
         }
 
         # Get performance baselines from monitor

--- a/scripts/check_module_coverage.py
+++ b/scripts/check_module_coverage.py
@@ -15,7 +15,8 @@ from pathlib import Path
 
 MODULE_FLOORS = {
     "backend/services/can/can_facade.py": 65.0,
-    "backend/services/safety/safety_service.py": 42.0,
+    # safety_service.py was renamed in HOF-051; floor carried over.
+    "backend/services/guardrails/command_guardrail_service.py": 42.0,
     "backend/services/auth/service.py": 80.0,
     "backend/services/auth/manager.py": 32.0,
     "backend/middleware/secure_auth.py": 60.0,

--- a/tests/api/test_startup_monitoring.py
+++ b/tests/api/test_startup_monitoring.py
@@ -1,0 +1,48 @@
+"""Tests for the startup-monitoring metrics endpoint."""
+
+from unittest.mock import Mock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend.api.routers.startup_monitoring import router
+from backend.core.dependencies import get_composition_root
+
+pytestmark = pytest.mark.api
+
+
+def _make_root_with_timings(service_timings: dict[str, float]) -> Mock:
+    root = Mock()
+    root.get_startup_metrics.return_value = {
+        "total_startup_time_ms": sum(service_timings.values()),
+        "service_count": len(service_timings),
+        "average_service_time_ms": 0.0,
+        "startup_errors": {},
+    }
+    root.get_service_timings.return_value = service_timings
+    root.has_service.return_value = True
+    return root
+
+
+def test_startup_metrics_reports_slow_service_bottlenecks() -> None:
+    """Slow services (>200ms) appear as bottlenecks instead of 500ing.
+
+    Regression: the bottleneck comprehension subscripted ServiceTimingInfo
+    models (service["name"]), so any run with a >200ms service startup
+    turned /api/startup/metrics into an HTTP 500.
+    """
+    app = FastAPI()
+    app.include_router(router)
+    root = _make_root_with_timings({"slow_service": 350.0, "fast_service": 10.0})
+    app.dependency_overrides[get_composition_root] = lambda: root
+
+    response = TestClient(app).get("/api/startup/metrics")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["performance_analysis"]["bottlenecks"] == ["slow_service"]
+    assert [service["name"] for service in body["slowest_services"]] == [
+        "slow_service",
+        "fast_service",
+    ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,8 +29,8 @@ from httpx import AsyncClient
 
 from backend.core.dependencies import (
     get_can_facade,
-    get_rvc_config_facade,
     get_entity_service,
+    get_rvc_config_facade,
 )
 
 # Persistence is now default - using dependencies from core.dependencies
@@ -206,7 +206,7 @@ def client_with_persistence(
     # Override persistence dependencies with test instances
     app.dependency_overrides[get_persistence_feature] = lambda: test_persistence_feature  # type: ignore[attr-defined]
     app.dependency_overrides[get_database_manager] = (
-        lambda: test_persistence_feature._database_manager  # noqa: SLF001
+        lambda: test_persistence_feature._database_manager
     )  # type: ignore[attr-defined]
 
     with TestClient(app=app, base_url="http://test") as test_client:
@@ -249,7 +249,7 @@ async def async_client_with_persistence(
     # Override persistence dependencies with test instances
     app.dependency_overrides[get_persistence_feature] = lambda: test_persistence_feature  # type: ignore[attr-defined]
     app.dependency_overrides[get_database_manager] = (
-        lambda: test_persistence_feature._database_manager  # noqa: SLF001
+        lambda: test_persistence_feature._database_manager
     )  # type: ignore[attr-defined]
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
@@ -561,6 +561,22 @@ def reset_dependency_overrides() -> Generator[None, None, None]:
     """
     yield
     app.dependency_overrides.clear()  # type: ignore[attr-defined]
+
+
+@pytest.fixture(autouse=True)
+def reset_composition_root_global() -> Generator[None, None, None]:
+    """
+    Automatically clear the module-level composition root after each test.
+
+    The app lifespan resets it on clean shutdown, but a test that calls
+    initialize_composition_root() directly (or an aborted startup) would
+    otherwise poison every later test that boots the real app with
+    "Composition root already initialized".
+    """
+    yield
+    from backend.core.dependencies import reset_composition_root
+
+    reset_composition_root()
 
 
 # ================================

--- a/tests/integrations/can/test_can_bus_recorder.py
+++ b/tests/integrations/can/test_can_bus_recorder.py
@@ -1,0 +1,56 @@
+"""Tests for CANBusRecorder buffer queries used by the CAN facade."""
+
+from pathlib import Path
+
+import pytest
+
+from backend.integrations.can.can_bus_recorder import CANBusRecorder, RecordedMessage
+
+pytestmark = pytest.mark.can
+
+
+def _message(index: int) -> RecordedMessage:
+    return RecordedMessage(
+        timestamp=1000.0 + index,
+        can_id=0x18FEF100 + index,
+        data=bytes([index & 0xFF] * 8),
+        interface="can0",
+    )
+
+
+@pytest.fixture
+def recorder(tmp_path: Path) -> CANBusRecorder:
+    return CANBusRecorder(buffer_size=10, storage_path=tmp_path)
+
+
+@pytest.mark.asyncio
+async def test_get_recent_messages_returns_newest_slice_as_dicts(
+    recorder: CANBusRecorder,
+) -> None:
+    """The facade's /api/can/recent path reads dict-shaped messages from the buffer.
+
+    Regression: CANFacade.get_recent_messages delegated to a recorder method
+    that did not exist, 500ing /api/can/recent on any live app.
+    """
+    for index in range(5):
+        recorder.message_buffer.append(_message(index))
+
+    recent = await recorder.get_recent_messages(limit=3)
+
+    assert [message["can_id"] for message in recent] == [
+        0x18FEF102,
+        0x18FEF103,
+        0x18FEF104,
+    ]
+    assert recent[-1] == _message(4).to_dict()
+
+
+@pytest.mark.asyncio
+async def test_get_recent_messages_handles_empty_buffer_and_bad_limits(
+    recorder: CANBusRecorder,
+) -> None:
+    assert await recorder.get_recent_messages() == []
+
+    recorder.message_buffer.append(_message(0))
+    assert await recorder.get_recent_messages(limit=0) == []
+    assert len(await recorder.get_recent_messages(limit=100)) == 1

--- a/tests/services/test_can_facade.py
+++ b/tests/services/test_can_facade.py
@@ -97,8 +97,11 @@ class TestCANFacade:
         # Verify all safety-critical services received emergency stop call
         mock_dependencies["bus_service"].halt_command_emission.assert_awaited_once_with(reason)
         mock_dependencies["injector"].halt_command_emission.assert_awaited_once_with(reason)
-        mock_dependencies["message_filter"].halt_command_emission.assert_awaited_once_with(reason)
         mock_dependencies["recorder"].halt_command_emission.assert_awaited_once_with(reason)
+
+        # The message filter is monitoring-only for transmit flow and stays
+        # outside the command-halt cascade.
+        mock_dependencies["message_filter"].halt_command_emission.assert_not_awaited()
 
         # Verify operational services received stop call
         mock_dependencies["analyzer"].stop.assert_awaited_once()
@@ -125,10 +128,10 @@ class TestCANFacade:
         # Verify all services were attempted despite failure
         mock_dependencies["bus_service"].halt_command_emission.assert_awaited_once_with(reason)
         mock_dependencies["injector"].halt_command_emission.assert_awaited_once_with(reason)
-        mock_dependencies["message_filter"].halt_command_emission.assert_awaited_once_with(reason)
+        mock_dependencies["recorder"].halt_command_emission.assert_awaited_once_with(reason)
 
         # Verify failure was logged
-        assert "Emergency stop failed for service" in caplog.text
+        assert "Command halt failed for service" in caplog.text
         assert "Bus hardware fault" in caplog.text
 
         # Verify emergency stop state is still set despite failure
@@ -195,13 +198,16 @@ class TestCANFacade:
             }
         )
         mock_dependencies["recorder"].get_queue_status = AsyncMock(return_value={"size": 0})
-        mock_dependencies["analyzer"].get_statistics = AsyncMock(return_value={})
+        # Sync Mock on purpose: the real ProtocolAnalyzer.get_statistics is not
+        # a coroutine; an AsyncMock here masked a facade-level await bug.
+        mock_dependencies["analyzer"].get_statistics = Mock(return_value={"messages": 0})
         mock_dependencies["performance_monitor"].get_performance_baselines = AsyncMock(
             return_value={"uptime_seconds": 42.0}
         )
 
         stats = await can_facade.get_bus_statistics()
 
+        assert stats["analyzer"] == {"messages": 0}
         assert stats["summary"]["total_messages"] == 135
         assert stats["summary"]["total_errors"] == 7
         assert stats["summary"]["error_rate_percent"] == pytest.approx(7 / 135 * 100)

--- a/tests/services/test_component_identification_discovery.py
+++ b/tests/services/test_component_identification_discovery.py
@@ -114,25 +114,6 @@ CAPTURED_COMPONENT_IDS = [
 ]
 
 
-class FakeRegistry:
-    """Minimal ServiceRegistry test double for CANBusService runtime lookup."""
-
-    def __init__(self, discovery_service: DeviceDiscoveryService):
-        """Initialize with the device discovery service to return."""
-        self.discovery_service = discovery_service
-
-    def has_service(self, service_name: str) -> bool:
-        """Return whether the requested service is available."""
-        return service_name == "device_discovery_service"
-
-    def get_service(self, service_name: str) -> DeviceDiscoveryService:
-        """Return the requested service."""
-        if service_name != "device_discovery_service":
-            msg = f"unexpected service {service_name}"
-            raise RuntimeError(msg)
-        return self.discovery_service
-
-
 def make_bam_frames(payload: bytes, source_address: int = 0x9E) -> Iterable[tuple[int, bytes]]:
     """Build an addressed BAM Component-ID transfer."""
     packet_count = (len(payload) + 6) // 7
@@ -170,19 +151,15 @@ def test_decode_component_id_uses_captured_field_shape() -> None:
 
 
 @pytest.mark.asyncio
-async def test_can_bus_reassembles_component_id_and_dedupes_mirror(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+async def test_can_bus_reassembles_component_id_and_dedupes_mirror() -> None:
     """Mirrored 0xFEEB BAM completions update one discovered device."""
     discovery_service = DeviceDiscoveryService(config=Mock())
-    service = CANBusService(can_tracking_repository=Mock(), system_state_repository=Mock())
-    service.bam_handler = BAMHandler()
-
-    from backend.core import dependencies
-
-    monkeypatch.setattr(
-        dependencies, "get_service_registry", lambda: FakeRegistry(discovery_service)
+    service = CANBusService(
+        can_tracking_repository=Mock(),
+        system_state_repository=Mock(),
+        device_discovery_service=discovery_service,
     )
+    service.bam_handler = BAMHandler()
 
     for interface in ("can0", "can1"):
         for arbitration_id, data in make_bam_frames(AQUA_HOT_PAYLOAD):

--- a/tests/services/test_service_key_lookups.py
+++ b/tests/services/test_service_key_lookups.py
@@ -154,7 +154,7 @@ async def test_can_tool_websocket_handlers_use_canonical_service_keys(
     """CAN-tool websocket handlers resolve canonical root service keys."""
     monkeypatch.setattr(
         websocket_service_module,
-        "get_websocket_auth_handler",
+        "_get_websocket_auth_handler",
         lambda: _AllowingAuthHandler(),
     )
     websocket_service = WebSocketService(**{canonical_key: service})


### PR DESCRIPTION
## Summary

The **Full CI / Nix-based CI** backend test stage (`nix run .#guardrail-coverage`) has been red on main since before #179 (e.g. run 28693219101). This fixes both failure clusters *and* the four real production 500s the live-route regression test was correctly reporting.

### Test isolation — 12 ERRORS `RuntimeError: Composition root already initialized`

Every `TestClient(app)` enter/exit runs the lifespan, which builds a fresh `CompositionRoot`, but the module-level global in `backend/core/dependencies.py` was never cleared — so the second test in a process to boot the real app blew up.

- `dependencies.py`: new `reset_composition_root()`, called from the lifespan shutdown path (guarded so a stale shutdown can't clobber a newer app's root)
- `tests/conftest.py`: autouse fixture clears the root between tests as a backstop

### Real bugs behind the `test_live_authenticated_parameterless_get_routes_do_not_500` failure

Pulled from the CI run's server-side tracebacks:

| Route | Cause | Fix |
|---|---|---|
| `/api/can/statistics`, `/api/can/metrics/computed`, `/api/v1/networks/statistics` | `can_facade.py` awaited the **sync** `ProtocolAnalyzer.get_statistics()` | drop the `await` |
| `/api/can/recent` | facade delegated to a **nonexistent** `CANBusRecorder.get_recent_messages` | implement it from the recorder's ring buffer |
| `/api/startup/metrics` | `service["name"]` subscripted a Pydantic `ServiceTimingInfo` — only triggers when a service takes >200ms to start, which is why it reproduced on CI runners but not locally | `service.name`, threshold extracted to a constant |

An `AsyncMock` in the existing facade test masked the analyzer bug; the stub is now a sync `Mock` matching the real interface, plus new regression tests (`tests/integrations/can/test_can_bus_recorder.py`, `tests/api/test_startup_monitoring.py`).

### Stale tests updated to current contracts

- `test_component_identification_discovery.py`: injects `device_discovery_service` via the `CANBusService` constructor (the `get_service_registry` monkeypatch target no longer exists)
- `test_service_key_lookups.py`: patches the renamed `_get_websocket_auth_handler`
- `test_can_facade.py` halt tests: the message filter is monitoring-only and intentionally outside the command-halt cascade (pre-existing failures, not in the CI subset)

### Latent CI landmine defused

`scripts/check_module_coverage.py` still ratcheted `backend/services/safety/safety_service.py`, which HOF-051 renamed — CI never reached the ratchet because pytest failed first, but it would have failed the job immediately after the test fixes landed. The 42% floor now follows the rename to `backend/services/guardrails/command_guardrail_service.py` (currently 52.1%).

## Verification

- `pytest -m "can or auth or safety or websocket"` (the exact CI selection): **171 passed, 4 skipped**
- `scripts/check_module_coverage.py`: all floors OK
- Zero new ruff findings on changed lines; all files format-clean
- Pyright error count identical before/after (no baseline drift from 1243)

🤖 Generated with [Claude Code](https://claude.com/claude-code)