### PR TITLE
feat(dev_tools): CAN reverse-engineering toolkit

### DIFF
--- a/dev_tools/__init__.py
+++ b/dev_tools/__init__.py
@@ -1,0 +1,1 @@
+"""Developer tooling (not part of the shipped backend package)."""

--- a/dev_tools/can_re/README.md
+++ b/dev_tools/can_re/README.md
@@ -1,0 +1,76 @@
+# CAN reverse-engineering toolkit
+
+Standalone capture / census / diff tools for reverse-engineering the coach's
+CAN traffic — built to crack the **Firefly G6 command dialect** that standard
+RV-C `DC_DIMMER_COMMAND_2` frames do not drive (see
+[`docs/can-re-findings.md`](../../docs/can-re-findings.md)).
+
+These talk to SocketCAN directly via `candump`/`cansend`. They need **no**
+running CoachIQ app and **no** auth, so you can run them from the coach while
+pressing physical Vegatouch Mira buttons. Capture files are JSONL in the same
+field shape as the app's in-recorder `RecordedMessage`, so they interoperate.
+
+## The workflow that cracks a control frame
+
+The whole point: **diff what's on the bus when idle vs. while you press a
+button.** Whatever a Mira button toggles shows up as the delta.
+
+On the coach (SSH to the Pi, or a terminal in the RV):
+
+```bash
+cd <repo>            # wherever the coachiq checkout lives on the Pi
+                     # (or copy dev_tools/ + config/rvc.json next to each other)
+
+# 1. Two baselines back-to-back, nothing touched. The second is a "noise
+#    floor" that cancels the bus's normal churn (clocks, slow status frames).
+python -m dev_tools.can_re.capture --iface can1 --seconds 10 --label idle  --out captures/idle.jsonl
+python -m dev_tools.can_re.capture --iface can1 --seconds 10 --label idle2 --out captures/idle2.jsonl
+
+# 2. Action: start this, then press "bedroom ceiling ON" on the Mira panel
+#    once, within the 10-second window.
+python -m dev_tools.can_re.capture --iface can1 --seconds 10 \
+    --label bedroom-ceiling-on --out captures/bedroom-ceiling-on.jsonl
+
+# 3. Diff, with the noise floor subtracted. The ranked "CHANGED payloads" list
+#    floats the most likely command frame to the top.
+python -m dev_tools.can_re.diff captures/idle.jsonl captures/bedroom-ceiling-on.jsonl \
+    --noise captures/idle2.jsonl
+```
+
+Reading the output:
+
+- **`CHANGED payloads`** is where the answer usually is — look for a dimmer
+  status/command byte or a proprietary `SA 9C` frame that flips with the press.
+- **Ignore `NEW frame types` that are `GENERIC_CONFIGURATION_STATUS` or other
+  slow status frames** — those are periodics that a short window samples
+  unevenly, not your button.
+- **Run step 2/3 two or three times.** The change that shows up *every* time you
+  press is the signal; one-off flickers are noise. Longer captures (`--seconds
+  15`) also help.
+
+Repeat for OFF, dim up/down, and a couple of different lights. The frame + byte
+that consistently tracks the action **is** the command the Firefly system uses.
+Send me the `captures/*.jsonl` files (or just the diff output) and that's enough
+to implement the encoder.
+
+Tip: `can0` and `can1` are bridged on this coach, so either interface sees the
+same traffic — `can1` is fine.
+
+## Commands
+
+| Command | What it does |
+|---|---|
+| `python -m dev_tools.can_re.capture --iface can1 --seconds N --label L --out F.jsonl` | Record N seconds to a labeled JSONL capture. |
+| `python -m dev_tools.can_re.census F.jsonl` | Inventory a capture: per-(PGN,SA) counts/rates, standard vs proprietary, RV-C names, dimmer instance breakdown. |
+| `python -m dev_tools.can_re.diff idle.jsonl action.jsonl` | Surface NEW / GONE frame types and per-byte payload changes between two captures, ranked by likely control signal. |
+
+`census` and `diff` also read plain `candump -ta` logs, so an ad-hoc
+`candump -ta can1 > f.txt` works as input too.
+
+## Layout
+
+- `canframe.py` — frame parsing, J1939/RV-C arbitration-id decomposition, RV-C
+  naming from `config/rvc.json`. Pure functions; unit-tested.
+- `loader.py` — read capture JSONL (or raw candump logs) into frames.
+- `capture.py` / `census.py` / `diff.py` — the three CLIs.
+- `tests/` — `pytest -m unit` over the decomposition, parsing, census, and diff.

--- a/dev_tools/can_re/__init__.py
+++ b/dev_tools/can_re/__init__.py
@@ -1,0 +1,30 @@
+"""CAN reverse-engineering toolkit.
+
+Standalone capture / census / diff tools for reverse-engineering the coach's
+CAN traffic — in particular the Firefly G6 command dialect that standard
+RV-C DC_DIMMER_COMMAND_2 frames do not drive (see docs/can-re-findings.md).
+
+No dependency on the running CoachIQ app or its auth: these run directly
+against SocketCAN via ``candump``/``cansend`` so they can be operated from the
+coach while pressing physical Vegatouch Mira buttons.
+
+Capture files are JSONL, one frame per line, in the same field shape as the
+app's ``RecordedMessage`` (``timestamp``/``can_id``/``data``/``interface``),
+so captures interoperate with the in-app CAN recorder.
+"""
+
+from dev_tools.can_re.canframe import (
+    Frame,
+    RvcNames,
+    classify_pgn,
+    decompose_arbitration_id,
+    parse_candump_line,
+)
+
+__all__ = [
+    "Frame",
+    "RvcNames",
+    "classify_pgn",
+    "decompose_arbitration_id",
+    "parse_candump_line",
+]

