### PR TITLE
feat(nix): ship can-re toolkit as coachiq-can-re on-device CLI

### DIFF
--- a/dev_tools/can_re/README.md
+++ b/dev_tools/can_re/README.md
@@ -10,6 +10,22 @@ running CoachIQ app and **no** auth, so you can run them from the coach while
 pressing physical Vegatouch Mira buttons. Capture files are JSONL in the same
 field shape as the app's in-recorder `RecordedMessage`, so they interoperate.
 
+## Two ways to run
+
+**On the coach (packaged):** the Nix package ships a `coachiq-can-re` command on
+the system `PATH`, wrapped with `can-utils` and pointed at the packaged RV-C
+spec. Prefer this on the Pi — it is version-matched to the running backend:
+
+```bash
+coachiq-can-re capture --iface can1 --seconds 10 --label idle --out idle.jsonl
+coachiq-can-re census idle.jsonl
+coachiq-can-re diff idle.jsonl action.jsonl --noise idle2.jsonl
+```
+
+**From a checkout (dev):** the equivalent `python -m dev_tools.can_re.<tool>`
+module CLIs behave identically. The examples below use the module form; swap in
+`coachiq-can-re <subcommand>` on the coach.
+
 ## The workflow that cracks a control frame
 
 The whole point: **diff what's on the bus when idle vs. while you press a

--- a/dev_tools/can_re/canframe.py
+++ b/dev_tools/can_re/canframe.py
@@ -7,6 +7,7 @@ capture/census/diff CLIs build on it.
 from __future__ import annotations
 
 import json
+import os
 import re
 from dataclasses import dataclass
 from pathlib import Path
@@ -132,13 +133,30 @@ class RvcNames:
     def name(self, pgn: int) -> str | None:
         return self._by_pgn.get(pgn)
 
+    @staticmethod
+    def _locate_spec() -> Path | None:
+        """Find rvc.json across dev-checkout and Nix-packaged layouts.
+
+        Order: explicit ``COACHIQ_RVC_SPEC_PATH`` env var (the Nix wrapper sets
+        this to the packaged spec) -> repo-relative -> the ``config/`` dir the
+        package installs alongside site-packages.
+        """
+        candidates: list[Path] = []
+        env = os.environ.get("COACHIQ_RVC_SPEC_PATH")
+        if env:
+            candidates.append(Path(env))
+        here = Path(__file__).resolve()
+        candidates.append(here.parents[2] / "config" / "rvc.json")  # repo checkout
+        candidates.append(here.parents[1] / "config" / "rvc.json")  # site-packages/config
+        return next((c for c in candidates if c.is_file()), None)
+
     @classmethod
     def load(cls, path: str | Path | None = None) -> RvcNames:
-        if path is None:
-            # dev_tools/can_re/canframe.py -> repo root -> config/rvc.json
-            path = Path(__file__).resolve().parents[2] / "config" / "rvc.json"
+        resolved = Path(path) if path is not None else cls._locate_spec()
+        if resolved is None:
+            return cls({})
         try:
-            raw = json.loads(Path(path).read_text(encoding="utf-8"))
+            raw = json.loads(resolved.read_text(encoding="utf-8"))
         except (FileNotFoundError, ValueError):
             return cls({})
         pgns = raw.get("pgns", raw)

