### PR TITLE
feat(ui): dedicated Power page with Victron controls

### DIFF
--- a/frontend/src/api/victron.ts
+++ b/frontend/src/api/victron.ts
@@ -1,0 +1,44 @@
+/**
+ * Victron power system API client (/api/victron).
+ *
+ * Control endpoints are admin-gated on the backend and write to the Cerbo GX
+ * over MQTT. Validation errors (e.g. current limit outside the adjustable
+ * range) come back as 422 with a human-readable detail message.
+ */
+
+import { apiGet, apiPost } from './client';
+
+export interface IVictronStatus {
+  service: string;
+  healthy: boolean;
+  running: boolean;
+  connected: boolean;
+  portal_id: string | null;
+  bound_devices: Record<string, string>;
+}
+
+/** VE.Bus switch positions (vebus /Mode). */
+export type InverterMode = 'on' | 'off' | 'charger_only' | 'inverter_only';
+
+export const INVERTER_MODE_CODES: Record<InverterMode, number> = {
+  charger_only: 1,
+  inverter_only: 2,
+  on: 3,
+  off: 4,
+};
+
+export async function fetchVictronStatus(): Promise<IVictronStatus> {
+  return apiGet<IVictronStatus>('/api/victron/status');
+}
+
+export async function setInverterMode(
+  mode: InverterMode
+): Promise<{ success: boolean; mode: number; mode_name: string }> {
+  return apiPost('/api/victron/inverter/mode', { mode });
+}
+
+export async function setInputCurrentLimit(
+  amps: number
+): Promise<{ success: boolean; input_current_limit: number }> {
+  return apiPost('/api/victron/inverter/input-current-limit', { amps });
+}

--- a/frontend/src/components/power-section.tsx
+++ b/frontend/src/components/power-section.tsx
@@ -11,9 +11,11 @@
 import {
   IconBattery,
   IconBolt,
+  IconChevronRight,
   IconPlugConnected,
   IconSun,
 } from "@tabler/icons-react"
+import { Link } from "react-router-dom"
 
 import type { EntitySchema } from "@/api/types/domains"
 import { Badge } from "@/components/ui/badge"
@@ -191,7 +193,10 @@ function cardFor(entity: EntitySchema) {
   }
 }
 
