### PR TITLE
fix(auth): persist refresh sessions and end OIDC double-login race

### DIFF
--- a/backend/repositories/auth_repository.py
+++ b/backend/repositories/auth_repository.py
@@ -11,7 +11,7 @@ import logging
 import uuid
 from collections import defaultdict
 from datetime import UTC, datetime
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from backend.repositories.base import MonitoredRepository
 
@@ -115,7 +115,19 @@ class CredentialRepository(MonitoredRepository):
 
 
 class SessionRepository(MonitoredRepository):
-    """Repository for session and refresh token management."""
+    """Repository for session and refresh token management.
+
+    Refresh tokens are opaque and stored server-side. Sessions are persisted in
+    the ``user_sessions`` table via :class:`AuthRepository` so they survive a
+    backend restart — without this, every ``coachiq.service`` restart wiped all
+    refresh sessions and bounced authenticated users back to /login.
+
+    An in-memory fallback is retained for two cases where the database cannot
+    hold the session: the ``null://memory`` persistence backend (dev/tests) and
+    sessions whose ``user_id`` has no row in ``users`` (e.g. the synthetic
+    single-user "admin"), which would violate the ``user_sessions`` FK. These
+    fall back to the previous in-memory behaviour instead of failing outright.
+    """
 
     def __init__(self, database_manager, performance_monitor):
         """Initialize the repository.
@@ -126,9 +138,31 @@ class SessionRepository(MonitoredRepository):
         """
         super().__init__(database_manager, performance_monitor)
 
-        # In-memory storage
-        self._sessions: dict[str, dict[str, Any]] = {}  # refresh_token -> session
+        # Persistent, restart-surviving session store.
+        from backend.services.auth.repository import AuthRepository
+
+        self._auth_repo = AuthRepository(database_manager)
+
+        # In-memory fallback for sessions that cannot be persisted (null backend
+        # or non-persistable user ids). Keyed by refresh_token.
+        self._sessions: dict[str, dict[str, Any]] = {}
         self._user_sessions: dict[str, list[str]] = defaultdict(list)  # user_id -> [refresh_tokens]
