### PR TITLE
fix: acknowledge working light commands + stream live CAN tool updates

### DIFF
--- a/backend/core/composition_root.py
+++ b/backend/core/composition_root.py
@@ -1064,6 +1064,23 @@ class CompositionRoot:
 
         await self._construct_websocket_manager()
 
+        # Back-inject the websocket manager into the per-frame CAN tools so their
+        # broadcast methods reach connected clients. These tools are constructed
+        # above (before the manager exists), so the injection has to happen here,
+        # after the manager is available. Without it, every tool's
+        # ``self._websocket_manager`` stays None and its broadcasts short-circuit,
+        # so the Recorder/Analyzer/Filter pages only ever see the initial snapshot.
+        websocket_manager = self.get_optional_service("websocket_manager")
+        if websocket_manager is not None:
+            for tool_name in (
+                "can_bus_recorder",
+                "can_protocol_analyzer",
+                "can_message_filter",
+            ):
+                tool = self.get_optional_service(tool_name)
+                if tool is not None:
+                    tool._websocket_manager = websocket_manager  # noqa: SLF001
+
         if self._should_construct("can_bus_service"):
             can_bus_service = CANBusService(
                 can_tracking_repository=self.require_service("can_tracking_repository"),

--- a/backend/integrations/can/can_bus_recorder.py
+++ b/backend/integrations/can/can_bus_recorder.py
@@ -812,7 +812,11 @@ class CANBusRecorder(GuardrailParticipant):
         if self._websocket_manager:
             try:
                 status = self.get_status()
-                await self._websocket_manager.broadcast_can_recorder_update("status", status)
+                # The frontend hook (useCANRecorderWebSocket) switches on
+                # ``recorder_status`` and reads ``payload.status``.
+                await self._websocket_manager.broadcast_can_recorder_update(
+                    "recorder_status", {"status": status}
+                )
             except Exception as e:
                 logger.debug(f"Failed to broadcast recorder status: {e}")
 

--- a/backend/integrations/can/message_filter.py
+++ b/backend/integrations/can/message_filter.py
@@ -283,8 +283,14 @@ class MessageFilter(GuardrailParticipant):
         # Service state
         self._is_running = False
 
-        # WebSocket manager for broadcasting updates (injected by main.py)
+        # WebSocket manager for broadcasting updates (injected by composition root)
         self._websocket_manager = None
+
+        # Throttle live WebSocket broadcasts so a busy bus does not flood clients.
+        self._last_status_broadcast = 0.0
+        self._status_broadcast_interval = 1.0  # seconds
+        self._last_captured_broadcast = 0.0
+        self._captured_broadcast_interval = 1.0  # seconds
 
         # Performance tracking
         self.stats = {
@@ -502,7 +508,11 @@ class MessageFilter(GuardrailParticipant):
         if self._websocket_manager:
             try:
                 status = self.get_status()
-                await self._websocket_manager.broadcast_can_filter_update("status", status)
+                # Frontend hook (useCANFilterWebSocket) switches on
+                # ``filter_status`` and reads ``payload.status``.
+                await self._websocket_manager.broadcast_can_filter_update(
+                    "filter_status", {"status": status}
+                )
             except Exception as e:
                 logger.debug(f"Failed to broadcast filter status: {e}")
 
@@ -510,10 +520,11 @@ class MessageFilter(GuardrailParticipant):
         """Broadcast captured messages via WebSocket if available."""
         if self._websocket_manager and self.capture_buffer:
             try:
-                # Send last 100 captured messages
+                # Send last 100 captured messages. Frontend hook switches on
+                # ``captured_messages`` and reads ``payload.messages``.
                 messages = self.capture_buffer[-100:]
                 await self._websocket_manager.broadcast_can_filter_update(
-                    "captured_messages", messages
+                    "captured_messages", {"messages": messages}
                 )
             except Exception as e:
                 logger.debug(f"Failed to broadcast captured messages: {e}")
@@ -605,6 +616,19 @@ class MessageFilter(GuardrailParticipant):
             self.stats["processing_time_ms"] = (
                 0.9 * self.stats["processing_time_ms"] + 0.1 * processing_time
             )
+
+            # Push live updates to WebSocket clients (throttled). Guarded inside
+            # the broadcast helpers so a broken client never breaks filtering.
+            if self._websocket_manager is not None:
+                now = time.time()
+                if should_capture and (
+                    now - self._last_captured_broadcast >= self._captured_broadcast_interval
+                ):
+                    await self._broadcast_captured_messages()
+                    self._last_captured_broadcast = now
+                if now - self._last_status_broadcast >= self._status_broadcast_interval:
+                    await self._broadcast_status()
+                    self._last_status_broadcast = now
 
             return should_pass
 

--- a/backend/integrations/can/protocol_analyzer.py
+++ b/backend/integrations/can/protocol_analyzer.py
@@ -638,7 +638,11 @@ class ProtocolAnalyzer(GuardrailParticipant):
         if self._websocket_manager:
             try:
                 stats = self.get_statistics()
-                await self._websocket_manager.broadcast_can_analyzer_update("statistics", stats)
+                # Frontend hook (useCANAnalyzerWebSocket) switches on
+                # ``analyzer_statistics`` and reads ``payload.statistics``.
+                await self._websocket_manager.broadcast_can_analyzer_update(
+                    "analyzer_statistics", {"statistics": stats}
+                )
             except Exception as e:
                 logger.debug(f"Failed to broadcast analyzer statistics: {e}")
 
@@ -674,7 +678,11 @@ class ProtocolAnalyzer(GuardrailParticipant):
                         }
                     )
 
