### PR TITLE
docs: bring the session-bootstrap docs current with the climate findings

### DIFF
--- a/dev_tools/can_re/README.md
+++ b/dev_tools/can_re/README.md
@@ -1,9 +1,11 @@
 # CAN reverse-engineering toolkit
 
 Standalone capture / census / diff tools for reverse-engineering the coach's
-CAN traffic — built to crack the **Firefly G6 command dialect** that standard
-RV-C `DC_DIMMER_COMMAND_2` frames do not drive (see
-[`docs/can-re-findings.md`](../../docs/can-re-findings.md)).
+CAN traffic. Originally built to crack the Firefly light-command dialect;
+that and the climate zone/sensor maps are cracked and shipped (see
+[`docs/can-re-findings.md`](../../docs/can-re-findings.md) for everything
+learned so far). The toolkit remains the standing method for mapping whatever
+is next — awnings, generator, Aqua-Hot commands, tank sensors.
 
 These talk to SocketCAN directly via `candump`/`cansend`. They need **no**
 running CoachIQ app and **no** auth, so you can run them from the coach while
@@ -64,10 +66,13 @@ Reading the output:
   press is the signal; one-off flickers are noise. Longer captures (`--seconds
   15`) also help.
 
-Repeat for OFF, dim up/down, and a couple of different lights. The frame + byte
-that consistently tracks the action **is** the command the Firefly system uses.
-Send me the `captures/*.jsonl` files (or just the diff output) and that's enough
-to implement the encoder.
+Repeat the press two or three times. The frame + byte that consistently
+tracks the action **is** the signal — record the result in
+`docs/can-re-findings.md` and wire it into the coach mapping
+(`config/2021_Entegra_Aspire_44R.yml`, entity-first schema: add a `sources`
+entry for a status feed, or a `command` target plus encoder support for a new
+control). The light and climate encoders in
+`backend/integrations/can/message_factory.py` are the pattern to follow.
 
 Tip: `can0` and `can1` are bridged on this coach, so either interface sees the
 same traffic — `can1` is fine.

--- a/docs/can-re-findings.md
+++ b/docs/can-re-findings.md
@@ -1,11 +1,15 @@
 # CAN reverse-engineering findings (2021 Entegra Aspire 44R)
 
-Passive-sniff observations from the coach bus, gathered while diagnosing why
-CoachIQ can receive live state but cannot command lights. Tooling to reproduce
-and extend this lives in [`dev_tools/can_re/`](../dev_tools/can_re/README.md).
+The living map of this coach's CAN bus: who talks, which DGNs carry what, and
+which command dialects the Firefly system honors — all verified on the wire.
+Tooling to reproduce and extend this lives in
+[`dev_tools/can_re/`](../dev_tools/can_re/README.md).
 
-**Status:** receive path proven end to end; **transmit/control is blocked** on
-learning the Firefly command dialect. This document is the map for that work.
+**Status (2026-07-05):** RX and TX both proven end to end. CoachIQ controls
+**lights** (DC_DIMMER_COMMAND_2 with the payload dialect below) and **climate**
+(standard THERMOSTAT_COMMAND_1) from SA `0xF9`, with the G6 echoing commanded
+state in its next status broadcast. The idle-vs-action capture diff remains
+the method for mapping anything new (awnings, generator, Aqua-Hot commands).
 
 ## Bus topology
 