+
+    @staticmethod
+    def _session_to_dict(session: "Any") -> dict[str, Any]:
+        """Convert a persistent ``UserSession`` ORM row to the consumer dict shape."""
+        return {
+            "session_id": session.id,
+            "user_id": session.user_id,
+            "refresh_token": session.session_token,
+            "device_info": session.device_info,
+            "created_at": session.created_at.isoformat() if session.created_at else None,
+            "expires_at": session.expires_at.isoformat() if session.expires_at else None,
+            "last_used": (
+                session.last_accessed_at.isoformat() if session.last_accessed_at else None
+            ),
+            "is_active": session.is_active,
+        }
 
     @MonitoredRepository._monitored_operation("create_user_session")
     async def create_user_session(
@@ -145,9 +179,21 @@ class SessionRepository(MonitoredRepository):
         Returns:
             Session ID
         """
-        session_id = str(uuid.uuid4())
+        # Persist to the database so the session survives a backend restart.
+        persisted = await self._auth_repo.create_user_session(
+            user_id=user_id,
+            session_token=refresh_token,
+            expires_at=expires_at,
+            device_info=device_info,
+        )
+        if persisted is not None:
+            logger.debug(f"Persisted session for user {user_id}")
+            return persisted.id
 
-        session = {
+        # Fallback: null backend or a user_id with no ``users`` row (FK). Keep the
+        # previous in-memory behaviour rather than dropping the session entirely.
+        session_id = str(uuid.uuid4())
+        self._sessions[refresh_token] = {
             "session_id": session_id,
             "user_id": user_id,
             "refresh_token": refresh_token,
@@ -157,11 +203,8 @@ class SessionRepository(MonitoredRepository):
             "last_used": datetime.now(UTC).isoformat(),
             "is_active": True,
         }
-
-        self._sessions[refresh_token] = session
         self._user_sessions[user_id].append(refresh_token)
-
-        logger.debug(f"Created session for user {user_id}")
+        logger.debug(f"Stored in-memory fallback session for user {user_id}")
         return session_id
 
     @MonitoredRepository._monitored_operation("get_user_session")
@@ -174,23 +217,35 @@ class SessionRepository(MonitoredRepository):
         Returns:
             Session data or None
         """
-        session = self._sessions.get(refresh_token)
+        now = datetime.now(UTC)
 
+        # In-memory fallback sessions take precedence (they only exist when the
+        # DB could not hold them).
+        session = self._sessions.get(refresh_token)
         if session and session["is_active"]:
-            # Check expiration
             expires_at = datetime.fromisoformat(session["expires_at"].replace("Z", "+00:00"))
-            if expires_at > datetime.now(UTC):
-                # Update last used
-                session["last_used"] = datetime.now(UTC).isoformat()
+            if expires_at > now:
+                session["last_used"] = now.isoformat()
                 return session
-            # Expired - mark as inactive
             session["is_active"] = False
+            return None
+
+        # Persistent store. Normalize expiry to UTC-aware: SQLite may hand back a
+        # naive datetime, which would raise when compared against an aware ``now``.
+        persisted = await self._auth_repo.get_user_session(refresh_token)
+        if persisted and persisted.is_active:
+            expires_at = persisted.expires_at
+            if expires_at.tzinfo is None:
+                expires_at = expires_at.replace(tzinfo=UTC)
+            if expires_at > now:
+                await self._auth_repo.update_session_last_accessed(refresh_token)
+                return self._session_to_dict(persisted)
 
         return None
 
     @MonitoredRepository._monitored_operation("get_user_sessions")
     async def get_user_sessions(self, user_id: str) -> list[dict[str, Any]]:
-        """Get all sessions for a user.
+        """Get all active sessions for a user.
 
         Args:
             user_id: User identifier
@@ -198,12 +253,17 @@ class SessionRepository(MonitoredRepository):
         Returns:
             List of active sessions
         """
-        sessions = []
+        sessions: list[dict[str, Any]] = []
 
-        for token in self._user_sessions.get(user_id, []):
+        # In-memory fallback sessions.
+        for token in list(self._user_sessions.get(user_id, [])):
             session = await self.get_user_session(token)
             if session:
                 sessions.append(session)
+
+        # Persistent sessions.
+        for persisted in await self._auth_repo.get_active_user_sessions(user_id):
+            sessions.append(self._session_to_dict(persisted))
 
         return sessions
 
@@ -218,21 +278,18 @@ class SessionRepository(MonitoredRepository):
             True if revoked successfully
         """
         if refresh_token in self._sessions:
-            self._sessions[refresh_token]["is_active"] = False
-            self._sessions[refresh_token]["revoked_at"] = datetime.now(UTC).isoformat()
-
-            # Remove from user's active sessions
             session = self._sessions[refresh_token]
+            session["is_active"] = False
+            session["revoked_at"] = datetime.now(UTC).isoformat()
             user_id = session["user_id"]
             if user_id in self._user_sessions:
                 self._user_sessions[user_id] = [
                     t for t in self._user_sessions[user_id] if t != refresh_token
                 ]
-
-            logger.info(f"Revoked session for user {user_id}")
+            logger.info(f"Revoked in-memory session for user {user_id}")
             return True
 
-        return False
+        return await self._auth_repo.revoke_user_session(refresh_token)
 
     @MonitoredRepository._monitored_operation("revoke_all_user_sessions")
     async def revoke_all_user_sessions(self, user_id: str) -> int:
@@ -250,6 +307,8 @@ class SessionRepository(MonitoredRepository):
             if await self.revoke_user_session(token):
                 count += 1
 
+        count += await self._auth_repo.revoke_all_user_sessions(user_id)
+
         if count > 0:
             logger.info(f"Revoked {count} sessions for user {user_id}")
 
@@ -263,21 +322,24 @@ class SessionRepository(MonitoredRepository):
             Number of sessions cleaned up
         """
         now = datetime.now(UTC)
-        expired_tokens = []
 
-        for token, session in self._sessions.items():
-            expires_at = datetime.fromisoformat(session["expires_at"].replace("Z", "+00:00"))
-            if expires_at <= now:
-                expired_tokens.append(token)
-
-        # Clean up expired sessions
+        # In-memory fallback sessions.
+        expired_tokens = [
+            token
+            for token, session in self._sessions.items()
+            if datetime.fromisoformat(session["expires_at"].replace("Z", "+00:00")) <= now
+        ]
         for token in expired_tokens:
             await self.revoke_user_session(token)
 
-        if expired_tokens:
-            logger.info(f"Cleaned up {len(expired_tokens)} expired sessions")
+        # Persistent sessions.
+        db_cleaned = await self._auth_repo.cleanup_expired_sessions()
 
-        return len(expired_tokens)
+        total = len(expired_tokens) + db_cleaned
+        if total:
+            logger.info(f"Cleaned up {total} expired sessions")
+
+        return total
 
     @MonitoredRepository._monitored_operation("get_active_session_count")
     async def get_active_session_count(self, user_id: str) -> int:

--- a/backend/services/auth/repository.py
+++ b/backend/services/auth/repository.py
@@ -23,9 +23,9 @@ from backend.models.auth import (
     MagicLinkToken,
     User,
     UserAuthProvider,
-    UserRole,
     UserMFA,
     UserMFABackupCode,
+    UserRole,
     UserSession,
 )
 from backend.services.database.database_manager import DatabaseManager
@@ -618,6 +618,23 @@ class AuthRepository:
             return result.scalar_one_or_none()
 
         return await self._execute_with_session(_get_session, session_token)
+
+    async def get_active_user_sessions(self, user_id: str) -> list[UserSession]:
+        """Get all active, unexpired sessions for a user."""
+
+        async def _get_sessions(session: AsyncSession, uid: str) -> list[UserSession]:
+            result = await session.execute(
+                select(UserSession).where(
+                    and_(
+                        UserSession.user_id == uid,
+                        UserSession.is_active == True,  # noqa: E712
+                        UserSession.expires_at > datetime.now(UTC),
+                    )
+                )
+            )
+            return list(result.scalars().all())
+
+        return await self._execute_list_operation(_get_sessions, user_id)
 
     async def update_session_last_accessed(self, session_token: str) -> bool:
         """Update the last accessed time for a session."""

--- a/frontend/src/contexts/auth-context.tsx
+++ b/frontend/src/contexts/auth-context.tsx
@@ -131,7 +131,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
   // Login mutation
   const loginMutation = useMutation({
     mutationFn: ({ username, password }: LoginCredentials) => apiLogin(username, password),
-    onSuccess: (data) => {
+    onSuccess: async (data) => {
       // Store tokens using secure token storage
       tokenStorage.storeTokens({
         access_token: data.access_token,
@@ -139,8 +139,14 @@ export function AuthProvider({ children }: AuthProviderProps) {
         expires_in: data.expires_in,
         refresh_expires_in: data.refresh_expires_in,
       });
-      // Invalidate auth queries to refetch user data
-      void queryClient.invalidateQueries({ queryKey: queryKeys.auth.all });
+      // Refetch auth queries with the freshly-stored token and AWAIT completion
+      // before the mutation resolves. Cancelling first drops any in-flight
+      // unauthenticated fetch so it can't overwrite the authenticated result.
+      // Awaiting here is what closes the login race: callers (e.g. the OIDC
+      // callback page) only navigate once `user` reflects the new session, so
+      // AuthGuard never sees a stale unauthenticated state and bounces to /login.
+      await queryClient.cancelQueries({ queryKey: queryKeys.auth.all });
+      await queryClient.invalidateQueries({ queryKey: queryKeys.auth.all });
     },
     onError: (error) => {
       console.error('Login failed:', error);
@@ -151,14 +157,19 @@ export function AuthProvider({ children }: AuthProviderProps) {
 
   const oidcLoginMutation = useMutation({
     mutationFn: (sessionCode: string) => apiCompleteOidcLogin(sessionCode),
-    onSuccess: (data) => {
+    onSuccess: async (data) => {
       tokenStorage.storeTokens({
         access_token: data.access_token,
         refresh_token: data.refresh_token,
         expires_in: data.expires_in,
         refresh_expires_in: data.refresh_expires_in,
       });
-      void queryClient.invalidateQueries({ queryKey: queryKeys.auth.all });
+      // See loginMutation above: await the authenticated refetch so the OIDC
+      // callback only redirects to the app after `user` is hydrated. Without
+      // this await the PocketID flow runs twice (AuthGuard bounces to /login
+      // before the token lands in the query cache).
+      await queryClient.cancelQueries({ queryKey: queryKeys.auth.all });
+      await queryClient.invalidateQueries({ queryKey: queryKeys.auth.all });
     },
     onError: (error) => {
       console.error('PocketID login failed:', error);

--- a/frontend/src/lib/token-storage.ts
+++ b/frontend/src/lib/token-storage.ts
@@ -17,6 +17,11 @@ const REFRESH_TOKEN_EXPIRY_KEY = 'refresh_token_expiry'
 // Token refresh timing
 const REFRESH_BUFFER_MS = 60000 // Refresh 1 minute before expiry
 const REFRESH_RETRY_DELAY_MS = 5000 // Retry failed refresh after 5 seconds
+// Cap transient-failure retries so a permanently-broken refresh (e.g. the
+// backend was restarted and the server-side session is gone) lands the user on
+// /login instead of looping "Token refresh failed" every 5s until the refresh
+// token's multi-day expiry.
+const MAX_REFRESH_RETRIES = 3
 
 /**
  * Interface for token data
@@ -42,6 +47,7 @@ class TokenStorageManager {
   private refreshCallbacks: TokenRefreshCallbacks = {}
   private isRefreshing = false
   private authEnabled: boolean | null = null
+  private refreshRetryCount = 0
 
   /**
    * Store authentication tokens securely
@@ -197,6 +203,7 @@ class TokenStorageManager {
       // Store new tokens
       const newTokenData = this.storeTokens(response)
 
+      this.refreshRetryCount = 0
       this.refreshCallbacks.onRefreshSuccess?.(newTokenData)
       return true
     } catch (error) {
@@ -207,22 +214,51 @@ class TokenStorageManager {
         return false
       }
       console.error('Token refresh failed:', error)
-
-      // Schedule retry if refresh token is still valid
-      if (this.isRefreshTokenValid()) {
-        setTimeout(() => {
-          this.isRefreshing = false
-          void this.attemptTokenRefresh()
-        }, REFRESH_RETRY_DELAY_MS)
-      } else {
-        this.refreshCallbacks.onTokenExpired?.()
-      }
-
-      this.refreshCallbacks.onRefreshFailure?.(error as Error)
+      this.handleRefreshFailure(error as Error)
       return false
     } finally {
       this.isRefreshing = false
     }
+  }
+
+  /**
+   * Decide whether a failed refresh is worth retrying, or whether the session
+   * is dead and the user should be routed to /login.
+   *
+   * A 4xx means the server rejected the refresh token itself (invalid, revoked,
+   * or its server-side session no longer exists — e.g. after a backend
+   * restart). Retrying can never succeed, so give up immediately. Only
+   * genuinely transient failures (network drops, 5xx) get a bounded retry;
+   * without a cap a permanently-broken refresh loops every few seconds until
+   * the refresh token's multi-day expiry.
+   */
+  private handleRefreshFailure(error: Error): void {
+    const status = (error as { statusCode?: number; status?: number }).statusCode
+      ?? (error as { status?: number }).status
+    const isUnrecoverable = typeof status === 'number' && status >= 400 && status < 500
+    const canRetry =
+      !isUnrecoverable &&
+      this.isRefreshTokenValid() &&
+      this.refreshRetryCount < MAX_REFRESH_RETRIES
+
+    if (canRetry) {
+      this.refreshRetryCount += 1
+      setTimeout(() => {
+        this.isRefreshing = false
+        void this.attemptTokenRefresh()
+      }, REFRESH_RETRY_DELAY_MS)
+    } else {
+      // Unrecoverable or out of retries: clear the dead session and signal
+      // expiry so the auth layer routes the user to /login instead of looping.
+      this.refreshRetryCount = 0
+      if (this.refreshTimeout) {
+        clearTimeout(this.refreshTimeout)
+        this.refreshTimeout = null
+      }
+      this.refreshCallbacks.onTokenExpired?.()
+    }
+
+    this.refreshCallbacks.onRefreshFailure?.(error)
   }
 
   /**

--- a/frontend/src/pages/oidc-callback.tsx
+++ b/frontend/src/pages/oidc-callback.tsx
@@ -1,5 +1,5 @@
 import { IconLoader2, IconShieldCheck, IconShieldX } from "@tabler/icons-react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 
 import { Alert, AlertDescription } from "@/components/ui/alert";
@@ -17,6 +17,10 @@ export default function OidcCallbackPage() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const [error, setError] = useState<string | null>(null);
+  // The session code is single-use; guard against exchanging it twice (e.g.
+  // React StrictMode double-invoking the effect), which would fail the second
+  // exchange and clear the tokens the first exchange just stored.
+  const exchangedCodeRef = useRef<string | null>(null);
 
   useEffect(() => {
     const sessionCode = searchParams.get("code");
@@ -24,6 +28,11 @@ export default function OidcCallbackPage() {
       setError("PocketID sign-in did not return a session code.");
       return;
     }
+
+    if (exchangedCodeRef.current === sessionCode) {
+      return;
+    }
+    exchangedCodeRef.current = sessionCode;
 
     let isCancelled = false;
     void completeOidcLogin(sessionCode)

--- a/tests/repositories/test_session_repository_persistence.py
+++ b/tests/repositories/test_session_repository_persistence.py
@@ -1,0 +1,141 @@
+"""Regression tests for refresh-session persistence across backend restarts.
+
+Historically ``SessionRepository`` stored refresh-token sessions only in an
+in-memory dict, so every ``coachiq.service`` restart invalidated all refresh
+tokens and bounced authenticated users back to /login. These tests pin the
+fix: sessions are persisted to the ``user_sessions`` table and survive a
+process restart (modelled here as a fresh ``SessionRepository`` on the same
+SQLite file), while unpersistable sessions still fall back to in-memory.
+"""
+
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend.models.auth import Base, User
+from backend.repositories.auth_repository import SessionRepository
+
+
+class _FakeEngineSettings:
+    def __init__(self, url: str) -> None:
+        self._url = url
+
+    def get_database_url(self) -> str:
+        return self._url
+
+
+class _FakeEngine:
+    def __init__(self, url: str) -> None:
+        self.settings = _FakeEngineSettings(url)
+
+
+class _FakeDatabaseManager:
+    """Minimal DatabaseManager surface used by AuthRepository."""
+
+    def __init__(self, url: str, session_factory) -> None:
+        self.engine = _FakeEngine(url)
+        self._session_factory = session_factory
+
+    @asynccontextmanager
+    async def get_session(self):
+        async with self._session_factory() as session:
+            yield session
+
+
+@pytest.fixture
+def db_url(tmp_path):
+    # A file-backed SQLite DB so data survives disposing the engine, modelling a
+    # backend restart. (":memory:" would vanish per-connection.)
+    return f"sqlite+aiosqlite:///{tmp_path / 'coachiq_test.db'}"
+
+
+async def _make_db_manager(url: str) -> _FakeDatabaseManager:
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    return _FakeDatabaseManager(url, factory)
+
+
+async def _seed_user(manager: _FakeDatabaseManager, user_id: str) -> None:
+    async with manager.get_session() as session:
+        session.add(
+            User(id=user_id, email=f"{user_id}@example.com", username=user_id, is_active=True)
+        )
+        await session.commit()
+
+
+async def test_session_survives_restart(db_url):
+    """A persisted session is found again by a fresh repository (post-restart)."""
+    user_id = "user-persist-1"
+    refresh_token = "refresh-token-persist-1"
+    expires_at = datetime.now(UTC) + timedelta(days=7)
+
+    manager = await _make_db_manager(db_url)
+    await _seed_user(manager, user_id)
+
+    repo = SessionRepository(manager, performance_monitor=None)
+    session_id = await repo.create_user_session(user_id, refresh_token, {"ua": "test"}, expires_at)
+    assert session_id
+
+    # Simulate a restart: brand-new repository (empty in-memory maps) on the same
+    # database file. Before the fix this returned None and forced re-login.
+    restarted_manager = await _make_db_manager(db_url)
+    restarted_repo = SessionRepository(restarted_manager, performance_monitor=None)
+
+    found = await restarted_repo.get_user_session(refresh_token)
+    assert found is not None
+    assert found["user_id"] == user_id
+    assert found["refresh_token"] == refresh_token
+    assert found["is_active"] is True
+
+
+async def test_revoked_session_not_returned_after_restart(db_url):
+    """Revocation persists too — a revoked token stays dead across a restart."""
+    user_id = "user-persist-2"
+    refresh_token = "refresh-token-persist-2"
+    expires_at = datetime.now(UTC) + timedelta(days=7)
+
+    manager = await _make_db_manager(db_url)
+    await _seed_user(manager, user_id)
+    repo = SessionRepository(manager, performance_monitor=None)
+    await repo.create_user_session(user_id, refresh_token, {}, expires_at)
+
+    assert await repo.revoke_user_session(refresh_token) is True
+
+    restarted_repo = SessionRepository(await _make_db_manager(db_url), performance_monitor=None)
+    assert await restarted_repo.get_user_session(refresh_token) is None
+
+
+async def test_expired_session_not_returned(db_url):
+    """An expired persisted session is rejected."""
+    user_id = "user-persist-3"
+    refresh_token = "refresh-token-persist-3"
+    expires_at = datetime.now(UTC) - timedelta(seconds=1)
+
+    manager = await _make_db_manager(db_url)
+    await _seed_user(manager, user_id)
+    repo = SessionRepository(manager, performance_monitor=None)
+    await repo.create_user_session(user_id, refresh_token, {}, expires_at)
+
+    assert await repo.get_user_session(refresh_token) is None
+
+
+async def test_unpersistable_user_falls_back_to_memory(db_url):
+    """A user_id with no ``users`` row (FK) falls back to in-memory storage."""
+    refresh_token = "refresh-token-fallback"
+    expires_at = datetime.now(UTC) + timedelta(days=7)
+
+    manager = await _make_db_manager(db_url)
+    repo = SessionRepository(manager, performance_monitor=None)
+
+    # No seeded user -> DB insert violates the FK -> in-memory fallback.
+    session_id = await repo.create_user_session("ghost-user", refresh_token, {}, expires_at)
+    assert session_id
+
+    found = await repo.get_user_session(refresh_token)
+    assert found is not None
+    assert found["user_id"] == "ghost-user"


### PR DESCRIPTION
Fixes two auth defects observed on the live PocketID/OIDC deployment (iq.holtel.io).

## 1. Double PocketID login (race)
The OIDC callback navigated to the app **before** the `user` query refetched with the freshly-stored token. The pre-login `user` query had *errored* (no token), so React Query reported `isLoading: false` (not pending) — AuthGuard saw a stale unauthenticated state and bounced to `/login`, forcing a second flow.

- `login`/`completeOidcLogin` `onSuccess` now `await cancelQueries` + `invalidateQueries`, so the mutation resolves only once `user` is re-fetched **with the new token**. AuthGuard never sees a stale state.
- Guarded the single-use session code against a double exchange (React StrictMode).

## 2. Sessions died on backend restart
Refresh tokens are opaque and were stored **only in the in-memory `SessionRepository` dict**, so every `coachiq.service` restart invalidated them (refresh → 401, frontend retry-looping). Production runs service-mode, which used that dict and bypassed the already-wired, persistent `AuthRepository`/`user_sessions` SQLite table.

- `SessionRepository` now persists sessions via `AuthRepository` (added `get_active_user_sessions`), with an in-memory fallback for the null backend and FK-unpersistable user ids (e.g. single-user admin).
- Verified the JWT signing key is read from `COACHIQ_AUTH__SECRET_KEY` and is **not** ephemeral — that link was already correct.

## Frontend refresh loop
`token-storage.ts` no longer loops forever: a 4xx (dead session) gives up immediately, transient errors get a bounded retry, then tokens are cleared and the user lands cleanly on `/login`.

## Verification
- Frontend `tsc` typecheck passes; zero new ESLint errors.
- 30 existing auth/composition/OIDC tests pass, plus 4 new regression tests proving a session survives a simulated restart, revocation persists, expiry is enforced, and FK-unpersistable users fall back to memory.

## Follow-up (out of scope)
`refresh_token_secret` is randomly regenerated each boot (a per-boot field validator shadows the intended stable fallback). Only affects *legacy* auth mode — production service mode uses opaque tokens — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)