--- a/dev_tools/can_re/canframe.py
+++ b/dev_tools/can_re/canframe.py
@@ -1,0 +1,156 @@
+"""Frame parsing, J1939/RV-C arbitration-id decomposition, and RV-C naming.
+
+Pure functions only — the unit tests exercise this module directly, and the
+capture/census/diff CLIs build on it.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+# J1939/RV-C arbitration-id field boundaries.
+_PDU1_MAX_PF = 0xF0  # PF below this is PDU1 (destination-specific)
+_PROPRIETARY_PF_MASK = 0xFF00  # PGN low byte 0xFF__ == proprietary-B
+_EXTENDED_ID_MIN = 0x7FF  # ids above the 11-bit range are extended (29-bit)
+
+# candump line, with optional leading "(timestamp)" from `candump -ta`:
+#   (1720098123.456789)  can1  19FEDB9C   [8]  B5 FF 00 22 FF 00 FF FF
+#   can1  19FEDB9C   [8]  B5 FF 00 22 FF 00 FF FF
+_CANDUMP_RE = re.compile(
+    r"^\s*(?:\((?P<ts>\d+\.\d+)\)\s+)?"
+    r"(?P<iface>\S+)\s+"
+    r"(?P<canid>[0-9A-Fa-f]+)\s+"
+    r"\[(?P<dlc>\d+)\]\s*"
+    r"(?P<data>(?:[0-9A-Fa-f]{2}\s*)*)$"
+)
+
+
+@dataclass(frozen=True)
+class Frame:
+    """A single observed CAN frame."""
+
+    timestamp: float
+    can_id: int
+    data: bytes
+    interface: str
+
+    # --- derived J1939/RV-C fields -------------------------------------
+    @property
+    def source_address(self) -> int:
+        return self.can_id & 0xFF
+
+    @property
+    def pgn(self) -> int:
+        return decompose_arbitration_id(self.can_id)[0]
+
+    @property
+    def priority(self) -> int:
+        return (self.can_id >> 26) & 0x7
+
+    @property
+    def instance(self) -> int | None:
+        """Byte 0 of the payload — the instance field for dimmer PGNs."""
+        return self.data[0] if self.data else None
+
+    def to_record(self) -> dict:
+        """Serialize in the app's RecordedMessage field shape (JSONL line)."""
+        return {
+            "timestamp": self.timestamp,
+            "can_id": self.can_id,
+            "data": self.data.hex(),
+            "interface": self.interface,
+            "is_extended": self.can_id > _EXTENDED_ID_MIN,
+        }
+
+    @classmethod
+    def from_record(cls, rec: dict) -> Frame:
+        return cls(
+            timestamp=float(rec["timestamp"]),
+            can_id=int(rec["can_id"]),
+            data=bytes.fromhex(rec["data"]),
+            interface=rec.get("interface", ""),
+        )
+
+
+def decompose_arbitration_id(can_id: int) -> tuple[int, int, int]:
+    """Return ``(pgn, source_address, pdu_format)`` for a 29-bit CAN id.
+
+    J1939/RV-C: a PDU1 message (PF < 0xF0) is destination-specific and its
+    PS byte is an address, not part of the PGN; a PDU2 message (PF >= 0xF0)
+    folds PS into the PGN. The Data Page bit is included so RV-C DGNs like
+    ``0x1FEDA`` come through intact.
+    """
+    sa = can_id & 0xFF
+    ps = (can_id >> 8) & 0xFF
+    pf = (can_id >> 16) & 0xFF
+    dp = (can_id >> 24) & 0x1
+    pgn = (dp << 16) | (pf << 8) | (ps if pf >= _PDU1_MAX_PF else 0)
+    return pgn, sa, pf
+
+
+def classify_pgn(pgn: int) -> str:
+    """``"proprietary"`` for the manufacturer PDU2 range, else ``"standard"``.
+
+    Proprietary-B occupies PF == 0xFF (PGN low byte 0xFF__), i.e. the
+    0x_FF00-0x_FFFF band the Firefly system uses for its private channel.
+    """
+    return "proprietary" if (pgn & _PROPRIETARY_PF_MASK) == _PROPRIETARY_PF_MASK else "standard"
+
+
+def parse_candump_line(line: str, default_ts: float = 0.0) -> Frame | None:
+    """Parse one ``candump`` output line into a :class:`Frame`, or ``None``.
+
+    Accepts both plain ``candump`` and ``candump -ta`` (absolute-timestamp)
+    output. Lines that do not match (blank lines, error frames) return None.
+    """
+    m = _CANDUMP_RE.match(line)
+    if not m:
+        return None
+    ts = float(m.group("ts")) if m.group("ts") else default_ts
+    data = bytes.fromhex(m.group("data").replace(" ", "")) if m.group("data").strip() else b""
+    return Frame(
+        timestamp=ts,
+        can_id=int(m.group("canid"), 16),
+        data=data,
+        interface=m.group("iface"),
+    )
+
+
+class RvcNames:
+    """DGN -> human name lookup, loaded from ``config/rvc.json``.
+
+    Falls back gracefully to an empty map (names become ``None``) so the tools
+    stay usable off-coach without the spec file.
+    """
+
+    def __init__(self, by_pgn: dict[int, str]) -> None:
+        self._by_pgn = by_pgn
+
+    def name(self, pgn: int) -> str | None:
+        return self._by_pgn.get(pgn)
+
+    @classmethod
+    def load(cls, path: str | Path | None = None) -> RvcNames:
+        if path is None:
+            # dev_tools/can_re/canframe.py -> repo root -> config/rvc.json
+            path = Path(__file__).resolve().parents[2] / "config" / "rvc.json"
+        try:
+            raw = json.loads(Path(path).read_text(encoding="utf-8"))
+        except (FileNotFoundError, ValueError):
+            return cls({})
+        pgns = raw.get("pgns", raw)
+        by_pgn: dict[int, str] = {}
+        for entry in pgns.values():
+            if not isinstance(entry, dict):
+                continue
+            name = entry.get("name")
+            pgn_hex = entry.get("pgn")
+            if name and isinstance(pgn_hex, str):
+                try:
+                    by_pgn[int(pgn_hex, 16)] = name
+                except ValueError:
+                    continue
+        return cls(by_pgn)

