### PR TITLE
fix(climate): ambient instances are G6 sensor channels, not zone numbers

### DIFF
--- a/config/2021_Entegra_Aspire_44R.yml
+++ b/config/2021_Entegra_Aspire_44R.yml
@@ -560,15 +560,26 @@ areas:
       remote_unlock: true
       <<: *lock_device
 
-# Thermostat Status 1 (DGN: 1FFE2) - zone setpoints/mode/fan from the G6 (SA 0x9C).
-# Instance -> zone mapping verified live 2026-07-04: pressing + on the Mira's
-# Front/Mid/Rear zones stepped instances 0/1/2 in order, and the G6 accepted a
-# standard THERMOSTAT_COMMAND_1 from CoachIQ (SA 0xF9) for instance 0 with the
-# status echoing the commanded setpoints. Instances 3 and 4 are heat-side
-# counterparts whose heat setpoint tracks zones 0 (front) and 2 (rear)
-# respectively; 5 and 6 are heat-only zones not yet correlated to a Mira
-# control (likely Bay / Floor) - press those on the Mira and diff to identify.
-1FFE2:
+# Thermostat Ambient Status (DGN: 1FF9C) - measured temperatures from the G6.
+#
+# IMPORTANT: 1FF9C instances are the G6's raw SENSOR CHANNELS, NOT the
+# thermostat zone instances used by 1FFE2/1FEF9. Verified live 2026-07-05 by
+# matching readings against the Mira display and warming the Mid wall sensor
+# (channel 5 rose 70.3F -> 77.5F under a thumb; channel 4 never moved):
+#   0 = Front zone air     (joined to climate_front)
+#   1 = Rear zone air      (joined to climate_rear)   <- NOT zone order!
+#   2 = Bay                (81F, matches Mira Bay; unmapped until the bay
+#                           status zone among 1FFE2 5/6 is identified)
+#   3 = disconnected       (broadcasts -88C; unmapped)
+#   4 = Floor              (matches Mira Floor; unmapped until the floor
+#                           status zone among 1FFE2 5/6 is identified)
+#   5 = Mid zone air       (joined to climate_mid)
+#
+# ORDERING: this section MUST come before 1FFE2. The config loader's
+# inst_map keeps the LAST instance seen per entity_id, and the control path
+# uses it to address THERMOSTAT_COMMAND_1 - so 1FFE2 (zone instances) must
+# win. The zone anchors are therefore defined here and aliased below.
+1FF9C:
   0:
     - &climate_front_zone
       entity_id: climate_front
@@ -576,17 +587,34 @@ areas:
       area: interior.living_main
       <<: *climate_zone
   1:
-    - &climate_mid_zone
-      entity_id: climate_mid
-      friendly_name: "Mid Zone"
-      area: interior.living_main
-      <<: *climate_zone
-  2:
     - &climate_rear_zone
       entity_id: climate_rear
       friendly_name: "Rear Zone"
       area: interior.bedroom
       <<: *climate_zone
+  5:
+    - &climate_mid_zone
+      entity_id: climate_mid
+      friendly_name: "Mid Zone"
+      area: interior.living_main
+      <<: *climate_zone
+
+# Thermostat Status 1 (DGN: 1FFE2) - zone setpoints/mode/fan from the G6 (SA 0x9C).
+# Instance -> zone mapping verified live 2026-07-04: pressing + on the Mira's
+# Front/Mid/Rear zones stepped instances 0/1/2 in order, and the G6 accepted a
+# standard THERMOSTAT_COMMAND_1 from CoachIQ (SA 0xF9) for instance 0 with the
+# status echoing the commanded setpoints. Instances 3 and 4 are heat-side
+# counterparts whose heat setpoint tracks zones 0 (front) and 2 (rear)
+# respectively; 5 and 6 are heat-only zones not yet correlated to a Mira
+# control (Bay + Floor in some order) - change the Bay or Floor setpoint on
+# the Mira and diff to identify, then join ambient channels 2/4 to them.
+1FFE2:
+  0:
+    - <<: *climate_front_zone
+  1:
+    - <<: *climate_mid_zone
+  2:
+    - <<: *climate_rear_zone
   3:
     - &climate_front_heat_zone
       entity_id: climate_front_heat
@@ -611,26 +639,6 @@ areas:
       friendly_name: "Heat Zone 6 (Bay/Floor?)"
       area: interior.bedroom
       <<: *climate_zone_heat_only
