### PR TITLE
fix(can): key exact decoder lookups by wire arbitration id

### DIFF
--- a/backend/integrations/rvc/decode.py
+++ b/backend/integrations/rvc/decode.py
@@ -159,11 +159,12 @@ def load_config_data(
     dict[str, str],  # pgn_hex_to_name_map
     dict[str, Any],  # dgn_pairs
     CoachInfo,  # coach_info
+    dict[int, dict[str, Any]],  # frame_id_dict
 ]:
     """
     Load and parse RVC spec and device mapping data.
 
-    DEPRECATED: This function returns a complex 10-element tuple that makes code
+    DEPRECATED: This function returns a complex 11-element tuple that makes code
     difficult to maintain and test. Use load_config_data_v2() instead, which returns
     a structured RVCConfiguration object with proper type hints and convenient
     access methods.
@@ -188,12 +189,14 @@ def load_config_data(
             - pgn_hex_to_name_map: Dictionary mapping DGN hex strings to PGN names
             - dgn_pairs: Dictionary mapping DGNs to useful metadata for faster lookups
             - coach_info: CoachInfo object with detected coach metadata
+            - frame_id_dict: Dictionary mapping wire-captured 29-bit arbitration
+              ids to specification entries
     """
     # Log deprecation warning
     import warnings
 
     warnings.warn(
-        "load_config_data() is deprecated and returns a complex 10-element tuple. "
+        "load_config_data() is deprecated and returns a complex 11-element tuple. "
         "Use load_config_data_v2() instead for a structured RVCConfiguration object.",
         DeprecationWarning,
         stacklevel=2,
@@ -212,6 +215,7 @@ def load_config_data(
 
     # Process DGN dictionary
     dgn_dict: dict[int, dict[str, Any]] = {}
+    frame_id_dict: dict[int, dict[str, Any]] = {}
     pgn_hex_to_name_map: dict[str, str] = {}
     rvc_spec_dgn_pairs: dict[str, dict[str, Any]] = {}
 
@@ -234,6 +238,14 @@ def load_config_data(
                 dgn_dict[dgn].get("name", "?"),
             )
         dgn_dict[dgn] = pgn_entry
+        # Spec entries carry the full wire-captured 29-bit arbitration id.
+        # dgn_dict cannot serve exact-id lookups: its keys are synthesized with
+        # an assumed priority 6 when the entry has no "priority" field (e.g.
+        # the ATS_AC_STATUS_* frames actually broadcast at priority 3), and
+        # entries sharing a PGN would overwrite each other there.
+        frame_id = pgn_entry.get("id")
+        if isinstance(frame_id, int):
+            frame_id_dict[frame_id] = pgn_entry
         pgn_hex_to_name_map[pgn_entry["pgn"]] = pgn_name
         rvc_spec_dgn_pairs[pgn_entry["pgn"]] = {
             "dgn": dgn,
@@ -285,6 +297,7 @@ def load_config_data(
         pgn_hex_to_name_map,
         dgn_pairs,
         coach_info,
+        frame_id_dict,
     )
 
 
@@ -385,6 +398,7 @@ def load_config_data_v2(
         pgn_hex_to_name_map,
         dgn_pairs,
         coach_info,
+        frame_id_dict,
     ) = load_config_data(rvc_spec_path_override, device_mapping_path_override)
 
     # Convert inst_map to use RVCEntityMapping objects
@@ -400,6 +414,7 @@ def load_config_data_v2(
     # Return structured configuration
     return RVCConfiguration(
         dgn_dict=dgn_dict,
+        frame_id_dict=frame_id_dict,
         spec_meta=spec_meta_structured,
         mapping_dict=mapping_dict,
         entity_map=entity_map,

--- a/backend/models/rvc_config.py
+++ b/backend/models/rvc_config.py
@@ -31,13 +31,21 @@ class RVCConfiguration(BaseModel):
     """
     Structured RVC configuration data.
 
-    This replaces the complex 10-element tuple returned by load_config_data()
+    This replaces the complex tuple returned by load_config_data()
     with a properly typed structure that is easier to work with and maintain.
     """
 
     # Core RVC specification data
     dgn_dict: dict[int, dict[str, Any]] = Field(
         default_factory=dict, description="Dictionary mapping DGNs to specification entries"
+    )
+
+    frame_id_dict: dict[int, dict[str, Any]] = Field(
+        default_factory=dict,
+        description=(
+            "Dictionary mapping wire-captured 29-bit CAN arbitration ids to "
+            "specification entries, for exact-id decoder lookups"
+        ),
     )
 
     spec_meta: RVCSpecMeta = Field(

--- a/backend/services/can/can_bus_service.py
+++ b/backend/services/can/can_bus_service.py
@@ -120,6 +120,7 @@ class CANBusService(GuardrailParticipant):
 
         # RVC decoder data - will be loaded on startup
         self.decoder_map: dict[int, dict[str, Any]] = {}
+        self.decoder_frame_id_map: dict[int, dict[str, Any]] = {}
         self.decoder_pgn_map: dict[int, dict[str, Any]] = {}
         self.device_lookup: dict[tuple[str, str], Any] = {}
         self.status_lookup: dict[tuple[str, str], dict[str, Any]] = {}
@@ -397,7 +398,13 @@ class CANBusService(GuardrailParticipant):
 
             # Extract values from structured config
             self.decoder_map = rvc_config.dgn_dict
-            self.decoder_pgn_map = self._build_decoder_pgn_map(self.decoder_map)
+            self.decoder_frame_id_map = rvc_config.frame_id_dict
+            # Build the PGN fallback from the id-keyed map when available:
+            # dgn_dict drops spec entries that share a PGN (its keys collide),
+            # so it under-populates the fallback.
+            self.decoder_pgn_map = self._build_decoder_pgn_map(
+                self.decoder_frame_id_map or self.decoder_map
+            )
             self.entity_id_lookup = rvc_config.inst_map  # entity ID to config lookup
             self.pgn_hex_to_name_map = rvc_config.pgn_hex_to_name_map  # PGN hex to name mapping
 
@@ -447,8 +454,13 @@ class CANBusService(GuardrailParticipant):
         return pgn_map
 
     def _get_decoder_entry(self, arbitration_id: int, pgn: int) -> dict[str, Any] | None:
-        """Get a decoder entry by exact ID or PGN fallback."""
-        entry = self.decoder_map.get(arbitration_id)
+        """Get a decoder entry by exact 29-bit arbitration id, else PGN fallback.
+
+        The exact match must use the id-keyed map: decoder_map (dgn_dict) keys
+        are ``(priority << 18) | pgn`` with an assumed priority, so they never
+        equal a full arbitration id.
+        """
+        entry = self.decoder_frame_id_map.get(arbitration_id)
         if entry is not None:
             return entry
         return self.decoder_pgn_map.get(pgn)

--- a/tests/services/test_can_rx_pipeline_wiring.py
+++ b/tests/services/test_can_rx_pipeline_wiring.py
@@ -8,6 +8,10 @@ Covers the root-cause fixes for live-data gaps in the RX pipeline:
   updated from live CAN traffic.
 - DiagnosticsRepository upsert helpers used to record unknown PGNs and
   unmapped devices from the RX path (count increments, first-seen preserved).
+- Decoder entry lookup: the exact-match branch keys off the wire-captured
+  29-bit arbitration id (``frame_id_dict``), not ``dgn_dict`` whose keys are
+  ``(priority << 18) | pgn`` with an assumed priority 6 and therefore can
+  never equal a real arbitration id.
 """
 
 from types import SimpleNamespace
@@ -21,7 +25,9 @@ from backend.services.can.can_bus_service import CANBusService, _device_lookup_k
 pytestmark = [pytest.mark.unit]
 
 
-def _make_message(arbitration_id: int = 0x19FEDA80, data: bytes = b"\x01\x02\x03\x04") -> SimpleNamespace:
+def _make_message(
+    arbitration_id: int = 0x19FEDA80, data: bytes = b"\x01\x02\x03\x04"
+) -> SimpleNamespace:
     """Build a minimal python-can-like message stub for the sniffer path."""
     return SimpleNamespace(
         arbitration_id=arbitration_id,
@@ -100,6 +106,92 @@ class TestDeviceLookupKeyNormalization:
 
     def test_lowercase_prefix_and_hex_are_uppercased(self):
         assert _device_lookup_key("0x1feda", "25") == ("1FEDA", "25")
+
+
+class TestDecoderEntryLookup:
+    """_get_decoder_entry: exact arbitration-id match first, PGN fallback second."""
+
+    # ATS_AC_STATUS_1 broadcasts at priority 3 from source 0x4F: id 0x0DFFAD4F,
+    # PGN 0x1FFAD. Its dgn_dict key would be (6 << 18) | 0x1FFAD — never the id.
+    ATS_ARBITRATION_ID = 0x0DFFAD4F
+    ATS_PGN = 0x1FFAD
+
+    def _service_with_decoders(self) -> CANBusService:
+        service = _make_service(None)
+        self.exact_entry = {"name": "ATS_AC_STATUS_1", "pgn": "0x1FFAD"}
+        self.fallback_entry = {"name": "GENERIC_AC_STATUS", "pgn": "0x1FFAD"}
+        service.decoder_frame_id_map = {self.ATS_ARBITRATION_ID: self.exact_entry}
+        service.decoder_pgn_map = {self.ATS_PGN: self.fallback_entry}
+        return service
+
+    def test_exact_arbitration_id_match_wins_over_pgn_fallback(self):
+        service = self._service_with_decoders()
+
+        entry = service._get_decoder_entry(self.ATS_ARBITRATION_ID, self.ATS_PGN)
+
+        assert entry is self.exact_entry
+
+    def test_unknown_source_address_falls_back_to_pgn(self):
+        service = self._service_with_decoders()
+
+        # Same frame from a different source address: no exact-id hit.
+        entry = service._get_decoder_entry(0x0DFFAD99, self.ATS_PGN)
+
+        assert entry is self.fallback_entry
+
+    def test_synthesized_dgn_key_is_not_treated_as_exact_match(self):
+        """A dgn_dict-style key must never satisfy the exact-id branch."""
+        service = self._service_with_decoders()
+        dgn_key = (6 << 18) | self.ATS_PGN
+        service.decoder_frame_id_map = {}
+        service.decoder_map = {dgn_key: self.exact_entry}
+        service.decoder_pgn_map = {}
+
+        assert service._get_decoder_entry(self.ATS_ARBITRATION_ID, self.ATS_PGN) is None
+
+    def test_no_match_returns_none(self):
+        service = self._service_with_decoders()
+
+        assert service._get_decoder_entry(0x18FF0102, 0x1FF01) is None
+
+
+class TestFrameIdDictWiring:
+    """The spec's wire-captured ids must reach the service's exact-id map."""
+
+    @pytest.fixture(scope="class")
+    def rvc_config(self):
+        from backend.integrations.rvc import load_config_data_v2
+
+        return load_config_data_v2()
+
+    def test_frame_id_dict_keys_are_wire_arbitration_ids(self, rvc_config):
+        assert rvc_config.frame_id_dict
+        for frame_id, entry in rvc_config.frame_id_dict.items():
+            assert frame_id == entry["id"]
+            # The embedded PGN must round-trip out of the arbitration id,
+            # otherwise the exact-match and fallback branches would disagree.
+            assert (frame_id >> 8) & 0x3FFFF == int(entry["pgn"], 16)
+
+    def test_priority_3_ats_frames_are_reachable_by_exact_id(self, rvc_config):
+        # ATS_AC_STATUS_* broadcast at priority 3 (0x0DFFxxxx). dgn_dict keys
+        # assume priority 6, so only the id-keyed map can exact-match them.
+        ats_ids = [
+            frame_id
+            for frame_id, entry in rvc_config.frame_id_dict.items()
+            if str(entry.get("name", "")).startswith("ATS_AC_STATUS")
+        ]
+        assert ats_ids, "expected ATS_AC_STATUS_* entries in the spec"
+        for frame_id in ats_ids:
+            assert (frame_id >> 26) & 0x7 == 3
+            assert frame_id not in rvc_config.dgn_dict
+
+    def test_every_dgn_dict_entry_is_reachable_by_exact_id(self, rvc_config):
+        # Entries sharing a PGN overwrite each other in dgn_dict, so the
+        # id-keyed map is a superset: every surviving dgn_dict entry must be
+        # reachable through its own wire id.
+        assert len(rvc_config.frame_id_dict) >= len(rvc_config.dgn_dict)
+        for entry in rvc_config.dgn_dict.values():
+            assert rvc_config.frame_id_dict[entry["id"]] == entry
 
 
 class TestDiagnosticsRepositoryUpserts:


### PR DESCRIPTION
## Summary

`_get_decoder_entry`'s exact-match branch looked up the full 29-bit arbitration id in `decoder_map` (`dgn_dict`), whose keys are `(priority << 18) | pgn` with priority assumed 6 when the spec entry carries none — a value that can never equal a wire arbitration id. The branch was dead: every frame decoded through the PGN fallback, which additionally drops spec entries that share a PGN (`dgn_dict` keys collide).

## Changes

- `load_config_data` now also builds `frame_id_dict`, keyed by each spec entry's wire-captured integer `id` (audited against the live bus in #196), and `RVCConfiguration` exposes it.
- `CANBusService._get_decoder_entry` exact-matches against the new id-keyed map, so the priority-3 `ATS_AC_STATUS_*` frames (`0x0DFFxxxx`) are exact-matchable even though their `dgn_dict` keys assume priority 6.
- The PGN fallback map is built from the id-keyed map, keeping all same-PGN entries as candidates.
- New tests in `tests/services/test_can_rx_pipeline_wiring.py`: exact-id-wins / PGN-fallback / no-match unit tests, plus real-config invariants (every `frame_id_dict` key equals its entry's `id` and round-trips the PGN; ATS frames exact-reachable; every `dgn_dict` entry reachable by its own id).

## Verification

- Wiring, rvc-integration, and services suites pass locally; only pre-existing failures remain (the 3 known `test_service_key_lookups` params, 2 others that fail identically on clean main, and the order-dependent `test_mapping_file_structure`).
- `ruff format`/`ruff check` clean on changed lines; local pyright error count unchanged (1172 before and after), so the CI ratchet baseline is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)