-                await self._websocket_manager.broadcast_can_analyzer_update("messages", messages)
+                # Frontend hook switches on ``analyzed_messages`` and reads
+                # ``payload.messages``.
+                await self._websocket_manager.broadcast_can_analyzer_update(
+                    "analyzed_messages", {"messages": messages}
+                )
 
                 # Clear the buffer after broadcasting
                 self._message_broadcast_buffer.clear()

--- a/backend/services/can/can_bus_service.py
+++ b/backend/services/can/can_bus_service.py
@@ -7,6 +7,7 @@ Uses repository injection pattern for all dependencies.
 
 import asyncio
 import contextlib
+import datetime
 import time
 from typing import Any, override
 
@@ -796,8 +797,43 @@ class CANBusService(GuardrailParticipant):
 
             self._can_tracking_repository.add_can_sniffer_entry(sniffer_entry)
 
+            # Broadcast the live frame to CAN sniffer WebSocket clients. Mirrors
+            # the entity RX broadcast: guarded so a broken client (or a missing
+            # websocket manager) never breaks the CAN RX path.
+            await self._broadcast_sniffer_entry(message, interface_name, direction)
+
         except Exception as e:
             logger.error("Error adding sniffer entry: %s", e)
+
+    async def _broadcast_sniffer_entry(
+        self, message: Any, interface_name: str, direction: str
+    ) -> None:
+        """Broadcast a live CAN frame to sniffer WebSocket clients (best effort).
+
+        The sniffer page (``useCANScanWebSocket``) consumes each frame as a bare
+        ``CANMessage``: ``pgn`` (hex string), ``source`` (int), ``data`` (byte
+        list), ``timestamp`` (ISO-8601), plus ``interface``/``error``. RV-C uses
+        29-bit extended IDs: Priority(3) + PGN(18) + Source(8).
+        """
+        websocket_manager = self._websocket_manager
+        if websocket_manager is None:
+            return
+        try:
+            arbitration_id = message.arbitration_id
+            pgn = (arbitration_id >> 8) & 0x3FFFF
+            source_address = arbitration_id & 0xFF
+            frame = {
+                "timestamp": datetime.datetime.now(datetime.UTC).isoformat(),
+                "pgn": f"{pgn:X}",
+                "source": source_address,
+                "data": list(message.data),
+                "interface": interface_name,
+                "error": bool(getattr(message, "is_error_frame", False)),
+                "direction": direction,
+            }
+            await websocket_manager.broadcast_can_sniffer_entry(frame)
+        except Exception as broadcast_error:
+            logger.debug("Unable to broadcast sniffer entry: %s", broadcast_error)
 
     async def _process_message(self, msg: dict[str, Any]) -> None:  # noqa: C901, PLR0912, PLR0915
         """

--- a/backend/services/entities/entity_domain_service.py
+++ b/backend/services/entities/entity_domain_service.py
@@ -171,83 +171,83 @@ class EntityDomainService:
         validation["passed"] = len(validation["issues"]) == 0
         return validation
 
-    async def _wait_for_acknowledgment(
-        self, operation_id: str, entity_id: str, timeout_seconds: float
-    ) -> tuple[bool, float | None]:
+    @staticmethod
+    def _expected_operating_status(command: "SafetyControlCommandV2") -> int | None:
+        """Target DC_DIMMER operating_status (0-200 scale) for a command.
+
+        Returns 0 for off, the commanded level for an explicit brightness, or
+        ``None`` meaning "on at any level" (toggle / on-without-brightness),
+        where the confirmed value depends on the light's restored level.
         """
-        Wait for command acknowledgment from the physical RV-C system.
+        if command.command != "set":
+            return None  # toggle / brightness_up / brightness_down: accept any on-state
+        if command.state is False:
+            return 0
+        if command.brightness is not None:
+            return max(0, min(200, round(command.brightness * 2)))
+        return None  # on, unspecified level
 
-        Simple Pi-optimized implementation that monitors local CAN interface
-        for state change confirmation from the target entity.
+    async def _read_operating_status(self, entity_id: str) -> int | None:
+        """Read the entity's current operating_status from live state."""
+        try:
+            entities = await self.entities.list_entities()
+            raw = (entities.get(entity_id) or {}).get("raw") or {}
+            value = raw.get("operating_status")
+            return int(value) if value is not None else None
+        except Exception as e:  # noqa: BLE001 - polling must not raise
+            logger.warning("Error reading operating_status for %s: %s", entity_id, e)
+            return None
 