-
-# Thermostat Ambient Status (DGN: 1FF9C) - per-zone measured temperature.
-# Same instances/entities as 1FFE2; the decoder merges ambient_temperature
-# into each zone's state. Instance 3 (bay) reported an implausible reading
-# (sensor absent?) and instance 6 was not observed broadcasting.
-1FF9C:
-  0:
-    - <<: *climate_front_zone
-  1:
-    - <<: *climate_mid_zone
-  2:
-    - <<: *climate_rear_zone
-  3:
-    - <<: *climate_front_heat_zone
-  4:
-    - <<: *climate_rear_heat_zone
-  5:
-    - <<: *climate_aux_heat_5_zone
-  6:
-    - <<: *climate_aux_heat_6_zone
 
 # Air Conditioner Status (DGN: 1FFE1) - rooftop AC units report from their own
 # source addresses (0x96-0x98, instances 1-3). Read-only; the thermostat zones

--- a/docs/can-re-findings.md
+++ b/docs/can-re-findings.md
@@ -101,8 +101,27 @@ stepped these instances in order):
   raw steps).
 - 3 tracks zone 0's setpoint and 4 tracks zone 2's — per-zone Aqua-Hot heat
   counterparts, not independent zones.
-- 5, 6 = heat-only, not yet correlated to a Mira control (likely Bay / Floor);
-  press those Mira buttons and diff to identify.
+- 5, 6 = heat-only, not yet correlated to a Mira control (Bay + Floor in some
+  order); change the Bay or Floor setpoint on the Mira and diff to identify.
+
+**`1FF9C` ambient instances are SENSOR CHANNELS, not zone instances** —
+discovered when the UI showed the rear temperature on the Mid card
+(2026-07-05). Verified against the Mira display plus a thumb-on-sensor test
+(channel 5 rose 70.3→77.5 °F while warming the Mid wall sensor):
+
+| channel | sensor | reading at test |
+|---|---|---|
+| 0 | Front zone air | 69.8 (Mira Front 69) |
+| 1 | **Rear** zone air | 96.8 (Mira Rear 97) |
+| 2 | Bay | 81.5 (Mira Bay 81) |
+| 3 | disconnected | −88 °C |
+| 4 | Floor | 70.2 (Mira Floor 70) |
+| 5 | **Mid** zone air | thumb test |
+
+The coach mapping joins channels 0/1/5 to the Front/Rear/Mid zones and leaves
+2/4 unmapped until the Bay/Floor status zones (1FFE2 5/6) are identified.
+A separate node at SA `0x75` also broadcasts `1FF9C` instance 0x13 (~82 °F,
+tracks bay/outdoor-ish — unidentified).
 
 ## Guardrail
 


### PR DESCRIPTION
## Summary

Ryan spotted the Mid zone card showing 97°F — the **rear** bedroom's temperature. Root cause: `THERMOSTAT_AMBIENT_STATUS` (1FF9C) instances are the G6's raw **sensor channels**, a different namespace from the `THERMOSTAT_STATUS_1` zone instances, so joining the two DGNs by instance attributed sensors to the wrong zones (Front only looked right by coincidence).

Verified live on the coach (2026-07-05) against the Mira display plus a thumb-on-sensor test (channel 5 rose 70.3→77.5°F while warming the Mid wall thermostat; channel 4 never moved):

| channel | sensor | evidence |
|---|---|---|
| 0 | Front air | 69.8 vs Mira 69 |
| 1 | **Rear** air | 96.8 vs Mira 97 |
| 2 | Bay | 81.5 vs Mira 81 |
| 3 | disconnected | −88°C |
| 4 | Floor | 70.2 vs Mira 70 |
| 5 | **Mid** air | thumb test |

## Changes

- Coach mapping: join ambient channels 0/1/5 to Front/Rear/Mid; leave 2 (Bay) and 4 (Floor) unmapped until the Bay/Floor **status** zones (1FFE2 instances 5/6) are identified by a Mira setpoint press.
- The 1FF9C section now precedes 1FFE2 (loader's `inst_map` keeps the last instance per entity; the control path must address `THERMOSTAT_COMMAND_1` by zone instance). Ordering requirement documented in the section comment; loader-level guard is part of the spec-audit follow-up task.
- docs/can-re-findings.md: sensor-channel table.

## Test plan

- [x] Loader assertions: control instances stay 0/1/2 (1FFE2) for Front/Mid/Rear; ambient channels 0/1/5 join the right entities; 2/3/4/6 unmapped
- [x] Climate + RVC suites pass
- [ ] After deploy: Mid card shows ~70°F, Rear ~97°F, matching the Mira

🤖 Generated with [Claude Code](https://claude.com/claude-code)