### PR TITLE
fix(can): wire the RX pipeline end to end

### DIFF
--- a/backend/core/composition_root.py
+++ b/backend/core/composition_root.py
@@ -1054,11 +1054,12 @@ class CompositionRoot:
             )
 
         if self._should_construct("can_network_telemetry_service"):
+            telemetry_service = CANNetworkTelemetryService(
+                can_interface_service=self.require_service("can_interface_service")
+            )
+            await telemetry_service.startup()
             self._set_root_constructed_service(
-                "can_network_telemetry_service",
-                CANNetworkTelemetryService(
-                    can_interface_service=self.require_service("can_interface_service")
-                ),
+                "can_network_telemetry_service", telemetry_service
             )
 
         await self._construct_websocket_manager()
@@ -1075,6 +1076,8 @@ class CompositionRoot:
                 device_discovery_service=self.get_optional_service("device_discovery_service"),
                 entity_manager_service=self.get_optional_service("entity_manager_service"),
                 websocket_manager=self.get_optional_service("websocket_manager"),
+                entity_state_repository=self.get_optional_service("entity_state_repository"),
+                diagnostics_repository=self.get_optional_service("diagnostics_repository"),
             )
             await can_bus_service.start()
             self._set_root_constructed_service("can_bus_service", can_bus_service)

--- a/backend/repositories/diagnostics_repository.py
+++ b/backend/repositories/diagnostics_repository.py
@@ -62,6 +62,18 @@ class DiagnosticsRepository:
         self._unmapped_entries.clear()
         logger.info(f"Cleared {count} unmapped entries")
 
+    def upsert_unmapped_entry(self, key: str, entry: dict[str, Any]) -> dict[str, Any]:
+        """Insert or update an unmapped entry, preserving first-seen and counting hits.
+
+        On first sight the entry is stored with ``count`` = 1. On subsequent
+        upserts the incoming fields overwrite the stored ones, except
+        ``first_seen_timestamp`` (kept from the original entry) and ``count``
+        (incremented).
+        """
+        merged = self._merge_upsert(self._unmapped_entries, key, entry)
+        logger.debug("Upserted unmapped entry: %s (count=%s)", key, merged["count"])
+        return merged
+
     # Unknown PGNs management
     def add_unknown_pgn(self, pgn: str, data: Any) -> None:
         """Add an unknown PGN."""
@@ -83,6 +95,31 @@ class DiagnosticsRepository:
         count = len(self._unknown_pgns)
         self._unknown_pgns.clear()
         logger.info(f"Cleared {count} unknown PGNs")
