### PR TITLE
feat(climate): AC compressor load-shed on Front/Mid zone cards

### DIFF
--- a/backend/services/can/can_bus_service.py
+++ b/backend/services/can/can_bus_service.py
@@ -1374,6 +1374,11 @@ class CANBusService(GuardrailParticipant):
             if device_type == "climate":
                 merged_raw.update(climate_units.derive_climate_fields(merged_raw))
                 payload["state"] = climate_units.climate_state_label(merged_raw)
+                # Zones whose compressor is an energy-managed AC load also
+                # carry AC_LOAD_STATUS (operating_status) — surface shed.
+                if "operating_status" in merged_raw:
+                    _label, shed = climate_units.ac_load_state(merged_raw)
+                    merged_raw["shed"] = shed
             elif device_type == "air_conditioner":
                 merged_raw.update(climate_units.derive_ac_fields(merged_raw))
                 payload["state"] = climate_units.ac_state_label(merged_raw)

--- a/config/2021_Entegra_Aspire_44R.yml
+++ b/config/2021_Entegra_Aspire_44R.yml
@@ -337,25 +337,35 @@ entities:
   # namespace: 0=Front air, 1=Rear air, 2=Bay, 3=disconnected (-88C),
   # 4=Floor, 5=Mid air. Verified against the Mira display and a warm-the-
   # sensor test. This is exactly why sources are declared per-DGN here.
+  #
+  # AC compressor load-shed: Front and Mid zones' compressors are
+  # energy-managed AC loads (AC_LOAD_STATUS 1FFBF) — D5 (213) = Front's
+  # inst1, D0 (208) = Mid's inst2, mapped live 2026-07-05 by disabling each
+  # zone and watching which unit + load dropped. Sourcing 1FFBF here lets
+  # the zone show "Shed" (operating_status 0xFD) like the Mira. Rear's
+  # compressor (inst3) is NOT load-managed — it never appears as a managed
+  # load (bedroom AC, always demanding), so no 1FFBF source.
 
   climate_front:
     name: "Front Zone"
     type: climate
     area: interior.living_main
-    capabilities: [temperature, setpoint, operating_mode, fan]
+    capabilities: [temperature, setpoint, operating_mode, fan, shed]
     sources:
       - { dgn: 1FFE2, instance: 0 }
       - { dgn: 1FF9C, instance: 0 }
+      - { dgn: 1FFBF, instance: 213 } # AC load D5 = Front compressor (shed)
     command: { dgn: 1FEF9, instances: [0] }
 
   climate_mid:
     name: "Mid Zone"
     type: climate
     area: interior.living_main
-    capabilities: [temperature, setpoint, operating_mode, fan]
+    capabilities: [temperature, setpoint, operating_mode, fan, shed]
     sources:
       - { dgn: 1FFE2, instance: 1 }
       - { dgn: 1FF9C, instance: 5 } # sensor channel 5, NOT zone 1
+      - { dgn: 1FFBF, instance: 208 } # AC load D0 = Mid compressor (shed)
     command: { dgn: 1FEF9, instances: [1] }
 
   climate_rear:

--- a/docs/can-re-findings.md
+++ b/docs/can-re-findings.md
@@ -203,10 +203,26 @@ requested state on the toggle plus a "Shed" badge when byte 2 is a shed
 sentinel, exactly like the Mira.
 
 Modeled as a reusable **`ac_load`** device type (control `1FFBE`, status
-`1FFBF` → on/off/shed). The rooftop AC compressors can also be shed (they
-outrank the Aqua-Hot); their shed field is not yet captured because they're
-the high-priority loads *causing* the shedding — a fast-follow when a
-compressor-shed is inducible.
+`1FFBF` → on/off/shed).
+
+**The rooftop AC compressors shed the same way** (2026-07-05). Under forced
+demand (all zones commanded to 60 °F + Aqua-Hot loaded) the Front and Mid
+compressors appear as AC loads and one was caught at `FD`. Mapped by
+disabling each zone and watching which AC unit + load dropped (turning a load
+off is immediate; forcing one ON hits the compressors' ~3 min anti-short-cycle
+lockout, so only the disable direction is reliable):
+
+- **Front (zone 0) = AC unit inst1 (SA98) = load `D5` (213)**
+- **Mid (zone 1) = AC unit inst2 (SA97) = load `D0` (208)**
+- **Rear (zone 2) = AC unit inst3 (SA96) = NOT load-managed** — never appears
+  as a managed AC load across any capture (bedroom, ambient ~97 °F, always
+  demanding, never a shed candidate).
+
+The Front/Mid climate zones source `1FFBF` D5/D0 so the zone card shows "Shed"
+(status `0xFD`) exactly like the Mira. Zone → unit mapping is via the AC
+*load*, not a fixed zone↔unit binding; the manager pools compressors, so map
+by the disable test, not by assuming zone N = unit N. (Front & Rear have heat
+pumps, Mid does not — per the owner.)
 
 ## Guardrail
 

--- a/frontend/src/pages/climate.tsx
+++ b/frontend/src/pages/climate.tsx
@@ -364,11 +364,15 @@ function ZoneCardHeader({
         </CardTitle>
         <p className="text-xs text-muted-foreground">Updated {relativeTime(entity.last_updated)}</p>
       </div>
-      <div className="text-right">
+      <div className="flex flex-col items-end">
         <p className="text-3xl font-semibold tabular-nums">{formatTempF(currentF)}</p>
-        <p className="text-xs text-muted-foreground">
-          {currentF === null ? "no sensor data" : subtitle}
-        </p>
+        {isShed(entity) ? (
+          <ShedBadge />
+        ) : (
+          <p className="text-xs text-muted-foreground">
+            {currentF === null ? "no sensor data" : subtitle}
+          </p>
+        )}
       </div>
     </CardHeader>
   )


### PR DESCRIPTION
## Summary

Extends the generalized shed indicator from the Aqua-Hot to the **rooftop AC compressors** — the thermostat-zone shed you wanted, mirroring the Mira.

Confirmed live (2026-07-05) that the AC compressors shed via the **exact same `AC_LOAD` `FD` mechanism** as the Aqua-Hot (caught the Front compressor at `FD` under forced demand). Mapped zone → load by **disabling each zone** and watching which AC unit + load dropped:

| Zone | AC unit | Compressor load |
|---|---|---|
| Front (0) | inst1 (SA98) | `D5` (213) |
| Mid (1) | inst2 (SA97) | `D0` (208) |
| Rear (2) | inst3 (SA96) | **not load-managed** — never a shed candidate (bedroom, ambient ~97°F, always demanding) |

Key method note: turning a load *off* is immediate, but forcing one *on* hits the compressors' ~3-minute anti-short-cycle lockout — so only the **disable** direction gives clean mapping. The compressor↔zone binding is via the AC load (the manager pools compressors), not a fixed zone=unit assumption.

## Changes

- Front/Mid climate zones source `AC_LOAD_STATUS` (`1FFBF` D5/D0) in addition to their thermostat/ambient DGNs. The RX shaping sets `shed` on the zone when its compressor load reports `0xFD`; the zone card shows the shared `ShedBadge`. Command still targets the thermostat instance (setpoint/mode) — unchanged.
- Rear left without a shed source (its compressor isn't load-managed).
- docs: the compressor shed mapping + the lockout-timer gotcha.

## Test plan

- [x] Config loads (45 entities, no dup-source conflict); Front←D5 / Mid←D0 joined while commands stay on the thermostat instance
- [x] Shed derivation from a climate zone's AC-load `operating_status`; climate + ac_load + rvc suites pass; frontend build + eslint + tsc clean
- [ ] After deploy: Front/Mid zone cards show "Shed" when their compressor is deferred under load

🤖 Generated with [Claude Code](https://claude.com/claude-code)