### PR TITLE
fix(entities): route light control through correct DGN + multi-instance fan-out

### DIFF
--- a/backend/integrations/can/message_factory.py
+++ b/backend/integrations/can/message_factory.py
@@ -33,17 +33,22 @@ def create_light_can_message(pgn: int, instance: int, brightness_can_level: int)
         ps = pgn & 0xFF  # PDU Specific (contains group extension or specific address)
         arbitration_id = (prio << 26) | (dp << 24) | (pf << 16) | (ps << 8) | sa
 
-    # Construct payload
+    # Construct payload. Byte layout verified on the live coach bus against the
+    # Firefly dimmer modules (see docs/can-re-findings.md): sending
+    # 19FEDBF9#19FF6400FF00FFFF set instance 0x19 to op_status 0x64 and
+    # ...#19FF0000FF00FFFF turned it off, with DC_DIMMER_STATUS_3 echoing the
+    # commanded level exactly. Group must be 0xFF (none), duration 0xFF
+    # (instant), byte5 0x00 — the previous 0x7C/0x00/0xFF values were no-ops.
     payload_data = bytes(
         [
-            instance,  # Instance
-            0x7C,  # Group Mask (typically 0x7C for DML_COMMAND_2 based lights)
-            brightness_can_level,  # Level (0-200, 0xC8 for 100%)
-            0x00,  # Command: SetLevel
-            0x00,  # Duration: Instantaneous
-            0xFF,  # Reserved
-            0xFF,  # Reserved
-            0xFF,  # Reserved
+            instance,  # byte0: instance
+            0xFF,  # byte1: group = none
+            brightness_can_level,  # byte2: level (0-200, 0xC8 = 100%, 0x00 = off)
+            0x00,  # byte3: command = set level
+            0xFF,  # byte4: duration = instant
+            0x00,  # byte5
+            0xFF,  # byte6
+            0xFF,  # byte7
         ]
     )
 

--- a/backend/models/entity_model.py
+++ b/backend/models/entity_model.py
@@ -29,6 +29,9 @@ class EntityConfig(TypedDict, total=False):
     protocol_metadata: dict[str, Any]  # Protocol-specific configuration data
     # Additional configuration fields that may be present
     instance: int
+    # Extra dimmer instances a command must fan out to (multi-channel lights);
+    # empty/absent means command only the primary `instance`.
+    command_instances: list[int]
     command_dgn: str
     status_dgn: str
     status_source_addr: int
@@ -66,6 +69,10 @@ class EntityState(BaseModel):
     # Required by the control path to build CAN messages; sourced from the
     # coach mapping's DGN section (inst_map) at initialization.
     instance: int | None = Field(None, description="RV-C DGN instance for command emission")
+    command_instances: list[int] = Field(
+        default_factory=list,
+        description="Extra dimmer instances to fan a command out to (multi-channel lights)",
+    )
 
 
 class Entity:
@@ -113,6 +120,7 @@ class Entity:
             physical_id=config.get("physical_id"),
             protocol_metadata=config.get("protocol_metadata", {}),
             instance=config.get("instance"),
+            command_instances=list(config.get("command_instances", [])),
         )
 
         # Add initial state to history

--- a/backend/services/entities/entity_initialization_service.py
+++ b/backend/services/entities/entity_initialization_service.py
@@ -156,6 +156,16 @@ class EntityInitializationService:
                 if raw_instance is not None:
                     with contextlib.suppress(TypeError, ValueError):
                         entity_config["instance"] = int(raw_instance)
+                # Multi-channel lights fan a command out to several instances;
+                # the list is carried on the inst_map entry from the coach mapping.
+                raw_cmd_instances = inst_info.get("command_instances") if inst_info else None
+                if isinstance(raw_cmd_instances, list | tuple):
+                    fan: list[int] = []
+                    for value in raw_cmd_instances:
+                        with contextlib.suppress(TypeError, ValueError):
+                            fan.append(int(value))
+                    if fan:
+                        entity_config["command_instances"] = fan
                 entity_config_objs[entity_id] = entity_config
 
             # Register with local entity manager for preseeding and then persist