--- a/dev_tools/can_re/cli.py
+++ b/dev_tools/can_re/cli.py
@@ -1,0 +1,87 @@
+"""Unified ``coachiq-can-re`` command: capture / census / diff subcommands.
+
+This is the console-script entry point shipped in the Nix package. It reuses
+the same library functions as the ``python -m dev_tools.can_re.<tool>`` module
+CLIs, so both invocation styles behave identically.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from dev_tools.can_re.canframe import RvcNames
+from dev_tools.can_re.capture import capture as run_capture
+from dev_tools.can_re.census import census, format_census
+from dev_tools.can_re.diff import apply_noise_filter, diff, format_diff
+from dev_tools.can_re.loader import load_capture
+
+
+def _cmd_capture(args: argparse.Namespace) -> int:
+    n = run_capture(args.iface, args.seconds, args.label, args.out)
+    print(
+        f"captured {n} frames from {args.iface} over {args.seconds}s -> {args.out}",
+        file=sys.stderr,
+    )
+    return 0
+
+
+def _cmd_census(args: argparse.Namespace) -> int:
+    frames, _meta = load_capture(args.capture)
+    print(format_census(census(frames, RvcNames.load()), top=args.top))
+    return 0
+
+
+def _cmd_diff(args: argparse.Namespace) -> int:
+    names = RvcNames.load()
+    idle_frames, _ = load_capture(args.idle)
+    action_frames, _ = load_capture(args.action)
+    result = diff(idle_frames, action_frames, names)
+    if args.noise:
+        noise_frames, _ = load_capture(args.noise)
+        result = apply_noise_filter(result, diff(idle_frames, noise_frames, names))
+    print(format_diff(result, top=args.top))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    ap = argparse.ArgumentParser(
+        prog="coachiq-can-re",
+        description="Reverse-engineering tools for the coach CAN bus "
+        "(capture / census / diff). See the Firefly dialect notes in "
+        "docs/can-re-findings.md.",
+    )
+    sub = ap.add_subparsers(dest="command", required=True)
+
+    cap = sub.add_parser("capture", help="Record a labeled session to JSONL.")
+    cap.add_argument("--iface", default="can1")
+    cap.add_argument("--seconds", type=float, default=10.0)
+    cap.add_argument("--label", required=True)
+    cap.add_argument("--out", type=Path, required=True)
+    cap.set_defaults(func=_cmd_capture)
+
+    cen = sub.add_parser("census", help="Inventory a capture.")
+    cen.add_argument("capture", type=Path)
+    cen.add_argument("--top", type=int, default=25)
+    cen.set_defaults(func=_cmd_census)
+
+    dif = sub.add_parser("diff", help="Diff idle vs. action to find the signal.")
+    dif.add_argument("idle", type=Path)
+    dif.add_argument("action", type=Path)
+    dif.add_argument(
+        "--noise", type=Path, default=None, help="Second idle capture; subtracts churn."
+    )
+    dif.add_argument("--top", type=int, default=20)
+    dif.set_defaults(func=_cmd_diff)
+
+    return ap
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/dev_tools/can_re/tests/test_can_re.py
+++ b/dev_tools/can_re/tests/test_can_re.py
@@ -12,6 +12,8 @@ from dev_tools.can_re.canframe import (
     parse_candump_line,
 )
 from dev_tools.can_re.census import census
+from dev_tools.can_re.cli import build_parser
+from dev_tools.can_re.cli import main as cli_main
 from dev_tools.can_re.diff import apply_noise_filter, diff
 
 pytestmark = [pytest.mark.unit]
@@ -146,3 +148,22 @@ def test_noise_filter_cancels_background_churn() -> None:
     assert (0x1FFFF, 0x9C) in raw_keys  # clock flagged in raw
     assert (0x1FFFF, 0x9C) not in filtered_keys  # ...but cancelled as noise
     assert (0x1FEDA, 0x8E) in filtered_keys  # real dimmer change survives
+
+
+# --- cli dispatch ------------------------------------------------------------
+def test_cli_parser_has_all_subcommands() -> None:
+    parser = build_parser()
+    args = parser.parse_args(["diff", "a.jsonl", "b.jsonl", "--noise", "c.jsonl"])
+    assert args.command == "diff"
+    assert args.func is not None
+
+
+def test_cli_census_runs_on_capture(tmp_path) -> None:
+    cap = tmp_path / "cap.jsonl"
+    cap.write_text(
+        '{"_meta": {"label": "t"}}\n'
+        '{"timestamp": 0.0, "can_id": 434069404, "data": "13ff00", "interface": "can1"}\n'
+        '{"timestamp": 0.5, "can_id": 434069404, "data": "16ff00", "interface": "can1"}\n',
+        encoding="utf-8",
+    )
+    assert cli_main(["census", str(cap), "--top", "5"]) == 0

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -99,6 +99,17 @@
       # from [tool.poetry.scripts] in pyproject.toml:
       # - coachiq-daemon (from backend.cli:main)
       # - coachiq-validate-config (from backend.core.config:validate_config_cli)
+      # - coachiq-can-re (from dev_tools.can_re.cli:main)
+
+      # On-device CAN reverse-engineering CLI. Point it at the packaged RV-C
+      # spec so PGN naming works without a repo checkout, and (on Linux, the
+      # coach target) put can-utils on its PATH since it shells out to
+      # candump/cansend. can-utils is Linux-only, so it is omitted on darwin
+      # builds where the CLI's capture subcommand is not usable anyway.
+      wrapProgram $out/bin/coachiq-can-re \
+        --set-default COACHIQ_RVC_SPEC_PATH $out/share/coachiq/config/rvc.json \
+        ${pkgs.lib.optionalString pkgs.stdenv.isLinux
+          "--prefix PATH : ${pkgs.lib.makeBinPath [ pkgs.can-utils ]}"}
 
       # Health check script with Nix-compatible shebang
       mkdir -p $out/share/coachiq/nix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
 ]
 include = [
     "backend/**/*",
+    "dev_tools/can_re/**/*",
     "frontend/dist/**/*",
     "config/**/*"
 ]
@@ -25,6 +26,11 @@ repository = "https://github.com/carpenike/coachiq"
 
 [[tool.poetry.packages]]
 include = "backend"
+
+# Ships the on-device CAN reverse-engineering CLI (coachiq-can-re). Pure
+# stdlib; the other dev_tools modules come along inert (not imported at runtime).
+[[tool.poetry.packages]]
+include = "dev_tools"
 
 # ------------------------------------------------------------------
 # Runtime dependencies + Python version (required by Poetry solver)
@@ -74,6 +80,7 @@ sqlite-vec = ">=0.1.6,<0.2.0"
 [tool.poetry.scripts]
 coachiq-daemon = "backend.cli:main"
 coachiq-validate-config = "backend.core.config:validate_config_cli"
+coachiq-can-re = "dev_tools.can_re.cli:main"
 
 [tool.ruff]
 line-length = 100


### PR DESCRIPTION
Packages the CAN reverse-engineering toolkit (PR #183) as a version-matched `coachiq-can-re` command on the Pi's system PATH. The coachiq package is already in `environment.systemPackages`, so this lands with the next deploy — no module change, no manual copy that rots on reimage.

- `coachiq-can-re {capture,census,diff}` console script (`dev_tools/can_re/cli.py`)
- `RvcNames.load` resolves the RV-C spec via `COACHIQ_RVC_SPEC_PATH` → repo-relative → packaged `config/`, so it works from a checkout and from the Nix package
- `nix/package.nix` wraps the binary with `can-utils` on PATH (Linux only) and points `COACHIQ_RVC_SPEC_PATH` at the packaged spec
- 15 unit tests (incl. CLI dispatch); wheel verified to include the modules and register the entry point

Local darwin `nix build` stops at the pre-existing Linux-only `cantools` runtime-deps check (unrelated to this change); the aarch64-linux deploy target builds fully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)