+
+    def upsert_unknown_pgn(self, pgn: str, entry: dict[str, Any]) -> dict[str, Any]:
+        """Insert or update an unknown PGN entry, preserving first-seen and counting hits.
+
+        Same merge semantics as :meth:`upsert_unmapped_entry`.
+        """
+        merged = self._merge_upsert(self._unknown_pgns, pgn, entry)
+        logger.debug("Upserted unknown PGN: %s (count=%s)", pgn, merged["count"])
+        return merged
+
+    @staticmethod
+    def _merge_upsert(
+        store: dict[str, Any], key: str, entry: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Merge an entry into a keyed store with first-seen/count upsert semantics."""
+        existing = store.get(key)
+        if isinstance(existing, dict):
+            merged = {**existing, **entry}
+            if "first_seen_timestamp" in existing:
+                merged["first_seen_timestamp"] = existing["first_seen_timestamp"]
+            merged["count"] = int(existing.get("count", 0)) + 1
+        else:
+            merged = {**entry, "count": 1}
+        store[key] = merged
+        return merged
 
     # Diagnostic counters
     def increment_message_count(self) -> None:

--- a/backend/services/can/can_bus_service.py
+++ b/backend/services/can/can_bus_service.py
@@ -43,6 +43,16 @@ LIGHT_STATUS_SIMULATION_TYPE = 2
 SIMULATION_ERROR_SLEEP_SECONDS = 5
 
 
+def _device_lookup_key(dgn_hex: str, instance: Any) -> tuple[str, str]:
+    """Normalize a spec DGN hex + instance into a coach-mapping device_lookup key.
+
+    Spec entries carry ``dgn_hex`` values like ``"0x1FEDA"`` while the coach
+    mapping's device_lookup keys are bare uppercase hex like ``"1FEDA"``, so the
+    ``0X`` prefix must be stripped after uppercasing for lookups to hit.
+    """
+    return (dgn_hex.upper().removeprefix("0X"), str(instance))
+
+
 class CANBusService(GuardrailParticipant):
     """
     Service that manages CAN bus integration.
@@ -63,6 +73,8 @@ class CANBusService(GuardrailParticipant):
         device_discovery_service: Any | None = None,
         entity_manager_service: Any | None = None,
         websocket_manager: Any | None = None,
+        entity_state_repository: Any | None = None,
+        diagnostics_repository: Any | None = None,
     ):
         """
         Initialize the CAN bus service with repository dependencies.
@@ -125,6 +137,8 @@ class CANBusService(GuardrailParticipant):
         self._device_discovery_service = device_discovery_service
         self._entity_manager_service = entity_manager_service
         self._websocket_manager = websocket_manager
+        self._entity_state_repository = entity_state_repository
+        self._diagnostics_repository = diagnostics_repository
 
         logger.info(
             "CANBusService initialized",
@@ -841,7 +855,7 @@ class CANBusService(GuardrailParticipant):
 
                     # Check if this maps to a known device/entity
                     if dgn_hex and instance is not None:
-                        device_key = (dgn_hex.upper(), str(instance))
+                        device_key = _device_lookup_key(dgn_hex, instance)
                         device_config = self.device_lookup.get(device_key)
 
                         if device_config:
@@ -854,6 +868,7 @@ class CANBusService(GuardrailParticipant):
                                 )
                         else:
                             logger.debug("Unmapped device: %s:%s", dgn_hex, instance)
+                            self._record_unmapped_device(dgn_hex, instance, entry, data, msg)
                             # Analyze unmapped but decodable message for patterns
                             if self.pattern_engine:
                                 try:
@@ -873,6 +888,7 @@ class CANBusService(GuardrailParticipant):
                     logger.error("Error decoding CAN message: %s", decode_error)
             else:
                 logger.debug("No decoder found for arbitration ID 0x%x", arbitration_id)
+                self._record_unknown_pgn(arbitration_id, pgn, data, msg)
                 # Analyze completely unknown message for patterns
                 if self.pattern_engine:
                     try:
@@ -889,6 +905,56 @@ class CANBusService(GuardrailParticipant):
 
         except Exception as e:
             logger.error("Error processing CAN message: %s", e)
+
+    def _record_unknown_pgn(
+        self, arbitration_id: int, pgn: int, data: bytes, msg: dict[str, Any]
+    ) -> None:
+        """Record an undecodable PGN in the diagnostics repository (best effort)."""
+        if self._diagnostics_repository is None:
+            return
+        try:
+            timestamp = float(msg.get("timestamp", time.time()))
+            self._diagnostics_repository.upsert_unknown_pgn(
+                f"{pgn:X}",
+                {
+                    "arbitration_id_hex": f"{arbitration_id:X}",
+                    "first_seen_timestamp": timestamp,
+                    "last_seen_timestamp": timestamp,
+                    "last_data_hex": data.hex().upper(),
+                },
+            )
+        except Exception as e:
+            logger.debug("Unable to record unknown PGN %X: %s", pgn, e)
+
+    def _record_unmapped_device(
+        self,
+        dgn_hex: str,
+        instance: Any,
+        entry: dict[str, Any],
+        data: bytes,
+        msg: dict[str, Any],
+    ) -> None:
+        """Record a decoded-but-unmapped device in the diagnostics repository (best effort)."""
+        if self._diagnostics_repository is None:
+            return
+        try:
+            timestamp = float(msg.get("timestamp", time.time()))
+            dgn_name = entry.get("name")
+            self._diagnostics_repository.upsert_unmapped_entry(
+                f"{dgn_hex}-{instance}",
+                {
+                    "pgn_hex": str(entry.get("pgn", dgn_hex)),
+                    "pgn_name": dgn_name,
+                    "dgn_hex": dgn_hex,
+                    "dgn_name": dgn_name,
+                    "instance": str(instance),
+                    "last_data_hex": data.hex().upper(),
+                    "first_seen_timestamp": timestamp,
+                    "last_seen_timestamp": timestamp,
+                },
+            )
+        except Exception as e:
+            logger.debug("Unable to record unmapped device %s:%s: %s", dgn_hex, instance, e)
 
     def _process_reassembled_message(
         self,
@@ -1091,6 +1157,11 @@ class CANBusService(GuardrailParticipant):
             if updated_entity:
                 logger.debug("Updated entity %s state from CAN message", entity_id)
 
+                # Persist to the runtime state repository so API reads
+                # (which go through EntityRuntimeStateRepository, not the
+                # EntityManager) see live CAN-derived state.
+                await self._persist_entity_state(entity_id, updated_entity)
+
                 # Broadcast the update via WebSocket
                 # Broadcast entity update via WebSocket
                 websocket_service = self._websocket_manager
@@ -1109,6 +1180,21 @@ class CANBusService(GuardrailParticipant):
 
         except Exception:
             logger.exception("Error updating entity %s from CAN message", entity_id)
+
+    async def _persist_entity_state(self, entity_id: str, updated_entity: Any) -> None:
+        """Persist a live entity update to the runtime state repository (best effort)."""
+        if self._entity_state_repository is None:
+            return
+        try:
+            await self._entity_state_repository.save_entity_state(
+                entity_id, updated_entity.to_dict()
+            )
+        except Exception as repo_error:
+            logger.debug(
+                "Unable to persist entity %s state to repository: %s",
+                entity_id,
+                repo_error,
+            )
 
     async def _update_light_state(
         self, payload: dict[str, Any], _decoded_data: dict[str, Any], raw_data: dict[str, Any]

--- a/backend/services/can/can_network_telemetry_service.py
+++ b/backend/services/can/can_network_telemetry_service.py
@@ -86,7 +86,12 @@ class CANNetworkTelemetryService:
     async def _poll_loop(self) -> None:
         """Continuously sample interface counters until cancelled."""
         while True:
-            await self.sample_once()
+            try:
+                await self.sample_once()
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                logger.debug("CAN network telemetry sampling error: %s", e)
             await asyncio.sleep(self._sample_interval_seconds)
 
     async def sample_once(self) -> None:

--- a/tests/services/test_can_rx_pipeline_wiring.py
+++ b/tests/services/test_can_rx_pipeline_wiring.py
@@ -1,0 +1,105 @@
+"""CAN RX pipeline wiring regression tests.
+
+Covers the root-cause fixes for live-data gaps in the RX pipeline:
+
+- Device lookup key normalization: spec entries carry ``dgn_hex`` values like
+  ``"0x1FEDA"`` while coach-mapping device_lookup keys are bare uppercase hex
+  like ``"1FEDA"``. Before the fix every lookup missed, so no entity ever
+  updated from live CAN traffic.
+- DiagnosticsRepository upsert helpers used to record unknown PGNs and
+  unmapped devices from the RX path (count increments, first-seen preserved).
+"""
+
+import pytest
+
+from backend.repositories.diagnostics_repository import DiagnosticsRepository
+from backend.services.can.can_bus_service import _device_lookup_key
+
+pytestmark = [pytest.mark.unit]
+
+
+class TestDeviceLookupKeyNormalization:
+    def test_spec_prefixed_dgn_hex_hits_bare_hex_lookup(self):
+        device_lookup = {("1FEDA", "25"): {"entity_id": "light_25"}}
+
+        key = _device_lookup_key("0x1FEDA", 25)
+
+        assert key == ("1FEDA", "25")
+        assert device_lookup[key] == {"entity_id": "light_25"}
+
+    def test_bare_hex_dgn_is_unchanged(self):
+        assert _device_lookup_key("1FEDA", 25) == ("1FEDA", "25")
+
+    def test_lowercase_prefix_and_hex_are_uppercased(self):
+        assert _device_lookup_key("0x1feda", "25") == ("1FEDA", "25")
+
+
+class TestDiagnosticsRepositoryUpserts:
+    def test_unknown_pgn_first_upsert_sets_count_one(self):
+        repo = DiagnosticsRepository()
+
+        merged = repo.upsert_unknown_pgn(
+            "1EF65",
+            {
+                "arbitration_id_hex": "19EF6580",
+                "first_seen_timestamp": 100.0,
+                "last_seen_timestamp": 100.0,
+                "last_data_hex": "0102030405060708",
+            },
+        )
+
+        assert merged["count"] == 1
+        stored = repo.get_unknown_pgns()["1EF65"]
+        assert stored["arbitration_id_hex"] == "19EF6580"
+        assert stored["first_seen_timestamp"] == 100.0
+        assert stored["last_seen_timestamp"] == 100.0
+
+    def test_unknown_pgn_second_upsert_increments_count_and_keeps_first_seen(self):
+        repo = DiagnosticsRepository()
+        repo.upsert_unknown_pgn(
+            "1EF65",
+            {
+                "arbitration_id_hex": "19EF6580",
+                "first_seen_timestamp": 100.0,
+                "last_seen_timestamp": 100.0,
+                "last_data_hex": "0102030405060708",
+            },
+        )
+
+        merged = repo.upsert_unknown_pgn(
+            "1EF65",
+            {
+                "arbitration_id_hex": "19EF6580",
+                "first_seen_timestamp": 200.0,
+                "last_seen_timestamp": 200.0,
+                "last_data_hex": "AABBCCDDEEFF0011",
+            },
+        )
+
+        assert merged["count"] == 2
+        assert merged["first_seen_timestamp"] == 100.0
+        assert merged["last_seen_timestamp"] == 200.0
+        assert merged["last_data_hex"] == "AABBCCDDEEFF0011"
+
+    def test_unmapped_entry_upsert_roundtrip_and_count_increment(self):
+        repo = DiagnosticsRepository()
+        entry = {
+            "pgn_hex": "1FEDA",
+            "dgn_hex": "1FEDA",
+            "instance": "25",
+            "last_data_hex": "0102030405060708",
+            "first_seen_timestamp": 100.0,
+            "last_seen_timestamp": 100.0,
+        }
+
+        first = repo.upsert_unmapped_entry("1FEDA-25", entry)
+        assert first["count"] == 1
+
+        second = repo.upsert_unmapped_entry(
+            "1FEDA-25", {**entry, "first_seen_timestamp": 300.0, "last_seen_timestamp": 300.0}
+        )
+
+        assert second["count"] == 2
+        assert second["first_seen_timestamp"] == 100.0
+        assert second["last_seen_timestamp"] == 300.0
+        assert repo.get_unmapped_entries()["1FEDA-25"] == second


### PR DESCRIPTION
Live-coach diagnosis: decoder demonstrably processing real bus frames, yet entities frozen at seed, unknown-PGNs empty, telemetry null. Root cause: four independent wiring gaps (0x-prefix key mismatch, split-brain state store, writer-less unknown-PGN store, never-started telemetry service). All fixed with minimal blast radius + unit tests.

Verified: 10 new/related tests pass; ruff and pyright identical to pre-change baseline on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)