@@ -28,46 +32,41 @@ The RV-C name lookup resolving the `0x4F` proprietary frames to `ATS_AC_STATUS_*
 means a large slice of the "proprietary" traffic is **AC power management, not
 lighting** — it can be set aside when hunting the light-command frame.
 
-## Why standard commands don't work
+## The light command dialect (RESOLVED 2026-07-04)
 
-1. **The G6 is a continuous master.** It re-broadcasts `DC_DIMMER_COMMAND_2`
-   (`1FEDB`, from SA `0x9C`) at ~2 Hz per output, cycling byte-0 (instance)
-   through `{0x13, 0x16, 0x32, 0xB5..0xBC}` — ~11 outputs. A single competing
-   command from CoachIQ (SA `0xF9`) is overwritten within ~90 ms. Verified: a
-   30-command burst of standard `DC_DIMMER_COMMAND_2` produced **no change** in
-   the target's `DC_DIMMER_STATUS_3` broadcast.
+Early standard-frame attempts failed and pointed at a proprietary dialect;
+the real causes turned out to be mundane (full chain in the PR #185–#188
+history): the payload byte layout was wrong, and — the biggest single cause —
+**the CAN TX writer was never started** after the service-layer rebuild, so
+commands built frames that nothing transmitted.
 
-2. **Instance numbering doesn't match.** The coach mapping calls the bedroom
-   ceiling light instance **25 (`0x19`)**, but the G6 never commands `0x19` on
-   the wire — its instance set is `{0x13, 0x16, 0x32, 0xB5..0xBC}`. So either
-   the mapping's instances are wrong, or Firefly addresses outputs by a
-   different scheme (zone/group) in a proprietary frame. **This is the open
-   question a button-press capture resolves.**
+The working dialect, verified by DC_DIMMER_STATUS_3 echoing commanded levels:
 
-## The open question → how to answer it
+- Frame `0x19FEDBF9` (DC_DIMMER_COMMAND_2, prio 6, SA `0xF9`), payload
+  `[instance, 0xFF group, level 0-200, 0x00 set-level, 0xFF duration, 0x00,
+  0xFF, 0xFF]`.
+- The mapping's instances (25/`0x19` etc.) were CORRECT; the instance set the
+  G6 cycles in its own ~2 Hz re-broadcasts is unrelated to what the modules
+  accept from other senders.
+- Some lights are multi-channel (bedroom ceiling = instances 25 **and** 26);
+  the command fans out to each (`command.instances` in the coach mapping).
+
+## The method: idle vs. action capture diffs
 
 Whatever a Vegatouch Mira button toggles is, by definition, the command the
-Firefly system honors. Capture idle vs. a button press and diff:
+Firefly system honors — and whatever changes on the panel shows up as a
+status delta. This cracked both lights and climate, and is the template for
+anything new (awnings, generator, Aqua-Hot burner/electric):
 
 ```