-        Returns (acknowledged, acknowledgment_time_ms)
+    @staticmethod
+    def _status_acknowledged(current: int | None, expected: int | None) -> bool:
+        """Whether the live operating_status confirms the commanded target."""
+        _tolerance = 10  # ~5% of the 0-200 scale, for ramp/rounding slack
+        if expected == 0:
+            return current == 0
+        if expected is not None:  # explicit level > 0
+            return current is not None and abs(current - expected) <= _tolerance
+        return current is not None and current > 0  # "on at any level"
+
+    async def _wait_for_acknowledgment(
+        self,
+        operation_id: str,
+        entity_id: str,
+        timeout_seconds: float,
+        expected_status: int | None,
+    ) -> tuple[bool, float | None]:
+        """Wait until the entity's live state reflects the commanded target.
+
+        Polls the RX-updated entity state (the same store that receives the
+        light's DC_DIMMER_STATUS_3 echo) for the target operating_status. Note
+        this confirms the commanded state was applied — a light that is toggled
+        off stops broadcasting, so its "off" is confirmed via the applied state
+        rather than a positive echo.
+
+        Returns ``(acknowledged, acknowledgment_time_ms)``.
         """
         start_time = time.time()
-        poll_interval = 0.1  # 100ms polls for responsive Pi performance
-
-        # Get the expected state after command execution
-        expected_state = await self._get_expected_entity_state(entity_id)
-
-        # Monitor CAN bus for actual state change
+        poll_interval = 0.1
         while (time.time() - start_time) < timeout_seconds:
-            try:
-                # Check current entity state from CAN bus via entity manager
-                current_state = await self.entity_manager.get_entity_current_state(entity_id)
-
-                if self._state_matches_expected(current_state, expected_state):
-                    acknowledgment_time = (time.time() - start_time) * 1000
-                    logger.info(f"Entity {entity_id} acknowledged in {acknowledgment_time:.1f}ms")
-                    return True, acknowledgment_time
-
-            except Exception as e:
-                logger.warning(f"Error checking entity state during ack wait: {e}")
-                # Continue polling rather than fail immediately
-
+            current = await self._read_operating_status(entity_id)
+            if self._status_acknowledged(current, expected_status):
+                ack_ms = (time.time() - start_time) * 1000
+                logger.info(
+                    "Entity %s acknowledged (op_status=%s, target=%s) in %.1fms",
+                    entity_id,
+                    current,
+                    expected_status,
+                    ack_ms,
+                )
+                return True, ack_ms
             await asyncio.sleep(poll_interval)
 