--- a/backend/services/entities/entity_service.py
+++ b/backend/services/entities/entity_service.py
@@ -805,21 +805,27 @@ class EntityService:
             }
         )
 
-        # Create and send CAN message
+        # Create and send CAN message(s). A light may map to several dimmer
+        # instances that must all be commanded (e.g. the bedroom ceiling is
+        # instances 25 and 26, both driven by one physical button); fan the
+        # command out to each. DGN 0x1FEDB = DC_DIMMER_COMMAND_2 (verified).
         try:
-            can_message = create_light_can_message(
-                pgn=0x1F0D0,  # Standard PGN for DML_COMMAND_2 light commands
-                instance=instance,
-                brightness_can_level=optimistic_raw_val,
-            )
-
-            # Use the resolved physical interface for this entity
+            command_instances = entity_config.get("command_instances") or [instance]
             can_interface = physical_interface
             logger.debug(
-                f"Sending CAN message for {entity_id} on interface {can_interface} (logical: {logical_interface})"
+                "Sending CAN command for %s to instances %s on interface %s (logical: %s)",
+                entity_id,
+                command_instances,
+                can_interface,
+                logical_interface,
             )
-
-            await can_tx_queue.put((can_message, can_interface))
+            for cmd_instance in command_instances:
+                can_message = create_light_can_message(
+                    pgn=0x1FEDB,  # DC_DIMMER_COMMAND_2
+                    instance=int(cmd_instance),
+                    brightness_can_level=optimistic_raw_val,
+                )
+                await can_tx_queue.put((can_message, can_interface))
 
             # Note: We don't have access to can_tracking_repo here for sniffer entries
             # This could be added as another dependency if needed

--- a/tests/integrations/can/test_light_message_factory.py
+++ b/tests/integrations/can/test_light_message_factory.py
@@ -1,0 +1,33 @@
+"""The live control path's CAN frame must match the verified Firefly dialect.
+
+These bytes were confirmed on the coach bus: sending 19FEDBF9#19FF6400FF00FFFF
+set instance 0x19 to op_status 0x64, and 19FF0000FF00FFFF turned it off, with
+DC_DIMMER_STATUS_3 echoing the commanded level (docs/can-re-findings.md).
+"""
+
+import pytest
+
+from backend.integrations.can.message_factory import create_light_can_message
+
+pytestmark = [pytest.mark.unit]
+
+
+@pytest.mark.parametrize(
+    ("level", "expected"),
+    [
+        (0xC8, "19FFC800FF00FFFF"),  # on, full
+        (0x64, "19FF6400FF00FFFF"),  # 50% — verified on the wire
+        (0x00, "19FF0000FF00FFFF"),  # off — verified on the wire
+    ],
+)
+def test_dimmer_command_matches_verified_frame(level: int, expected: str) -> None:
+    msg = create_light_can_message(pgn=0x1FEDB, instance=0x19, brightness_can_level=level)
+    assert msg.arbitration_id == 0x19FEDBF9  # priority 6, DGN 1FEDB, SA 0xF9
+    assert msg.is_extended_id
+    assert msg.data.hex().upper() == expected
+
+
+def test_instance_lands_in_byte0() -> None:
+    msg = create_light_can_message(pgn=0x1FEDB, instance=0x1A, brightness_can_level=0x64)
+    assert msg.data[0] == 0x1A
+    assert msg.data.hex().upper() == "1AFF6400FF00FFFF"


### PR DESCRIPTION
Follow-up to #185: that fixed `RVCEncoder`, but the **live** control path (`entity_service._execute_light_command`) uses `create_light_can_message` instead — which had a wrong hardcoded PGN (`0x1F0D0`), wrong payload bytes (group `0x7C`, duration `0x00`), and no fan-out.

Corrected to the verified DC_DIMMER_COMMAND_2 dialect (`0x1FEDB`, group `0xFF`, duration `0xFF`), and threaded `command_instances` through so the bedroom ceiling commands both instances 25 and 26. Factory output now matches the confirmed wire captures byte-for-byte. Discovered when an app-driven control POST emitted nothing on the bus despite #185.

🤖 Generated with [Claude Code](https://claude.com/claude-code)