-python -m dev_tools.can_re.capture --iface can1 --seconds 6 --label idle       --out captures/idle.jsonl
-python -m dev_tools.can_re.capture --iface can1 --seconds 6 --label ceiling-on  --out captures/ceiling-on.jsonl   # press the button now
-python -m dev_tools.can_re.diff captures/idle.jsonl captures/ceiling-on.jsonl --noise captures/idle2.jsonl
+coachiq-can-re capture --iface can1 --seconds 10 --label idle   --out captures/idle.jsonl
+coachiq-can-re capture --iface can1 --seconds 10 --label action --out captures/action.jsonl   # press the button now
+coachiq-can-re diff captures/idle.jsonl captures/action.jsonl --noise captures/idle2.jsonl
 ```
 
-The surviving ranked change is the control frame. Likely outcomes, in order of
-prior probability:
-
-1. A **proprietary `0x1FFxx` frame from SA `0x9C`** carries the real command
-   (Firefly's private channel). Decode it, emit it as `0x9C`/that PGN.
-2. It **is** `DC_DIMMER_COMMAND_2` but with a different instance/group byte than
-   our mapping assumes — fix the mapping, keep the standard encoder.
-3. The module only accepts commands from the master's SA `0x9C` — we'd emit as
-   `0x9C` (impersonation) rather than `0xF9`.
-
-Once known, implement in `backend/integrations/rvc/encoder.py` behind the
-existing command path, then the acknowledgment matcher in
-`entity_domain_service._wait_for_acknowledgment` starts confirming.
+A live `candump -ta can1,<id>:<mask>` watch during single presses is even
+better for instance identification — that is how the thermostat zone order,
+the ambient sensor channels, and the Bay/Floor zones were pinned.
 
 ## Climate (heating / cooling) — survey 2026-07-04
 
@@ -122,6 +121,19 @@ The coach mapping joins channels 0/1/5 to the Front/Rear/Mid zones and 2/4 to
 the Bay/Floor heat zones (status instances 5/6). A separate node at SA `0x75`
 also broadcasts `1FF9C` instance 0x13 (~82 °F, tracks bay/outdoor-ish —
 unidentified).
+
+## Trust level of config/rvc.json
+
+Treat unverified spec entries as **claims, not facts** — parts of the file
+were generated rather than transcribed. Confirmed cases (all fixed):
+THERMOSTAT_AMBIENT_STATUS had a fabricated signal layout, THERMOSTAT_COMMAND_1
+had the wrong PGN (`FEF6` vs real `1FEF9`), and auto-generated `UNKNOWN_*`
+placeholders shadowed real entries because the loader keys the decoder by PGN
+with last-entry-wins (that one blanked every climate temperature and all AC
+status in production). A scan found ~16 more entries whose `pgn` contradicts
+their own pdf_reference (generator commands among them) — tracked as the
+spec-audit follow-up task. Before building on an untested entry, verify it
+against the official RV-C PDF or a live capture.
 
 ## Guardrail
 

--- a/docs/frontend-redesign.md
+++ b/docs/frontend-redesign.md
@@ -20,6 +20,7 @@ Everything else (CAN tooling, mapping, spec search) is a technician surface, pre
 |---|---|---|
 | Home | `/` | Connectivity hero, zone grid (devices grouped by coach area from coach config), scenes, active alerts |
 | Lights | `/lights` | Zone-grouped light controls, per-zone all on/off, brightness where dimmable |
+| Climate | `/climate` | Thermostat zone cards (current temp, setpoint stepper, mode, fan), Aqua-Hot heat zones, read-only AC/Aqua-Hot equipment status (BUILT 2026-07) |
 | Devices | `/devices` | All entities table/cards, filter by type/area/protocol (replaces "Multi-Protocol Entities") |
 | Diagnostics | `/diagnostics` | DTCs (real v2 data), per-system health — the ONLY fault-code page |
 | System | `/system` | App/service status + CAN interface telemetry + performance, tabbed (replaces System Status, Health Dashboard, Performance Analytics, Analytics Dashboard) |
@@ -116,9 +117,10 @@ Unmapped Entries; use these names when assigning them in the coach mapping.
 **Climate model (Climate Control screen)** — zones Front/Mid/Rear each with current
 temp, setpoint, and mode (Cool / Heat Pump / Aqua-Hot / Auto) + fan High/Low; plus
 Bay (Aqua-Hot) and Floor (floor heat) zones and global Aqua-Hot Burner / Electric
-toggles. This is the blueprint for a CoachIQ Climate page once thermostat/HVAC DGNs
-are mapped — zone cards with setpoint steppers and mode selection, same pattern as
-the lighting zone cards.
+toggles. **BUILT (2026-07-04/05):** the `/climate` page ships this — all 7 zones
+mapped and wire-verified (instance/sensor-channel map in docs/can-re-findings.md),
+setpoint/mode/fan control via standard THERMOSTAT_COMMAND_1. Still open: Aqua-Hot
+Burner/Electric toggles (RX-only until a command wire test).
 
 **Tanks** — Mira's fault list shows fresh/grey/black tank sensors (currently not
 reporting on the panel either). TANK_STATUS mapping → Home tank-level card.


### PR DESCRIPTION
## Summary

The repo docs that bootstrap new working sessions (`docs/can-re-findings.md`, `docs/frontend-redesign.md`, `dev_tools/can_re/README.md`) still described the pre-climate world: TX "blocked", the light dialect an open question, the Climate page a future blueprint. Docs-only refresh:

- **can-re-findings**: status header reflects wire-verified light + climate control; light-dialect section rewritten as resolved history (payload dialect + the un-started TX writer); capture-diff workflow reframed as the standing method that also cracked the climate maps; new **"Trust level of config/rvc.json"** section records the fabricated-entry findings and points at the audit task.
- **can_re README**: intro reframed from "crack the dialect" to the standing mapping method; the "send me the captures" hand-off now points at the findings doc, the entity-first coach mapping, and the encoder pattern.
- **frontend-redesign**: `/climate` added to the owner routes table; Mira climate blueprint marked BUILT with the Aqua-Hot toggle gap noted.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)