-        # Timeout reached without acknowledgment
-        timeout_ms = timeout_seconds * 1000
-        logger.warning(f"Entity {entity_id} acknowledgment timeout after {timeout_ms:.1f}ms")
+        logger.warning(
+            "Entity %s acknowledgment timeout after %.0fms (target op_status=%s)",
+            entity_id,
+            timeout_seconds * 1000,
+            expected_status,
+        )
         return False, None
-
-    async def _get_expected_entity_state(self, entity_id: str) -> dict[str, Any]:
-        """Get the expected state for entity after command execution."""
-        # For Pi deployment, keep this simple - just return current state
-        # In more complex scenarios, this would predict the expected state
-        try:
-            current_entities = await self.entities.list_entities()
-            entity_data = current_entities.get(entity_id, {})
-            return entity_data.get("raw", {})
-        except Exception as e:
-            logger.error(f"Failed to get expected state for {entity_id}: {e}")
-            return {}
-
-    def _state_matches_expected(self, current_state: dict, expected_state: dict) -> bool:
-        """
-        Simple state comparison for Pi deployment.
-
-        Compares key state fields to determine if command was acknowledged.
-        For RV systems, typically checks 'state', 'brightness', etc.
-        """
-        if not current_state or not expected_state:
-            return False
-
-        # For Pi deployment, check key fields that matter for RV control
-        key_fields = ["state", "brightness", "level", "position"]
-
-        for field in key_fields:
-            if field in expected_state:
-                current_val = current_state.get(field)
-                expected_val = expected_state.get(field)
-
-                # Allow small tolerance for analog values
-                if isinstance(expected_val, (int, float)) and isinstance(current_val, (int, float)):
-                    if abs(current_val - expected_val) > 0.1:  # 0.1% tolerance
-                        return False
-                elif current_val != expected_val:
-                    return False
-
-        return True
 
     async def halt_command_emission(self) -> dict[str, Any]:
         """
@@ -366,8 +366,9 @@ class EntityDomainService:
             )
 
             # Step 5: Wait for acknowledgment from physical system
+            expected_status = self._expected_operating_status(command)
             acknowledged, ack_time = await self._wait_for_acknowledgment(
-                operation_id, entity_id, command.timeout_seconds
+                operation_id, entity_id, command.timeout_seconds, expected_status
             )
 
             # Step 6: Update operation result

--- a/backend/services/system/websocket_service.py
+++ b/backend/services/system/websocket_service.py
@@ -229,6 +229,20 @@ class WebSocketService:
         """
         await self.broadcast_json_to_clients(self.can_sniffer_clients, group)
 
