### PR TITLE
feat(climate): identify Bay/Floor zones and join their temperatures

### DIFF
--- a/config/2021_Entegra_Aspire_44R.yml
+++ b/config/2021_Entegra_Aspire_44R.yml
@@ -568,11 +568,9 @@ areas:
 # (channel 5 rose 70.3F -> 77.5F under a thumb; channel 4 never moved):
 #   0 = Front zone air     (joined to climate_front)
 #   1 = Rear zone air      (joined to climate_rear)   <- NOT zone order!
-#   2 = Bay                (81F, matches Mira Bay; unmapped until the bay
-#                           status zone among 1FFE2 5/6 is identified)
+#   2 = Bay                (joined to climate_bay_heat; 81F matched Mira Bay)
 #   3 = disconnected       (broadcasts -88C; unmapped)
-#   4 = Floor              (matches Mira Floor; unmapped until the floor
-#                           status zone among 1FFE2 5/6 is identified)
+#   4 = Floor              (joined to climate_floor_heat; matched Mira Floor)
 #   5 = Mid zone air       (joined to climate_mid)
 #
 # ORDERING: this section MUST come before 1FFE2. The config loader's
@@ -592,6 +590,18 @@ areas:
       friendly_name: "Rear Zone"
       area: interior.bedroom
       <<: *climate_zone
+  2:
+    - &climate_bay_heat_zone
+      entity_id: climate_bay_heat
+      friendly_name: "Bay Heat (Aqua-Hot)"
+      area: exterior.basement
+      <<: *climate_zone_heat_only
+  4:
+    - &climate_floor_heat_zone
+      entity_id: climate_floor_heat
+      friendly_name: "Floor Heat"
+      area: interior.living_main
+      <<: *climate_zone_heat_only
   5:
     - &climate_mid_zone
       entity_id: climate_mid
@@ -605,9 +615,8 @@ areas:
 # standard THERMOSTAT_COMMAND_1 from CoachIQ (SA 0xF9) for instance 0 with the
 # status echoing the commanded setpoints. Instances 3 and 4 are heat-side
 # counterparts whose heat setpoint tracks zones 0 (front) and 2 (rear)
-# respectively; 5 and 6 are heat-only zones not yet correlated to a Mira
-# control (Bay + Floor in some order) - change the Bay or Floor setpoint on
-# the Mira and diff to identify, then join ambient channels 2/4 to them.
+# respectively. Zones 5 and 6 identified live 2026-07-05: the Mira's Bay
+# setpoint button stepped zone 5 and the Floor button stepped zone 6.
 1FFE2:
   0:
     - <<: *climate_front_zone
@@ -628,17 +637,9 @@ areas:
       area: interior.bedroom
       <<: *climate_zone_heat_only
   5:
-    - &climate_aux_heat_5_zone
-      entity_id: climate_aux_heat_5
-      friendly_name: "Heat Zone 5 (Bay/Floor?)"
-      area: interior.living_main
-      <<: *climate_zone_heat_only
+    - <<: *climate_bay_heat_zone
   6:
-    - &climate_aux_heat_6_zone
-      entity_id: climate_aux_heat_6
-      friendly_name: "Heat Zone 6 (Bay/Floor?)"
-      area: interior.bedroom
-      <<: *climate_zone_heat_only
+    - <<: *climate_floor_heat_zone
 
 # Air Conditioner Status (DGN: 1FFE1) - rooftop AC units report from their own
 # source addresses (0x96-0x98, instances 1-3). Read-only; the thermostat zones

--- a/docs/can-re-findings.md
+++ b/docs/can-re-findings.md
@@ -101,8 +101,8 @@ stepped these instances in order):
   raw steps).
 - 3 tracks zone 0's setpoint and 4 tracks zone 2's — per-zone Aqua-Hot heat
   counterparts, not independent zones.
-- 5, 6 = heat-only, not yet correlated to a Mira control (Bay + Floor in some
-  order); change the Bay or Floor setpoint on the Mira and diff to identify.
+- 5 = **Bay**, 6 = **Floor** — identified live 2026-07-05: the Mira's Bay
+  setpoint button stepped zone 5, the Floor button stepped zone 6.
 
 **`1FF9C` ambient instances are SENSOR CHANNELS, not zone instances** —
 discovered when the UI showed the rear temperature on the Mid card
@@ -118,10 +118,10 @@ discovered when the UI showed the rear temperature on the Mid card
 | 4 | Floor | 70.2 (Mira Floor 70) |
 | 5 | **Mid** zone air | thumb test |
 
-The coach mapping joins channels 0/1/5 to the Front/Rear/Mid zones and leaves
-2/4 unmapped until the Bay/Floor status zones (1FFE2 5/6) are identified.
-A separate node at SA `0x75` also broadcasts `1FF9C` instance 0x13 (~82 °F,
-tracks bay/outdoor-ish — unidentified).
+The coach mapping joins channels 0/1/5 to the Front/Rear/Mid zones and 2/4 to
+the Bay/Floor heat zones (status instances 5/6). A separate node at SA `0x75`
+also broadcasts `1FF9C` instance 0x13 (~82 °F, tracks bay/outdoor-ish —
+unidentified).
 
 ## Guardrail
 


### PR DESCRIPTION
## Summary

Completes the climate zone map. Live identification with Ryan at the Mira panel: the **Bay** setpoint button stepped status zone **5** and the **Floor** button stepped zone **6** (both confirmed by repeated presses on the bus watch). Renames the placeholder `climate_aux_heat_5/6` entities to `climate_bay_heat` / `climate_floor_heat` and joins their ambient sensors — channel 2 (Bay, matched the Mira's 81°F) and channel 4 (Floor, matched 70°F).

Every climate card now shows a real temperature; the only unmapped ambient channel left is 3 (physically disconnected sensor).

## Test plan

- [x] Loader assertions: all 7 zones command by 1FFE2 instance; ambient joins 0→front, 1→rear, 2→bay, 4→floor, 5→mid; channels 3/6 unmapped
- [x] Climate + RVC suites pass (59)
- [x] Frontend heat-only detection unchanged (`_heat` id convention preserved)
- [ ] After deploy: Bay card ~81°F, Floor card ~70°F

🤖 Generated with [Claude Code](https://claude.com/claude-code)