-export function PowerSection({ entities }: Readonly<{ entities: EntitySchema[] }>) {
+export function PowerSection({
+  entities,
+  showTitle = true,
+}: Readonly<{ entities: EntitySchema[]; showTitle?: boolean }>) {
   const powerEntities = entities
     .filter((entity) => POWER_DEVICE_TYPES.has(entity.device_type))
     .sort(
@@ -202,7 +207,15 @@ export function PowerSection({ entities }: Readonly<{ entities: EntitySchema[] }
 
   return (
     <div className="space-y-3">
-      <h2 className="text-sm font-medium text-muted-foreground">Power</h2>
+      {showTitle && (
+        <Link
+          to="/power"
+          className="group flex items-center gap-1 text-sm font-medium text-muted-foreground hover:text-foreground"
+        >
+          Power
+          <IconChevronRight className="size-4 transition-transform group-hover:translate-x-0.5" aria-hidden />
+        </Link>
+      )}
       <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
         {powerEntities.map(cardFor)}
       </div>

--- a/frontend/src/lib/routes.tsx
+++ b/frontend/src/lib/routes.tsx
@@ -12,6 +12,7 @@
 import type { Icon } from "@tabler/icons-react"
 import {
   IconAdjustments,
+  IconBolt,
   IconBulb,
   IconCircuitSwitchOpen,
   IconCpu,
@@ -40,6 +41,7 @@ import DevicesPage from "@/pages/devices"
 import DiagnosticsPage from "@/pages/diagnostics"
 import Lights from "@/pages/lights"
 import NetworkMap from "@/pages/network-map"
+import PowerPage from "@/pages/power"
 import RVCSpec from "@/pages/rvc-spec"
 import AccountPage from "@/pages/account"
 import SystemPage from "@/pages/system"
@@ -65,6 +67,7 @@ export const appRoutes: IAppRoute[] = [
   { path: "/", title: "Home", icon: IconHome, section: "owner", element: <HomePage /> },
   { path: "/lights", title: "Lights", icon: IconBulb, section: "owner", element: <Lights /> },
   { path: "/climate", title: "Climate", icon: IconTemperature, section: "owner", element: <ClimatePage /> },
+  { path: "/power", title: "Power", icon: IconBolt, section: "owner", element: <PowerPage /> },
   { path: "/devices", title: "Devices", icon: IconCpu, section: "owner", element: <DevicesPage /> },
   { path: "/diagnostics", title: "Diagnostics", icon: IconStethoscope, section: "owner", element: <DiagnosticsPage /> },
   { path: "/system", title: "System", icon: IconListDetails, section: "owner", element: <SystemPage /> },

--- a/frontend/src/pages/power.tsx
+++ b/frontend/src/pages/power.tsx
@@ -1,0 +1,325 @@
+/**
+ * Power — Victron power system telemetry and controls.
+ *
+ * Telemetry reuses the home page's PowerSection cards. Controls write to the
+ * Cerbo GX through the admin-gated /api/victron endpoints: VE.Bus mode
+ * changes require an explicit confirmation dialog (they can cut AC output);
+ * the shore input current limit applies from presets or a custom value and
+ * is validated server-side against the range the Cerbo reports.
+ */
+
+import { IconAlertTriangle, IconPlugConnected, IconPlugConnectedX } from "@tabler/icons-react"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { useState } from "react"
+
+import type { EntitySchema } from "@/api/types/domains"
+import {
+  fetchVictronStatus,
+  setInputCurrentLimit,
+  setInverterMode,
+  type InverterMode,
+} from "@/api/victron"
+import { PowerSection } from "@/components/power-section"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { toast } from "@/hooks/use-toast"
+import { entitiesQueryKeys, useEntities } from "@/hooks/useEntities"
+import { cn } from "@/lib/utils"
+
+const MODE_OPTIONS: {
+  mode: InverterMode
+  code: number
+  label: string
+  description: string
+}[] = [
+  {
+    mode: "on",
+    code: 3,
+    label: "On",
+    description:
+      "Normal operation: charge the batteries when shore power is present, invert from the batteries when it is not.",
+  },
+  {
+    mode: "charger_only",
+    code: 1,
+    label: "Charger only",
+    description:
+      "Inverting stops. AC loads are only powered while shore or generator power is present; charging continues.",
+  },
+  {
+    mode: "inverter_only",
+    code: 2,
+    label: "Inverter only",
+    description:
+      "Charging stops. The batteries will not charge from shore power; loads run from the inverter.",
+  },
+  {
+    mode: "off",
+    code: 4,
+    label: "Off",
+    description:
+      "The inverter and charger both stop. Coach AC output shuts down and the batteries stop charging.",
+  },
+]
+
+const LIMIT_PRESETS = [15, 20, 30, 50]
+
+/** Shared status query — controls gate on the Cerbo MQTT link, not the CAN bus. */
+function useVictronStatus() {
+  return useQuery({
+    queryKey: ["victron", "status"],
+    queryFn: fetchVictronStatus,
+    refetchInterval: 30_000,
+    retry: false,
+  })
+}
+
+function VictronStatusChip() {
+  const { data } = useVictronStatus()
+
+  if (!data) return null
+  const connected = data.connected
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-2 rounded-lg border px-3 py-1.5 text-sm",
+        connected
+          ? "border-green-200 bg-green-50 text-green-800 dark:border-green-900 dark:bg-green-950/40 dark:text-green-300"
+          : "border-red-300 bg-red-50 text-red-900 dark:border-red-900 dark:bg-red-950/40 dark:text-red-200"
+      )}
+    >
+      {connected ? (
+        <IconPlugConnected className="size-4" aria-hidden />
+      ) : (
+        <IconPlugConnectedX className="size-4" aria-hidden />
+      )}
+      <span className="font-medium">
+        {connected ? "Cerbo GX connected" : "Cerbo GX unreachable"}
+      </span>
+      {data.portal_id && (
+        <span className="text-xs opacity-70">portal {data.portal_id}</span>
+      )}
+    </div>
+  )
+}
+
+function num(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null
+}
+
+interface IControlsProps {
+  inverter: EntitySchema | undefined
+  controlsDisabled: boolean
+}
+
+function InverterModeCard({ inverter, controlsDisabled }: Readonly<IControlsProps>) {
+  const queryClient = useQueryClient()
+  const [pendingMode, setPendingMode] = useState<(typeof MODE_OPTIONS)[number] | null>(null)
+
+  const state = inverter?.state ?? {}
+  const currentCode = num(state.mode)
+  const modeAdjustable = num(state.mode_adjustable) !== 0
+
+  const mutation = useMutation({
+    mutationFn: (mode: InverterMode) => setInverterMode(mode),
+    onSuccess: (result) => {
+      toast({
+        title: `Inverter/charger set to ${result.mode_name.replace(/_/g, " ")}`,
+      })
+      void queryClient.invalidateQueries({ queryKey: entitiesQueryKeys.all })
+    },
+    onError: (error: Error) => {
+      toast({
+        variant: "destructive",
+        title: "Mode change failed",
+        description: error.message,
+      })
+    },
+    onSettled: () => setPendingMode(null),
+  })
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base">Inverter/charger mode</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="grid grid-cols-2 gap-2">
+          {MODE_OPTIONS.map((option) => {
+            const isCurrent = currentCode === option.code
+            return (
+              <Button
+                key={option.mode}
+                variant={isCurrent ? "default" : "outline"}
+                disabled={
+                  controlsDisabled || !modeAdjustable || mutation.isPending || isCurrent
+                }
+                onClick={() => setPendingMode(option)}
+              >
+                {option.label}
+              </Button>
+            )
+          })}
+        </div>
+        {!modeAdjustable && (
+          <p className="text-xs text-muted-foreground">
+            The Cerbo reports the mode as not adjustable (check the physical switch
+            position on the Quattros).
+          </p>
+        )}
+      </CardContent>
+
+      <Dialog open={pendingMode !== null} onOpenChange={(open) => !open && setPendingMode(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <IconAlertTriangle className="size-5 text-amber-500" aria-hidden />
+              Switch to {pendingMode?.label}?
+            </DialogTitle>
+            <DialogDescription>{pendingMode?.description}</DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setPendingMode(null)}>
+              Cancel
+            </Button>
+            <Button
+              disabled={mutation.isPending}
+              onClick={() => pendingMode && mutation.mutate(pendingMode.mode)}
+            >
+              {mutation.isPending ? "Sending…" : `Switch to ${pendingMode?.label}`}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </Card>
+  )
+}
+
+function ShoreLimitCard({ inverter, controlsDisabled }: Readonly<IControlsProps>) {
+  const queryClient = useQueryClient()
+  const [customAmps, setCustomAmps] = useState("")
+
+  const state = inverter?.state ?? {}
+  const currentLimit = num(state.input_current_limit)
+  const limitAdjustable = num(state.input_current_limit_adjustable) !== 0
+
+  const mutation = useMutation({
+    mutationFn: (amps: number) => setInputCurrentLimit(amps),
+    onSuccess: (result) => {
+      toast({ title: `Shore input limit set to ${result.input_current_limit} A` })
+      setCustomAmps("")
+      void queryClient.invalidateQueries({ queryKey: entitiesQueryKeys.all })
+    },
+    onError: (error: Error) => {
+      toast({
+        variant: "destructive",
+        title: "Limit change failed",
+        description: error.message,
+      })
+    },
+  })
+
+  const disabled = controlsDisabled || !limitAdjustable || mutation.isPending
+  const customValue = Number(customAmps)
+  const customValid = customAmps !== "" && Number.isFinite(customValue) && customValue >= 0
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="flex items-center justify-between text-base">
+          Shore input limit
+          <Badge variant="secondary" className="tabular-nums">
+            {currentLimit === null ? "—" : `${currentLimit} A`}
+          </Badge>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <p className="text-xs text-muted-foreground">
+          Match this to the pedestal breaker. The Quattros draw at most this much from
+          shore and make up the difference from the batteries.
+        </p>
+        <div className="flex flex-wrap gap-2">
+          {LIMIT_PRESETS.map((amps) => (
+            <Button
+              key={amps}
+              variant={currentLimit === amps ? "default" : "outline"}
+              size="sm"
+              disabled={disabled || currentLimit === amps}
+              onClick={() => mutation.mutate(amps)}
+            >
+              {amps} A
+            </Button>
+          ))}
+        </div>
+        <div className="flex items-center gap-2">
+          <Input
+            type="number"
+            inputMode="decimal"
+            min={0}
+            placeholder="Custom amps"
+            value={customAmps}
+            disabled={disabled}
+            onChange={(event) => setCustomAmps(event.target.value)}
+            className="max-w-32"
+            aria-label="Custom shore input limit in amps"
+          />
+          <Button
+            size="sm"
+            disabled={disabled || !customValid}
+            onClick={() => mutation.mutate(customValue)}
+          >
+            Apply
+          </Button>
+        </div>
+        {!limitAdjustable && (
+          <p className="text-xs text-muted-foreground">
+            The Cerbo reports the input limit as not adjustable.
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+export default function PowerPage() {
+  const { data: victronStatus } = useVictronStatus()
+  const { data: entityCollection } = useEntities({ page_size: 100 })
+
+  const entities = entityCollection?.entities ?? []
+  const inverter = entities.find((entity) => entity.device_type === "inverter_charger")
+
+  // Victron commands travel over the Cerbo's MQTT link (IP), independent of
+  // the RV-C CAN bus — so gate on that link, not on coach CAN liveness.
+  const controlsDisabled = victronStatus?.connected !== true
+
+  return (
+    <div className="flex-1 space-y-6 p-4 pt-6 lg:px-6">
+      <VictronStatusChip />
+
+      <PowerSection entities={entities} showTitle={false} />
+
+      <div className="space-y-3">
+        <h2 className="text-sm font-medium text-muted-foreground">Controls</h2>
+        {controlsDisabled && (
+          <p className="text-sm text-muted-foreground">
+            Controls are disabled — the Cerbo GX is not reachable.
+          </p>
+        )}
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <InverterModeCard inverter={inverter} controlsDisabled={controlsDisabled} />
+          <ShoreLimitCard inverter={inverter} controlsDisabled={controlsDisabled} />
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Adds a **Power** page to the owner nav — the control surface for the Victron system on top of the telemetry shipped in #201.

### Features
- **Telemetry**: reuses the four PowerSection cards (`showTitle` prop added; the home-page Power section header now links here).
- **Cerbo GX connection chip** from `/api/victron/status`. Controls gate on the **Cerbo MQTT link**, not CAN liveness — Victron commands travel over IP, so a quiet RV-C bus must not lock them out.
- **Inverter/charger mode** (on / charger only / inverter only / off): every change goes through a confirmation dialog that states the consequence in plain language (e.g. Off ⇒ "coach AC output shuts down and the batteries stop charging"). Current mode is highlighted and non-clickable; buttons disable when the Cerbo reports the mode as not adjustable.
- **Shore input limit**: preset chips (15/20/30/50 A) + custom-amps input with Apply. Server-side validation against the Cerbo-reported adjustable range; failures surface as destructive toasts.
- Both endpoints are admin-gated on the backend (unchanged from #200).

### Verification (live against cerbo.holtel.io)
- Cards streamed real-time data during testing — watched solar ramp 4 W → 763 W and the battery card flip Idle → **Charging 860 W**.
- Mode dialog opens and cancels without sending anything.
- Same-value shore-limit apply (45 A → 45 A) round-tripped: UI → `POST /api/victron/inverter/input-current-limit` → 200 → MQTT write confirmed in the backend log.
- `tsc -b` clean, eslint clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)