+    async def broadcast_can_sniffer_entry(self, entry: dict[str, Any]) -> None:
+        """
+        Broadcast a single live CAN sniffer entry to all connected sniffer clients.
+
+        Mirrors ``broadcast_to_data_clients`` (dead-socket cleanup, exception
+        guards) so a broken client can never break the RX path. The entry is
+        sent as a bare frame; the sniffer page (useCANScanWebSocket) consumes
+        the raw JSON directly as a CANMessage.
+
+        Args:
+            entry: The CAN sniffer entry to broadcast
+        """
+        await self.broadcast_json_to_clients(self.can_sniffer_clients, entry)
+
     async def broadcast_network_map(self, network_map: dict[str, Any]) -> None:
         """
         Broadcast network map data to all connected network map clients.
@@ -709,12 +723,18 @@ class WebSocketService:
             user_info.get("username", "unknown"),
         )
         try:
-            # Send initial recorder status if available
+            # Send initial recorder status if available. Shape matches
+            # broadcast_can_recorder_update("recorder_status", ...) so the
+            # frontend hook handles the snapshot and live updates identically.
             if self._can_bus_recorder is not None:
                 initial_status = self._can_bus_recorder.get_status()
                 if initial_status:
                     await websocket.send_json(
-                        {"type": "status", "payload": initial_status, "timestamp": time.time()}
+                        {
+                            "type": "recorder_status",
+                            "payload": {"status": initial_status},
+                            "timestamp": time.time(),
+                        }
                     )
 
             while True:
@@ -763,12 +783,18 @@ class WebSocketService:
             user_info.get("username", "unknown"),
         )
         try:
-            # Send initial analyzer stats if available
+            # Send initial analyzer stats if available. Shape matches
+            # broadcast_can_analyzer_update("analyzer_statistics", ...) so the
+            # frontend hook handles snapshot and live updates identically.
             if self._can_protocol_analyzer is not None:
                 initial_stats = self._can_protocol_analyzer.get_statistics()
                 if initial_stats:
                     await websocket.send_json(
-                        {"type": "statistics", "payload": initial_stats, "timestamp": time.time()}
+                        {
+                            "type": "analyzer_statistics",
+                            "payload": {"statistics": initial_stats},
+                            "timestamp": time.time(),
+                        }
                     )
 
             while True:
@@ -817,12 +843,18 @@ class WebSocketService:
             user_info.get("username", "unknown"),
         )
         try:
-            # Send initial filter status if available
+            # Send initial filter status if available. Shape matches
+            # broadcast_can_filter_update("filter_status", ...) so the frontend
+            # hook handles snapshot and live updates identically.
             if self._can_message_filter is not None:
                 initial_status = self._can_message_filter.get_status()
                 if initial_status:
                     await websocket.send_json(
-                        {"type": "status", "payload": initial_status, "timestamp": time.time()}
+                        {
+                            "type": "filter_status",
+                            "payload": {"status": initial_status},
+                            "timestamp": time.time(),
+                        }
                     )
 
             while True:

--- a/tests/services/test_can_rx_pipeline_wiring.py
+++ b/tests/services/test_can_rx_pipeline_wiring.py
@@ -10,12 +10,80 @@ Covers the root-cause fixes for live-data gaps in the RX pipeline:
   unmapped devices from the RX path (count increments, first-seen preserved).
 """
 
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
 import pytest
 
 from backend.repositories.diagnostics_repository import DiagnosticsRepository
-from backend.services.can.can_bus_service import _device_lookup_key
+from backend.services.can.can_bus_service import CANBusService, _device_lookup_key
 
 pytestmark = [pytest.mark.unit]
+
+
+def _make_message(arbitration_id: int = 0x19FEDA80, data: bytes = b"\x01\x02\x03\x04") -> SimpleNamespace:
+    """Build a minimal python-can-like message stub for the sniffer path."""
+    return SimpleNamespace(
+        arbitration_id=arbitration_id,
+        data=data,
+        dlc=len(data),
+        is_extended_id=True,
+        is_error_frame=False,
+    )
+
+
+def _make_service(websocket_manager: object | None) -> CANBusService:
+    """Construct a CANBusService with only the sniffer-path deps wired."""
+    return CANBusService(
+        can_tracking_repository=MagicMock(),
+        system_state_repository=MagicMock(),
+        websocket_manager=websocket_manager,
+    )
+
+
+class TestSnifferBroadcastWiring:
+    @pytest.mark.asyncio
+    async def test_add_sniffer_entry_broadcasts_live_frame(self):
+        websocket_manager = MagicMock()
+        websocket_manager.broadcast_can_sniffer_entry = AsyncMock()
+        service = _make_service(websocket_manager)
+
+        await service._add_sniffer_entry(_make_message(), "can0", "rx")
+
+        # Recorded to the tracking repository AND broadcast to sniffer clients.
+        service._can_tracking_repository.add_can_sniffer_entry.assert_called_once()
+        websocket_manager.broadcast_can_sniffer_entry.assert_awaited_once()
+
+        frame = websocket_manager.broadcast_can_sniffer_entry.await_args.args[0]
+        # Shape matches the frontend CANMessage the sniffer page consumes.
+        assert frame["pgn"] == "1FEDA"  # (0x19FEDA80 >> 8) & 0x3FFFF
+        assert frame["source"] == 0x80  # 0x19FEDA80 & 0xFF
+        assert frame["data"] == [0x01, 0x02, 0x03, 0x04]
+        assert frame["interface"] == "can0"
+        assert frame["direction"] == "rx"
+        assert frame["error"] is False
+
+    @pytest.mark.asyncio
+    async def test_add_sniffer_entry_without_websocket_manager_is_noop(self):
+        service = _make_service(None)
+
+        # Must not raise when no websocket manager is injected.
+        await service._add_sniffer_entry(_make_message(), "can0", "rx")
+
+        service._can_tracking_repository.add_can_sniffer_entry.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_broadcast_failure_does_not_break_rx_path(self):
+        websocket_manager = MagicMock()
+        websocket_manager.broadcast_can_sniffer_entry = AsyncMock(
+            side_effect=RuntimeError("client exploded")
+        )
+        service = _make_service(websocket_manager)
+
+        # A broken broadcast must be swallowed, never propagated to the RX path.
+        await service._add_sniffer_entry(_make_message(), "can0", "rx")
+
+        service._can_tracking_repository.add_can_sniffer_entry.assert_called_once()
 
 
 class TestDeviceLookupKeyNormalization:

--- a/tests/services/test_light_ack_matcher.py
+++ b/tests/services/test_light_ack_matcher.py
@@ -1,0 +1,52 @@
+"""Acknowledgment matching for light commands.
+
+Regression: the old matcher compared pre-command state with broken field
+logic and always timed out, so working commands surfaced as errors. These
+tests pin the target derivation and the status match.
+"""
+
+import pytest
+
+from backend.services.entities.entity_domain_service import (
+    EntityDomainService,
+    SafetyControlCommandV2,
+)
+
+pytestmark = [pytest.mark.unit]
+
+
+def _cmd(**kw) -> SafetyControlCommandV2:
+    return SafetyControlCommandV2(**kw)
+
+
+@pytest.mark.parametrize(
+    ("command", "expected"),
+    [
+        (_cmd(command="set", state=False), 0),  # off -> 0
+        (_cmd(command="set", state=True, brightness=50), 100),  # 50% -> 0-200 scale
+        (_cmd(command="set", state=True, brightness=100), 200),  # full
+        (_cmd(command="set", state=True, brightness=0), 0),
+        (_cmd(command="set", state=True), None),  # on, unspecified level
+        (_cmd(command="toggle"), None),  # non-set: any resulting on-state
+    ],
+)
+def test_expected_operating_status(command: SafetyControlCommandV2, expected: int | None) -> None:
+    assert EntityDomainService._expected_operating_status(command) == expected
+
+
+@pytest.mark.parametrize(
+    ("current", "expected", "ok"),
+    [
+        (0, 0, True),  # off confirmed
+        (5, 0, False),  # still on -> not off
+        (None, 0, False),  # unknown -> not confirmed off
+        (100, 100, True),  # exact level
+        (104, 100, True),  # within tolerance
+        (150, 100, False),  # too far
+        (100, None, True),  # "on at any level"
+        (0, None, False),  # off does not confirm an on-command
+        (None, None, False),
+    ],
+)
+def test_status_acknowledged(current: int | None, expected: int | None, ok: bool) -> None:
+    assert EntityDomainService._status_acknowledged(current, expected) is ok


### PR DESCRIPTION
Two "wire up the missing broadcast/correlation" fixes of the same species we've been clearing.

**Ack-matcher** (`entity_domain_service`): control commands physically worked but reported `ACKNOWLEDGMENT_TIMEOUT` — the old matcher compared pre-command state with field logic that no-op'd for lights and polled a store that isn't RX-updated. Rewritten to derive the target `operating_status` from the command and poll the live RX-updated state. Stops spurious error toasts on every working command.

**CAN Sniffer / Recorder / Analyzer / Filter live updates** (flagged by user): the WebSockets sent an initial snapshot then went stale. The tools' `websocket_manager` was never injected (broadcasts short-circuited) and the broadcast `type` strings didn't match the frontend hooks (delivered frames dropped). Injected the manager in the composition root, added the sniffer broadcast, and aligned every message shape. Injector/J1939/Templates (HTTP) already worked.

Verified: 113 tests pass (18 new/related), ruff delta 0 on all touched files, pyright at baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)