### PR TITLE
feat(ui): power section for Victron entities on the home page

### DIFF
--- a/backend/services/victron/victron_service.py
+++ b/backend/services/victron/victron_service.py
@@ -200,14 +200,17 @@ class VictronService:
         pending.clear()
 
         entity_def = self._def_for_entity(entity_id)
+        state_label = entity_def.state_fn(merged) if entity_def else "unknown"
+        # MQTT values arrive already decoded, so raw mirrors value; the v2
+        # entities API surfaces `raw` as the state dict, and the frontend
+        # reads the derived human label from its `status` key.
+        signals = {**merged, "status": state_label}
         payload = {
             "entity_id": entity_id,
             "timestamp": time.time(),
-            "value": merged,
-            # MQTT values arrive already decoded, so raw mirrors value; the
-            # entities API surfaces `raw` as the state dict.
-            "raw": merged,
-            "state": entity_def.state_fn(merged) if entity_def else "unknown",
+            "value": signals,
+            "raw": signals,
+            "state": state_label,
         }
         updated_entity = entity_manager.update_entity_state(entity_id, payload)
         if updated_entity is None:

--- a/frontend/src/components/power-section.tsx
+++ b/frontend/src/components/power-section.tsx
@@ -1,0 +1,211 @@
+/**
+ * Power — read-only cards for the Victron power system entities.
+ *
+ * These entities (inverter/charger, battery, solar, system aggregate) are
+ * telemetry, not switches: they must never render the generic DeviceRow
+ * toggle, which would send a bare `toggle` command at the inverter. All
+ * numbers come straight from the entity state dict; anything missing shows
+ * as "—" (no fabricated values, per docs/frontend-redesign.md).
+ */
+
+import {
+  IconBattery,
+  IconBolt,
+  IconPlugConnected,
+  IconSun,
+} from "@tabler/icons-react"
+
+import type { EntitySchema } from "@/api/types/domains"
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Progress } from "@/components/ui/progress"
+import { POWER_DEVICE_TYPES } from "@/lib/power"
+import { cn } from "@/lib/utils"
+
+/** system /Ac/ActiveIn/Source enum (Venus OS). */
+const AC_SOURCE_NAMES = new Map<number, string>([
+  [1, "Grid"],
+  [2, "Generator"],
+  [3, "Shore power"],
+  [240, "Inverting"],
+])
+
+function num(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null
+}
+
+function fmtWatts(watts: number | null): string {
+  if (watts === null) return "—"
+  return Math.abs(watts) >= 1000 ? `${(watts / 1000).toFixed(1)} kW` : `${Math.round(watts)} W`
+}
+
+function fmtNumber(value: number | null, unit: string, digits = 1): string {
+  return value === null ? "—" : `${value.toFixed(digits)} ${unit}`
+}
+
+function statusLabel(state: Record<string, unknown>): string {
+  const status = state.status
+  return typeof status === "string" ? status.replace(/_/g, " ") : "unknown"
+}
+
+function StatRow({ label, value }: Readonly<{ label: string; value: string }>) {
+  return (
+    <div className="flex items-center justify-between py-1 text-sm">
+      <span className="text-muted-foreground">{label}</span>
+      <span className="font-medium tabular-nums">{value}</span>
+    </div>
+  )
+}
+
+interface IPowerCardProps {
+  entity: EntitySchema
+  icon: typeof IconBolt
+  statusVariant?: "default" | "secondary"
+  children: React.ReactNode
+}
+
+function PowerCard({ entity, icon: Icon, children }: Readonly<IPowerCardProps>) {
+  const state = entity.state ?? {}
+  const offline = entity.available === false
+  return (
+    <Card className={cn(offline && "opacity-50")}>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+        <CardTitle className="flex items-center gap-2 text-base">
+          <Icon className="size-4 text-muted-foreground" aria-hidden />
+          {entity.name}
+        </CardTitle>
+        {offline ? (
+          <Badge variant="outline" className="gap-1 text-xs text-muted-foreground">
+            <span className="size-1.5 rounded-full bg-red-500" aria-hidden />
+            offline
+          </Badge>
+        ) : (
+          <Badge variant="secondary" className="text-xs capitalize">
+            {statusLabel(state)}
+          </Badge>
+        )}
+      </CardHeader>
+      <CardContent>{children}</CardContent>
+    </Card>
+  )
+}
+
+function PowerFlowCard({ entity }: Readonly<{ entity: EntitySchema }>) {
+  const state = entity.state ?? {}
+  const sourceCode = num(state.ac_source_code)
+  const acIn = sumWatts(state.ac_in_l1_power, state.ac_in_l2_power)
+  const loads = sumWatts(state.ac_loads_l1_power, state.ac_loads_l2_power)
+  const batteryPower = num(state.battery_power)
+  const source =
+    sourceCode !== null ? (AC_SOURCE_NAMES.get(sourceCode) ?? "Off-grid") : "—"
+
+  return (
+    <PowerCard entity={entity} icon={IconBolt}>
+      <StatRow label="AC source" value={source} />
+      <StatRow label="AC input" value={fmtWatts(acIn)} />
+      <StatRow label="Loads" value={fmtWatts(loads)} />
+      <StatRow label="Battery" value={batteryFlowLabel(batteryPower)} />
+      <StatRow label="Solar" value={fmtWatts(num(state.pv_power))} />
+    </PowerCard>
+  )
+}
+
+function sumWatts(...values: unknown[]): number | null {
+  const numbers = values.map(num).filter((value): value is number => value !== null)
+  return numbers.length === 0 ? null : numbers.reduce((total, value) => total + value, 0)
+}
+
+function batteryFlowLabel(watts: number | null): string {
+  if (watts === null) return "—"
+  if (watts > 0) return `Charging ${fmtWatts(watts)}`
+  if (watts < 0) return `Discharging ${fmtWatts(Math.abs(watts))}`
+  return "Idle"
+}
+
+function InverterChargerCard({ entity }: Readonly<{ entity: EntitySchema }>) {
+  const state = entity.state ?? {}
+  const shoreConnected = num(state.ac_in_connected) === 1
+  const currentLimit = num(state.input_current_limit)
+  return (
+    <PowerCard entity={entity} icon={IconPlugConnected}>
+      <StatRow label="Shore input" value={shoreConnected ? "Connected" : "Disconnected"} />
+      <StatRow label="AC in" value={fmtWatts(num(state.ac_in_power))} />
+      <StatRow label="AC out" value={fmtWatts(num(state.ac_out_power))} />
+      <StatRow label="Input limit" value={fmtNumber(currentLimit, "A", 0)} />
+    </PowerCard>
+  )
+}
+
+function BatteryCard({ entity }: Readonly<{ entity: EntitySchema }>) {
+  const state = entity.state ?? {}
+  const soc = num(state.soc)
+  return (
+    <PowerCard entity={entity} icon={IconBattery}>
+      <div className="mb-2 space-y-1.5">
+        <p className="text-2xl font-semibold tabular-nums">
+          {soc === null ? "—" : `${Math.round(soc)}%`}
+        </p>
+        <Progress value={soc ?? 0} aria-label="Battery state of charge" />
+      </div>
+      <StatRow label="Power" value={batteryFlowLabel(num(state.power))} />
+      <StatRow label="Voltage" value={fmtNumber(num(state.voltage), "V")} />
+      <StatRow label="Temperature" value={fmtNumber(num(state.temperature), "°C", 0)} />
+    </PowerCard>
+  )
+}
+
+function SolarCard({ entity }: Readonly<{ entity: EntitySchema }>) {
+  const state = entity.state ?? {}
+  return (
+    <PowerCard entity={entity} icon={IconSun}>
+      <div className="mb-2">
+        <p className="text-2xl font-semibold tabular-nums">
+          {fmtWatts(num(state.pv_power))}
+        </p>
+      </div>
+      <StatRow label="Yield today" value={fmtNumber(num(state.yield_today_kwh), "kWh")} />
+      <StatRow label="Yield total" value={fmtNumber(num(state.yield_total_kwh), "kWh", 0)} />
+    </PowerCard>
+  )
+}
+
+const CARD_ORDER: Record<string, number> = {
+  power_system: 0,
+  inverter_charger: 1,
+  battery: 2,
+  solar_controller: 3,
+}
+
+function cardFor(entity: EntitySchema) {
+  switch (entity.device_type) {
+    case "power_system":
+      return <PowerFlowCard key={entity.entity_id} entity={entity} />
+    case "inverter_charger":
+      return <InverterChargerCard key={entity.entity_id} entity={entity} />
+    case "battery":
+      return <BatteryCard key={entity.entity_id} entity={entity} />
+    case "solar_controller":
+      return <SolarCard key={entity.entity_id} entity={entity} />
+    default:
+      return null
+  }
+}
+
+export function PowerSection({ entities }: Readonly<{ entities: EntitySchema[] }>) {
+  const powerEntities = entities
+    .filter((entity) => POWER_DEVICE_TYPES.has(entity.device_type))
+    .sort(
+      (a, b) => (CARD_ORDER[a.device_type] ?? 9) - (CARD_ORDER[b.device_type] ?? 9)
+    )
+
+  if (powerEntities.length === 0) return null
+
+  return (
+    <div className="space-y-3">
+      <h2 className="text-sm font-medium text-muted-foreground">Power</h2>
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
+        {powerEntities.map(cardFor)}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/lib/power.ts
+++ b/frontend/src/lib/power.ts
@@ -1,0 +1,11 @@
+/**
+ * Victron power-system device types. These entities are telemetry, not
+ * switches: they render in the home page's Power section and are excluded
+ * from the zone grid (whose DeviceRow would give them a toggle switch).
+ */
+export const POWER_DEVICE_TYPES = new Set([
+  "inverter_charger",
+  "battery",
+  "solar_controller",
+  "power_system",
+])

--- a/frontend/src/pages/home.tsx
+++ b/frontend/src/pages/home.tsx
@@ -26,7 +26,9 @@ import { Link } from "react-router-dom"
 
 import { fetchActiveDTCs } from "@/api/domains/diagnostics"
 import type { EntitySchema, OperationResultSchema } from "@/api/types/domains"
+import { PowerSection } from "@/components/power-section"
 import { Badge } from "@/components/ui/badge"
+import { POWER_DEVICE_TYPES } from "@/lib/power"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
@@ -601,7 +603,12 @@ export default function HomePage() {
   const { data: entityCollection, isLoading, error } = useEntities({ page_size: 100 })
 
   const entities = entityCollection?.entities ?? []
-  const zones = groupEntitiesByZone(entities, config)
+  // Power entities get their own read-only section; keeping them out of the
+  // zone grid also keeps them away from DeviceRow's toggle switch.
+  const zoneEntities = entities.filter(
+    (entity) => !POWER_DEVICE_TYPES.has(entity.device_type)
+  )
+  const zones = groupEntitiesByZone(zoneEntities, config)
 
   const controlsDisabled = coach !== "LIVE"
   const disabledReason =
@@ -615,6 +622,7 @@ export default function HomePage() {
       <ConnectionHero />
       <AlertsStrip />
       <ScenesRow entities={entities} />
+      <PowerSection entities={entities} />
 
       {isLoading && (
         <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">

--- a/tests/services/test_victron_service.py
+++ b/tests/services/test_victron_service.py
@@ -113,6 +113,10 @@ class TestUpdateFlow:
         assert state.value["ac_in_l1_power"] == 372
         assert state.value["vebus_state"] == 3
         assert state.state == "bulk"
+        # The v2 entities API exposes only the raw dict, so the derived human
+        # label must ride along in both signal dicts as `status`.
+        assert state.value["status"] == "bulk"
+        assert state.raw["status"] == "bulk"
 
         assert "victron_inverter_charger" in state_repository.saved
         assert len(websocket_manager.broadcasts) == 1


### PR DESCRIPTION
## Summary

Follow-up to #200: the four Victron entities were falling through to the zone grid's generic `DeviceRow`, rendering as **toggle switches wired to bare `toggle` commands** — wrong presentation and a misfire hazard aimed at the inverter.

### Changes
- **New Power section** on Home (between scenes and zones): read-only telemetry cards
  - *Power flow* — AC source (shore/generator/inverting), AC input, loads, battery direction, solar
  - *Inverter/Charger* — VE.Bus state badge (bulk/absorption/float/passthru/…), shore connected, AC in/out, input current limit
  - *Battery* — SOC headline + progress bar, charge/discharge watts, voltage, temperature
  - *Solar* — PV watts headline, yield today/total
- **Power device types excluded from the zone grid** (`frontend/src/lib/power.ts`) so they can never reach the switch row. Scenes are unaffected (globs only match `*_light`).
- **Backend**: flush payload now carries the derived human state label as `status` inside the signal dicts — the v2 entities API only surfaces the raw dict, so the frontend needed it there. Values show "—" when absent (no fabricated numbers).

### Verification
- Live browser check against `cerbo.holtel.io`: all four cards render real telemetry (Shore power · 3.3 kW in · loads 3.2 kW · Bulk · SOC 99% · 55.3 V), and no power entity renders a switch.
- `tsc -b` clean, eslint clean on changed files, 33 backend Victron tests pass (new `status` assertion included). Frontend `useWebSocket` test failures are pre-existing on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)