--- a/dev_tools/can_re/capture.py
+++ b/dev_tools/can_re/capture.py
@@ -1,0 +1,81 @@
+"""Capture a labeled CAN session to JSONL.
+
+Runs on the coach (Raspberry Pi) against a live SocketCAN interface via
+``candump``. No CoachIQ app, auth, or python-can dependency required.
+
+Usage:
+    python -m dev_tools.can_re.capture --iface can1 --seconds 6 \
+        --label bedroom-ceiling-on --out captures/bedroom-ceiling-on.jsonl
+
+Then diff two captures (e.g. an idle baseline vs. an action) with
+``python -m dev_tools.can_re.diff idle.jsonl bedroom-ceiling-on.jsonl``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+from dev_tools.can_re.canframe import parse_candump_line
+
+
+def capture(iface: str, seconds: float, label: str, out_path: Path) -> int:
+    """Capture for ``seconds`` from ``iface`` into ``out_path`` (JSONL).
+
+    Returns the number of frames written. The first line is a ``_meta`` record;
+    every subsequent line is a frame in RecordedMessage field shape.
+    """
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    # `-ta` gives absolute timestamps we can diff/rate on. `timeout` bounds
+    # the run so this always exits without a manual Ctrl-C.
+    cmd = ["timeout", str(seconds), "candump", "-ta", iface]
+    started = time.time()
+    # Fixed argv, no shell — inputs are a numeric duration and an interface name.
+    proc = subprocess.run(cmd, capture_output=True, text=True, check=False)  # noqa: S603
+
+    frames = 0
+    with out_path.open("w", encoding="utf-8") as fh:
+        fh.write(
+            json.dumps(
+                {
+                    "_meta": {
+                        "label": label,
+                        "interface": iface,
+                        "seconds": seconds,
+                        "started_at": started,
+                    }
+                }
+            )
+            + "\n"
+        )
+        for line in proc.stdout.splitlines():
+            frame = parse_candump_line(line)
+            if frame is None:
+                continue
+            fh.write(json.dumps(frame.to_record()) + "\n")
+            frames += 1
+    return frames
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Capture a labeled CAN session to JSONL.")
+    ap.add_argument("--iface", default="can1", help="SocketCAN interface (default: can1)")
+    ap.add_argument("--seconds", type=float, default=6.0, help="Capture duration")
+    ap.add_argument("--label", required=True, help="Human label, e.g. 'bedroom-ceiling-on'")
+    ap.add_argument("--out", type=Path, required=True, help="Output .jsonl path")
+    args = ap.parse_args(argv)
+
+    n = capture(args.iface, args.seconds, args.label, args.out)
+    print(
+        f"captured {n} frames from {args.iface} over {args.seconds}s -> {args.out}",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/dev_tools/can_re/census.py
+++ b/dev_tools/can_re/census.py
@@ -1,0 +1,87 @@
+"""Summarize a capture: what talks, how fast, standard vs proprietary.
+
+Usage:
+    python -m dev_tools.can_re.census captures/idle.jsonl
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+from pathlib import Path
+
+from dev_tools.can_re.canframe import Frame, RvcNames, classify_pgn, decompose_arbitration_id
+from dev_tools.can_re.loader import load_capture, span_seconds
+
+# Dimmer PGNs whose payload byte 0 is an addressable instance worth breaking out.
+INSTANCE_PGNS = (0x1FEDA, 0x1FEDB)
+
+
+def census(frames: list[Frame], names: RvcNames | None = None) -> dict:
+    """Compute a structured census over ``frames``."""
+    names = names or RvcNames({})
+    per_key: collections.Counter[tuple[int, int]] = collections.Counter()
+    instances: dict[int, collections.Counter[int]] = {
+        pgn: collections.Counter() for pgn in INSTANCE_PGNS
+    }
+    for f in frames:
+        pgn, sa, _pf = decompose_arbitration_id(f.can_id)
+        per_key[(pgn, sa)] += 1
+        if pgn in instances and f.instance is not None:
+            instances[pgn][f.instance] += 1
+
+    span = span_seconds(frames) or 1.0
+    proprietary = sum(1 for (pgn, _sa) in per_key if classify_pgn(pgn) == "proprietary")
+    rows = [
+        {
+            "pgn": pgn,
+            "sa": sa,
+            "count": count,
+            "rate": round(count / span, 1),
+            "name": names.name(pgn),
+            "kind": classify_pgn(pgn),
+        }
+        for (pgn, sa), count in per_key.most_common()
+    ]
+    return {
+        "frames": len(frames),
+        "span_seconds": round(span, 1),
+        "distinct_keys": len(per_key),
+        "proprietary_keys": proprietary,
+        "rows": rows,
+        "instances": {pgn: dict(sorted(c.items())) for pgn, c in instances.items() if c},
+    }
+
+
+def format_census(result: dict, top: int = 25) -> str:
+    lines = [
+        f"{result['frames']} frames over {result['span_seconds']}s "
+        f"(~{round(result['frames'] / (result['span_seconds'] or 1))}/s), "
+        f"{result['distinct_keys']} distinct (PGN,SA); "
+        f"{result['proprietary_keys']} proprietary",
+        "",
+        f"{'PGN':>6}  {'SA':>2}  {'count':>6}  {'rate/s':>7}  kind         name",
+    ]
+    lines.extend(
+        f"{r['pgn']:>6X}  {r['sa']:>02X}  {r['count']:>6}  {r['rate']:>7}  "
+        f"{r['kind']:<11}  {r['name'] or ''}"
+        for r in result["rows"][:top]
+    )
+    for pgn, dist in result["instances"].items():
+        pretty = ", ".join(f"{k:02X}:{v}" for k, v in dist.items())
+        lines.append(f"\n{pgn:X} payload-byte0 (instances): {pretty}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Census a CAN capture.")
+    ap.add_argument("capture", type=Path)
+    ap.add_argument("--top", type=int, default=25)
+    args = ap.parse_args(argv)
+    frames, _meta = load_capture(args.capture)
+    print(format_census(census(frames, RvcNames.load()), top=args.top))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/dev_tools/can_re/diff.py
+++ b/dev_tools/can_re/diff.py
@@ -1,0 +1,202 @@
+"""Diff two captures to isolate the frames an action produced.
+
+Compares a baseline (idle) capture against an action capture (e.g. taken while
+pressing a Vegatouch Mira button) and surfaces:
+
+  * NEW keys       — (PGN, SA) frame types that appeared only during the action
+  * GONE keys      — frame types that stopped during the action
+  * CHANGED bytes  — for shared (PGN, SA), payload byte positions that took a
+                     value during the action that was never seen at idle
+
+The changed-byte report is the payload delta that reveals which frame carries
+the command/state a button toggles. Candidates are ranked to float the most
+likely control signal (proprietary channel + a small, specific set of new
+values) to the top.
+
+Usage:
+    python -m dev_tools.can_re.diff captures/idle.jsonl captures/action.jsonl
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+from dataclasses import dataclass
+from pathlib import Path
+
+from dev_tools.can_re.canframe import Frame, RvcNames, classify_pgn, decompose_arbitration_id
+from dev_tools.can_re.loader import load_capture
+
+Key = tuple[int, int]  # (pgn, sa)
+
+
+@dataclass
+class ByteChange:
+    index: int
+    new_values: list[int]  # values seen in action, never at idle
+
+
+@dataclass
+class ChangedKey:
+    pgn: int
+    sa: int
+    name: str | None
+    kind: str
+    byte_changes: list[ByteChange]
+
+    @property
+    def score(self) -> float:
+        """Higher = more likely the signal a button toggled.
+
+        Proprietary frames (Firefly's private channel) rank up; a change
+        concentrated in few byte positions with few new values ranks up
+        (a specific edit, not noise); status/command dimmer PGNs rank up.
+        """
+        total_new = sum(len(bc.new_values) for bc in self.byte_changes)
+        specificity = 1.0 / (1 + total_new)
+        s = specificity + 0.5 / (1 + len(self.byte_changes))
+        if self.kind == "proprietary":
+            s += 1.0
+        if self.pgn in (0x1FEDA, 0x1FEDB):
+            s += 0.5
+        return s
+
+
+@dataclass
+class DiffResult:
+    new_keys: list[tuple[int, int, str | None]]
+    gone_keys: list[tuple[int, int, str | None]]
+    changed: list[ChangedKey]
+
+
+def _index(frames: list[Frame]) -> dict[Key, list[bytes]]:
+    idx: dict[Key, list[bytes]] = collections.defaultdict(list)
+    for f in frames:
+        pgn, sa, _pf = decompose_arbitration_id(f.can_id)
+        idx[(pgn, sa)].append(f.data)
+    return idx
+
+
+def _byte_value_sets(payloads: list[bytes]) -> list[set[int]]:
+    """Per-byte-index set of values observed across payloads."""
+    width = max((len(p) for p in payloads), default=0)
+    sets: list[set[int]] = [set() for _ in range(width)]
+    for p in payloads:
+        for i, b in enumerate(p):
+            sets[i].add(b)
+    return sets
+
+
+def diff(idle: list[Frame], action: list[Frame], names: RvcNames | None = None) -> DiffResult:
+    names = names or RvcNames({})
+    idle_idx = _index(idle)
+    action_idx = _index(action)
+    idle_keys = set(idle_idx)
+    action_keys = set(action_idx)
+
+    new_keys = sorted(
+        ((pgn, sa, names.name(pgn)) for (pgn, sa) in action_keys - idle_keys),
+        key=lambda t: (t[0], t[1]),
+    )
+    gone_keys = sorted(
+        ((pgn, sa, names.name(pgn)) for (pgn, sa) in idle_keys - action_keys),
+        key=lambda t: (t[0], t[1]),
+    )
+
+    changed: list[ChangedKey] = []
+    for key in idle_keys & action_keys:
+        pgn, sa = key
+        idle_sets = _byte_value_sets(idle_idx[key])
+        action_sets = _byte_value_sets(action_idx[key])
+        byte_changes: list[ByteChange] = []
+        for i, act_vals in enumerate(action_sets):
+            idle_vals = idle_sets[i] if i < len(idle_sets) else set()
+            new = sorted(act_vals - idle_vals)
+            if new:
+                byte_changes.append(ByteChange(index=i, new_values=new))
+        if byte_changes:
+            changed.append(
+                ChangedKey(
+                    pgn=pgn,
+                    sa=sa,
+                    name=names.name(pgn),
+                    kind=classify_pgn(pgn),
+                    byte_changes=byte_changes,
+                )
+            )
+    changed.sort(key=lambda c: c.score, reverse=True)
+    return DiffResult(new_keys=new_keys, gone_keys=gone_keys, changed=changed)
+
+
+def apply_noise_filter(result: DiffResult, noise: DiffResult) -> DiffResult:
+    """Subtract a noise-floor diff (idle-vs-idle) from an action diff.
+
+    The bus has legitimate background churn — clocks counting up, slow
+    periodic frames sampled in one window but not another, free-running
+    counters. Diffing two *idle* captures characterizes that churn; anything
+    it flags is not caused by the action, so we drop it here. What survives is
+    the signal a button press actually produced.
+    """
+    noise_new = {(pgn, sa) for pgn, sa, _ in noise.new_keys}
+    noise_bytes: set[tuple[int, int, int]] = {
+        (c.pgn, c.sa, bc.index) for c in noise.changed for bc in c.byte_changes
+    }
+
+    new_keys = [t for t in result.new_keys if (t[0], t[1]) not in noise_new]
+    gone_keys = [t for t in result.gone_keys if (t[0], t[1]) not in noise_new]
+
+    changed: list[ChangedKey] = []
+    for c in result.changed:
+        kept = [bc for bc in c.byte_changes if (c.pgn, c.sa, bc.index) not in noise_bytes]
+        if kept:
+            changed.append(
+                ChangedKey(pgn=c.pgn, sa=c.sa, name=c.name, kind=c.kind, byte_changes=kept)
+            )
+    changed.sort(key=lambda c: c.score, reverse=True)
+    return DiffResult(new_keys=new_keys, gone_keys=gone_keys, changed=changed)
+
+
+def format_diff(result: DiffResult, top: int = 20) -> str:
+    lines: list[str] = []
+    lines.append(f"NEW frame types during action ({len(result.new_keys)}):")
+    for pgn, sa, name in result.new_keys:
+        lines.append(f"  PGN {pgn:05X}  SA {sa:02X}  {name or ''}")
+    lines.append(f"\nGONE frame types during action ({len(result.gone_keys)}):")
+    for pgn, sa, name in result.gone_keys:
+        lines.append(f"  PGN {pgn:05X}  SA {sa:02X}  {name or ''}")
+    lines.append(f"\nCHANGED payloads, ranked ({len(result.changed)} keys; top {top}):")
+    for c in result.changed[:top]:
+        deltas = "; ".join(
+            f"byte{bc.index}+={{{','.join(f'{v:02X}' for v in bc.new_values)}}}"
+            for bc in c.byte_changes
+        )
+        lines.append(f"  PGN {c.pgn:05X}  SA {c.sa:02X}  [{c.kind}] {c.name or ''}")
+        lines.append(f"      {deltas}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Diff two CAN captures (idle vs. action).")
+    ap.add_argument("idle", type=Path, help="Baseline capture (nothing pressed)")
+    ap.add_argument("action", type=Path, help="Capture taken during the action")
+    ap.add_argument(
+        "--noise",
+        type=Path,
+        default=None,
+        help="A second idle capture; its idle-vs-idle churn is subtracted for a cleaner signal.",
+    )
+    ap.add_argument("--top", type=int, default=20)
+    args = ap.parse_args(argv)
+    names = RvcNames.load()
+    idle_frames, _ = load_capture(args.idle)
+    action_frames, _ = load_capture(args.action)
+    result = diff(idle_frames, action_frames, names)
+    if args.noise:
+        noise_frames, _ = load_capture(args.noise)
+        result = apply_noise_filter(result, diff(idle_frames, noise_frames, names))
+    print(format_diff(result, top=args.top))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/dev_tools/can_re/loader.py
+++ b/dev_tools/can_re/loader.py
@@ -1,0 +1,49 @@
+"""Load capture JSONL (or raw candump logs) into Frame lists."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from dev_tools.can_re.canframe import Frame, parse_candump_line
+
+_MIN_TS_FOR_SPAN = 2
+
+
+def load_capture(path: str | Path) -> tuple[list[Frame], dict]:
+    """Load a capture file, returning ``(frames, meta)``.
+
+    Accepts our JSONL captures (with a ``_meta`` header line) and also raw
+    ``candump`` text logs, so a plain ``candump -ta … > file`` works too.
+    """
+    frames: list[Frame] = []
+    meta: dict = {}
+    text = Path(path).read_text(encoding="utf-8")
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        if line.startswith("{"):
+            try:
+                obj = json.loads(line)
+            except ValueError:
+                continue
+            if "_meta" in obj:
+                meta = obj["_meta"]
+                continue
+            if "can_id" in obj:
+                frames.append(Frame.from_record(obj))
+                continue
+        else:
+            frame = parse_candump_line(line)
+            if frame is not None:
+                frames.append(frame)
+    return frames, meta
+
+
+def span_seconds(frames: list[Frame]) -> float:
+    """Wall-clock span covered by the frames (0.0 if <2 timestamped frames)."""
+    ts = [f.timestamp for f in frames if f.timestamp]
+    if len(ts) < _MIN_TS_FOR_SPAN:
+        return 0.0
+    return max(ts) - min(ts)

--- a/dev_tools/can_re/tests/test_can_re.py
+++ b/dev_tools/can_re/tests/test_can_re.py
@@ -1,0 +1,148 @@
+"""Unit tests for the CAN reverse-engineering toolkit (pure logic only)."""
+
+from __future__ import annotations
+
+import pytest
+
+from dev_tools.can_re.canframe import (
+    Frame,
+    RvcNames,
+    classify_pgn,
+    decompose_arbitration_id,
+    parse_candump_line,
+)
+from dev_tools.can_re.census import census
+from dev_tools.can_re.diff import apply_noise_filter, diff
+
+pytestmark = [pytest.mark.unit]
+
+
+# --- arbitration-id decomposition -------------------------------------------
+@pytest.mark.parametrize(
+    ("can_id", "pgn", "sa", "kind"),
+    [
+        (0x19FEDB9C, 0x1FEDB, 0x9C, "standard"),  # DC_DIMMER_COMMAND_2 from G6
+        (0x19FEDA8E, 0x1FEDA, 0x8E, "standard"),  # DC_DIMMER_STATUS_3
+        (0x0DFFAD4F, 0x1FFAD, 0x4F, "proprietary"),  # Firefly proprietary-B
+        (0x18FECA9C, 0x0FECA, 0x9C, "standard"),  # DM_RV (PDU2, DP=0)
+    ],
+)
+def test_decompose_and_classify(can_id: int, pgn: int, sa: int, kind: str) -> None:
+    got_pgn, got_sa, _pf = decompose_arbitration_id(can_id)
+    assert got_pgn == pgn
+    assert got_sa == sa
+    assert classify_pgn(got_pgn) == kind
+
+
+def test_pdu1_ps_is_address_not_pgn() -> None:
+    # PF 0xEF (<0xF0) is PDU1: the PS byte is a destination address, not PGN.
+    pgn_a, _, _ = decompose_arbitration_id(0x18EF1122)
+    pgn_b, _, _ = decompose_arbitration_id(0x18EF9922)
+    assert pgn_a == pgn_b == 0x0EF00
+
+
+# --- candump parsing ---------------------------------------------------------
+def test_parse_candump_plain_and_timestamped() -> None:
+    plain = parse_candump_line("  can1  19FEDB9C   [8]  B5 FF 00 22 FF 00 FF FF")
+    assert plain is not None
+    assert plain.can_id == 0x19FEDB9C
+    assert plain.data == bytes.fromhex("B5FF0022FF00FFFF")
+    assert plain.source_address == 0x9C
+    assert plain.pgn == 0x1FEDB
+    assert plain.instance == 0xB5
+
+    stamped = parse_candump_line("(1720098123.456789)  can0  18FECAFC   [8]  01 02 03 04 05 06 07 08")
+    assert stamped is not None
+    assert stamped.timestamp == pytest.approx(1720098123.456789)
+    assert stamped.pgn == 0x0FECA
+
+
+def test_parse_rejects_junk() -> None:
+    assert parse_candump_line("") is None
+    assert parse_candump_line("  can1  19FEDB9C   [8]") is not None  # zero data bytes ok
+
+
+def test_record_roundtrip() -> None:
+    f = Frame(timestamp=1.5, can_id=0x19FEDB9C, data=b"\x19\xc8", interface="can1")
+    assert Frame.from_record(f.to_record()) == f
+
+
+# --- rvc names ---------------------------------------------------------------
+def test_rvc_names_lookup() -> None:
+    names = RvcNames({0x1FEDA: "DC_DIMMER_STATUS_3"})
+    assert names.name(0x1FEDA) == "DC_DIMMER_STATUS_3"
+    assert names.name(0x1FFAD) is None
+
+
+# --- census ------------------------------------------------------------------
+def _frame(can_id: int, data: bytes, ts: float) -> Frame:
+    return Frame(timestamp=ts, can_id=can_id, data=data, interface="can1")
+
+
+def test_census_counts_and_instances() -> None:
+    frames = [
+        _frame(0x19FEDB9C, b"\x13\xff\x00", 0.0),
+        _frame(0x19FEDB9C, b"\x16\xff\x00", 0.5),
+        _frame(0x19FEDA8E, b"\x19\x7c\x00", 1.0),
+        _frame(0x0DFFAD4F, b"\x01\x02", 1.0),
+    ]
+    result = census(frames)
+    assert result["frames"] == 4
+    assert result["distinct_keys"] == 3
+    assert result["proprietary_keys"] == 1  # only 1FFAD
+    # dimmer command instances captured from byte0
+    assert result["instances"][0x1FEDB] == {0x13: 1, 0x16: 1}
+
+
+# --- diff (the crown jewel) --------------------------------------------------
+def test_diff_surfaces_new_key_and_changed_byte() -> None:
+    # Idle: a proprietary frame steady at byte2=0x00; a status frame steady off.
+    idle = [
+        _frame(0x0DFFAD4F, b"\x01\x00\x00", t) for t in (0.0, 0.1, 0.2)
+    ] + [_frame(0x19FEDA8E, b"\x19\x7c\x00", t) for t in (0.0, 0.1)]
+    # Action ("button pressed"): the proprietary byte2 flips to 0x22 (new value)
+    # and a brand-new frame type appears.
+    action = (
+        [_frame(0x0DFFAD4F, b"\x01\x00\x22", t) for t in (0.0, 0.1, 0.2)]
+        + [_frame(0x19FEDA8E, b"\x19\x7c\x00", 0.0)]
+        + [_frame(0x19FF859C, b"\xaa\xbb", 0.0)]  # new key
+    )
+    result = diff(idle, action)
+
+    # the new frame type is reported
+    assert (0x1FF85, 0x9C, None) in result.new_keys
+    # the proprietary byte-2 change is found and ranked first (proprietary +
+    # single specific new value beats everything else)
+    top = result.changed[0]
+    assert (top.pgn, top.sa) == (0x1FFAD, 0x4F)
+    assert top.byte_changes[0].index == 2
+    assert top.byte_changes[0].new_values == [0x22]
+
+
+def test_diff_ignores_unchanged() -> None:
+    steady = [_frame(0x19FEDA8E, b"\x19\x7c\x00", t) for t in (0.0, 0.1, 0.2)]
+    result = diff(steady, list(steady))
+    assert result.new_keys == []
+    assert result.gone_keys == []
+    assert result.changed == []
+
+
+def test_noise_filter_cancels_background_churn() -> None:
+    # A free-running clock byte changes every capture (idle churn); a real
+    # button also flips a dimmer status byte. The noise filter should keep the
+    # dimmer signal and drop the clock.
+    idle = [_frame(0x19FFFF9C, bytes([0, 0, 0, 0, 0, v]), 0.0) for v in (0x10, 0x11)]
+    idle += [_frame(0x19FEDA8E, b"\x19\x7c\x00", 0.0)]
+    noise = [_frame(0x19FFFF9C, bytes([0, 0, 0, 0, 0, v]), 0.0) for v in (0x12, 0x13)]
+    noise += [_frame(0x19FEDA8E, b"\x19\x7c\x00", 0.0)]
+    action = [_frame(0x19FFFF9C, bytes([0, 0, 0, 0, 0, v]), 0.0) for v in (0x14, 0x15)]
+    action += [_frame(0x19FEDA8E, b"\x19\x7c\xc8", 0.0)]  # dimmer went on
+
+    raw = diff(idle, action)
+    filtered = apply_noise_filter(raw, diff(idle, noise))
+
+    raw_keys = {(c.pgn, c.sa) for c in raw.changed}
+    filtered_keys = {(c.pgn, c.sa) for c in filtered.changed}
+    assert (0x1FFFF, 0x9C) in raw_keys  # clock flagged in raw
+    assert (0x1FFFF, 0x9C) not in filtered_keys  # ...but cancelled as noise
+    assert (0x1FEDA, 0x8E) in filtered_keys  # real dimmer change survives

--- a/docs/can-re-findings.md
+++ b/docs/can-re-findings.md
@@ -1,0 +1,75 @@
+# CAN reverse-engineering findings (2021 Entegra Aspire 44R)
+
+Passive-sniff observations from the coach bus, gathered while diagnosing why
+CoachIQ can receive live state but cannot command lights. Tooling to reproduce
+and extend this lives in [`dev_tools/can_re/`](../dev_tools/can_re/README.md).
+
+**Status:** receive path proven end to end; **transmit/control is blocked** on
+learning the Firefly command dialect. This document is the map for that work.
+
+## Bus topology
+
+- Two SocketCAN interfaces, `can0` and `can1`, are **bridged** — both carry the
+  same ~250 frames/s (they showed identical PGN/SA distributions in a 20 s
+  census). This is the known nixpi bridge; it is why the app runs a message
+  deduplicator. Capture from either; `can1` is fine.
+- ~62–77 distinct `(PGN, source-address)` pairs are live at idle.
+
+## Who's talking
+
+| Source | Role (inferred) | Notable PGNs |
+|---|---|---|
+| `0x9C` | **Firefly G6 controller** (the master) | `15F00`, `1FEDB` DC_DIMMER_COMMAND_2, `1FACE`, many `1FFxx` |
+| `0x8E`, `0x8F` | Dimmer/output modules (status reporters) | `1FEDA` DC_DIMMER_STATUS_3, `E800` |
+| `0x4F` | **Energy / ATS node** (not lighting) | `1FFAB/1FFAC/1FFAD/1FF85` = `ATS_AC_STATUS_1..4`, `1FFBF` = `AC_LOAD_STATUS` |
+| `0xFC` | Chassis diagnostics | `FECA` DM_RV / DM1 |
+
+The RV-C name lookup resolving the `0x4F` proprietary frames to `ATS_AC_STATUS_*`
+means a large slice of the "proprietary" traffic is **AC power management, not
+lighting** — it can be set aside when hunting the light-command frame.
+
+## Why standard commands don't work
+
+1. **The G6 is a continuous master.** It re-broadcasts `DC_DIMMER_COMMAND_2`
+   (`1FEDB`, from SA `0x9C`) at ~2 Hz per output, cycling byte-0 (instance)
+   through `{0x13, 0x16, 0x32, 0xB5..0xBC}` — ~11 outputs. A single competing
+   command from CoachIQ (SA `0xF9`) is overwritten within ~90 ms. Verified: a
+   30-command burst of standard `DC_DIMMER_COMMAND_2` produced **no change** in
+   the target's `DC_DIMMER_STATUS_3` broadcast.
+
+2. **Instance numbering doesn't match.** The coach mapping calls the bedroom
+   ceiling light instance **25 (`0x19`)**, but the G6 never commands `0x19` on
+   the wire — its instance set is `{0x13, 0x16, 0x32, 0xB5..0xBC}`. So either
+   the mapping's instances are wrong, or Firefly addresses outputs by a
+   different scheme (zone/group) in a proprietary frame. **This is the open
+   question a button-press capture resolves.**
+
+## The open question → how to answer it
+
+Whatever a Vegatouch Mira button toggles is, by definition, the command the
+Firefly system honors. Capture idle vs. a button press and diff:
+
+```
+python -m dev_tools.can_re.capture --iface can1 --seconds 6 --label idle       --out captures/idle.jsonl
+python -m dev_tools.can_re.capture --iface can1 --seconds 6 --label ceiling-on  --out captures/ceiling-on.jsonl   # press the button now
+python -m dev_tools.can_re.diff captures/idle.jsonl captures/ceiling-on.jsonl --noise captures/idle2.jsonl
+```
+
+The surviving ranked change is the control frame. Likely outcomes, in order of
+prior probability:
+
+1. A **proprietary `0x1FFxx` frame from SA `0x9C`** carries the real command
+   (Firefly's private channel). Decode it, emit it as `0x9C`/that PGN.
+2. It **is** `DC_DIMMER_COMMAND_2` but with a different instance/group byte than
+   our mapping assumes — fix the mapping, keep the standard encoder.
+3. The module only accepts commands from the master's SA `0x9C` — we'd emit as
+   `0x9C` (impersonation) rather than `0xF9`.
+
+Once known, implement in `backend/integrations/rvc/encoder.py` behind the
+existing command path, then the acknowledgment matcher in
+`entity_domain_service._wait_for_acknowledgment` starts confirming.
+
+## Guardrail
+
+Per ADR-0004, CoachIQ is API guardrails only; Firefly owns physical safety.
+Lighting control is in scope; slides and locks are not.


### PR DESCRIPTION
Standalone capture / census / diff tools to crack the Firefly G6 command dialect (standard RV-C `DC_DIMMER_COMMAND_2` doesn't drive the coach's lights — see `docs/can-re-findings.md`).

Runs directly against SocketCAN (no app/auth), so it's operable from the coach while pressing physical Mira buttons. Captures are `RecordedMessage`-compatible with the in-app recorder.

- **capture** — labeled JSONL sessions via `candump`
- **census** — per-(PGN,SA) rates, standard/proprietary split, RV-C names, dimmer instance breakdown
- **diff** — NEW/GONE frame types + per-byte payload deltas idle-vs-action, ranked to surface the control signal; `--noise` subtracts background churn
- 13 unit tests over the pure J1939/RV-C logic; validated end-to-end on the live coach bus

`docs/can-re-findings.md` records the passive census (bridged buses; G6 master cycles instances that don't match the mapping; SA 0x4F proprietary frames are ATS/AC power, not lighting) and the button-press capture workflow that answers the open question.

Dev-tooling only — no backend/app changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)