### PR TITLE
feat(victron): pull generator, DC loads, RuuviTag sensors, and GPS from the Cerbo

### DIFF
--- a/backend/integrations/victron/catalog.py
+++ b/backend/integrations/victron/catalog.py
@@ -97,6 +97,51 @@ def _system_state(values: dict[str, Any]) -> str:
     return SYSTEM_STATE_NAMES.get(code, f"state_{code}")
 
 
+# dbus-generator /State.
+GENERATOR_STATE_NAMES: dict[int, str] = {
+    0: "stopped",
+    1: "running",
+    2: "warm_up",
+    3: "cool_down",
+    10: "error",
+}
+
+
+def _generator_state(values: dict[str, Any]) -> str:
+    code = values.get("generator_state")
+    if not isinstance(code, int):
+        return "unknown"
+    return GENERATOR_STATE_NAMES.get(code, f"state_{code}")
+
+
+def _dc_system_state(values: dict[str, Any]) -> str:
+    power = values.get("power")
+    if not isinstance(power, int | float):
+        return "unknown"
+    return "active" if abs(power) > 1 else "idle"
+
+
+def _temperature_state(values: dict[str, Any]) -> str:
+    if values.get("low_battery") == 1:
+        return "low_battery"
+    return "ok" if isinstance(values.get("temperature"), int | float) else "unknown"
+
+
+def _temperature_extras(values: dict[str, Any]) -> dict[str, Any]:
+    """Convert Venus °C to the `current_temp_f` field the climate UI reads."""
+    celsius = values.get("temperature")
+    if not isinstance(celsius, int | float):
+        return {}
+    return {"current_temp_f": round(celsius * 9 / 5 + 32, 1)}
+
+
+def _gps_state(values: dict[str, Any]) -> str:
+    fix = values.get("fix")
+    if not isinstance(fix, int):
+        return "unknown"
+    return "fix" if fix == 1 else "no_fix"
+
+
 @dataclass(frozen=True)
 class VictronEntityDef:
     """Maps one Venus OS service type onto a CoachIQ entity."""
@@ -111,6 +156,8 @@ class VictronEntityDef:
     suggested_area: str = "electrical"
     # Derives the human-readable entity state string from the signal dict.
     state_fn: Callable[[dict[str, Any]], str] = _system_state
+    # Optional extra derived signals (e.g. unit conversions) merged in at flush.
+    derive_fn: Callable[[dict[str, Any]], dict[str, Any]] | None = None
 
 
 VICTRON_ENTITY_DEFS: tuple[VictronEntityDef, ...] = (
@@ -188,6 +235,68 @@ VICTRON_ENTITY_DEFS: tuple[VictronEntityDef, ...] = (
             "Dc/0/Current": "battery_current",
             "Yield/User": "yield_total_kwh",
             "History/Daily/0/Yield": "yield_today_kwh",
+        },
+    ),
+    VictronEntityDef(
+        key="victron_generator",
+        service_type="generator",
+        device_type="generator",
+        friendly_name="Generator",
+        state_fn=_generator_state,
+        paths={
+            "State": "generator_state",
+            "Error": "error_code",
+            "Runtime": "runtime_seconds",
+            "TodayRuntime": "runtime_today_seconds",
+            "AccumulatedRuntime": "runtime_total_seconds",
+            "ManualStart": "manual_start",
+            "AutoStartEnabled": "autostart_enabled",
+            "RunningByCondition": "running_by_condition",
+            "QuietHours": "quiet_hours",
+        },
+    ),
+    VictronEntityDef(
+        key="victron_dc_loads",
+        service_type="dcsystem",
+        device_type="dc_system",
+        friendly_name="DC Loads",
+        state_fn=_dc_system_state,
+        paths={
+            "Dc/0/Power": "power",
+            "Dc/0/Voltage": "voltage",
+            "Dc/0/Current": "current",
+            "ProductName": "product_name",
+        },
+    ),
+    VictronEntityDef(
+        key="victron_temperature",
+        service_type="temperature",
+        device_type="temperature",
+        friendly_name="Temperature Sensor",
+        state_fn=_temperature_state,
+        derive_fn=_temperature_extras,
+        paths={
+            "Temperature": "temperature",
+            "Humidity": "humidity",
+            "CustomName": "custom_name",
+            "BatteryVoltage": "sensor_battery_voltage",
+            "Alarms/LowBattery": "low_battery",
+        },
+    ),
+    VictronEntityDef(
+        key="victron_gps",
+        service_type="gps",
+        device_type="gps",
+        friendly_name="GPS",
+        state_fn=_gps_state,
+        paths={
+            "Fix": "fix",
+            "Position/Latitude": "latitude",
+            "Position/Longitude": "longitude",
+            "Speed": "speed_mps",
+            "Course": "course_deg",
+            "Altitude": "altitude_m",
+            "NrOfSatellites": "satellites",
         },
     ),
     VictronEntityDef(

--- a/backend/services/victron/victron_service.py
+++ b/backend/services/victron/victron_service.py
@@ -200,6 +200,8 @@ class VictronService:
         pending.clear()
 
         entity_def = self._def_for_entity(entity_id)
+        if entity_def and entity_def.derive_fn:
+            merged.update(entity_def.derive_fn(merged))
         state_label = entity_def.state_fn(merged) if entity_def else "unknown"
         # MQTT values arrive already decoded, so raw mirrors value; the v2
         # entities API surfaces `raw` as the state dict, and the frontend
@@ -212,6 +214,11 @@ class VictronService:
             "raw": signals,
             "state": state_label,
         }
+        # Devices that carry a user-assigned name on the bus (e.g. RuuviTag
+        # CustomName) override the generic catalog friendly name.
+        custom_name = merged.get("custom_name")
+        if isinstance(custom_name, str) and custom_name.strip():
+            payload["friendly_name"] = custom_name.strip()
         updated_entity = entity_manager.update_entity_state(entity_id, payload)
         if updated_entity is None:
             return

--- a/frontend/src/components/power-section.tsx
+++ b/frontend/src/components/power-section.tsx
@@ -12,8 +12,10 @@ import {
   IconBattery,
   IconBolt,
   IconChevronRight,
+  IconEngine,
   IconPlugConnected,
   IconSun,
+  IconTopologyStar3,
 } from "@tabler/icons-react"
 import { Link } from "react-router-dom"
 
@@ -171,11 +173,45 @@ function SolarCard({ entity }: Readonly<{ entity: EntitySchema }>) {
   )
 }
 
+function fmtRuntimeHours(seconds: number | null): string {
+  if (seconds === null) return "—"
+  return `${(seconds / 3600).toFixed(1)} h`
+}
+
+function GeneratorCard({ entity }: Readonly<{ entity: EntitySchema }>) {
+  const state = entity.state ?? {}
+  return (
+    <PowerCard entity={entity} icon={IconEngine}>
+      <StatRow
+        label="Autostart"
+        value={num(state.autostart_enabled) === 1 ? "Enabled" : "Disabled"}
+      />
+      <StatRow label="Run today" value={fmtRuntimeHours(num(state.runtime_today_seconds))} />
+      <StatRow label="Total runtime" value={fmtRuntimeHours(num(state.runtime_total_seconds))} />
+    </PowerCard>
+  )
+}
+
+function DcLoadsCard({ entity }: Readonly<{ entity: EntitySchema }>) {
+  const state = entity.state ?? {}
+  return (
+    <PowerCard entity={entity} icon={IconTopologyStar3}>
+      <div className="mb-2">
+        <p className="text-2xl font-semibold tabular-nums">{fmtWatts(num(state.power))}</p>
+      </div>
+      <StatRow label="Voltage" value={fmtNumber(num(state.voltage), "V")} />
+      <StatRow label="Current" value={fmtNumber(num(state.current), "A")} />
+    </PowerCard>
+  )
+}
+
 const CARD_ORDER: Record<string, number> = {
   power_system: 0,
   inverter_charger: 1,
   battery: 2,
   solar_controller: 3,
+  dc_system: 4,
+  generator: 5,
 }
 
 function cardFor(entity: EntitySchema) {
@@ -188,6 +224,10 @@ function cardFor(entity: EntitySchema) {
       return <BatteryCard key={entity.entity_id} entity={entity} />
     case "solar_controller":
       return <SolarCard key={entity.entity_id} entity={entity} />
+    case "generator":
+      return <GeneratorCard key={entity.entity_id} entity={entity} />
+    case "dc_system":
+      return <DcLoadsCard key={entity.entity_id} entity={entity} />
     default:
       return null
   }
@@ -216,7 +256,7 @@ export function PowerSection({
           <IconChevronRight className="size-4 transition-transform group-hover:translate-x-0.5" aria-hidden />
         </Link>
       )}
-      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
         {powerEntities.map(cardFor)}
       </div>
     </div>

--- a/frontend/src/lib/power.ts
+++ b/frontend/src/lib/power.ts
@@ -8,4 +8,6 @@ export const POWER_DEVICE_TYPES = new Set([
   "battery",
   "solar_controller",
   "power_system",
+  "generator",
+  "dc_system",
 ])

--- a/frontend/src/pages/home.tsx
+++ b/frontend/src/pages/home.tsx
@@ -603,10 +603,13 @@ export default function HomePage() {
   const { data: entityCollection, isLoading, error } = useEntities({ page_size: 100 })
 
   const entities = entityCollection?.entities ?? []
-  // Power entities get their own read-only section; keeping them out of the
-  // zone grid also keeps them away from DeviceRow's toggle switch.
+  // Victron entities are telemetry, never switches: power devices get their
+  // own section, and the rest (temperature sensors, GPS) live on their own
+  // pages — none of them belong in the zone grid, whose DeviceRow renders a
+  // toggle switch for every row.
   const zoneEntities = entities.filter(
-    (entity) => !POWER_DEVICE_TYPES.has(entity.device_type)
+    (entity) =>
+      entity.protocol !== "victron" && !POWER_DEVICE_TYPES.has(entity.device_type)
   )
   const zones = groupEntitiesByZone(zoneEntities, config)
 

--- a/tests/integrations/victron/test_victron_catalog.py
+++ b/tests/integrations/victron/test_victron_catalog.py
@@ -4,8 +4,13 @@ from backend.integrations.victron.catalog import (
     DEFS_BY_SERVICE_TYPE,
     VICTRON_ENTITY_DEFS,
     _battery_state,
+    _dc_system_state,
+    _generator_state,
+    _gps_state,
     _solar_state,
     _system_state,
+    _temperature_extras,
+    _temperature_state,
     _vebus_state,
 )
 
@@ -20,7 +25,16 @@ class TestCatalogIntegrity:
         assert len(service_types) == len(set(service_types))
 
     def test_expected_services_covered(self):
-        assert set(DEFS_BY_SERVICE_TYPE) == {"vebus", "battery", "solarcharger", "system"}
+        assert set(DEFS_BY_SERVICE_TYPE) == {
+            "vebus",
+            "battery",
+            "solarcharger",
+            "system",
+            "generator",
+            "dcsystem",
+            "temperature",
+            "gps",
+        }
 
     def test_signal_names_unique_within_entity(self):
         for entity_def in VICTRON_ENTITY_DEFS:
@@ -52,3 +66,29 @@ class TestStateDerivation:
     def test_system_state_extends_vebus_enum(self):
         assert _system_state({"system_state": 256}) == "discharging"
         assert _system_state({"system_state": 9}) == "inverting"
+
+    def test_generator_state(self):
+        assert _generator_state({"generator_state": 0}) == "stopped"
+        assert _generator_state({"generator_state": 1}) == "running"
+        assert _generator_state({"generator_state": 10}) == "error"
+        assert _generator_state({}) == "unknown"
+
+    def test_dc_system_state_from_power_draw(self):
+        assert _dc_system_state({"power": 163.9}) == "active"
+        assert _dc_system_state({"power": 0.5}) == "idle"
+        assert _dc_system_state({}) == "unknown"
+
+    def test_temperature_state_and_low_battery(self):
+        assert _temperature_state({"temperature": 30.2}) == "ok"
+        assert _temperature_state({"temperature": 30.2, "low_battery": 1}) == "low_battery"
+        assert _temperature_state({}) == "unknown"
+
+    def test_temperature_derives_fahrenheit(self):
+        assert _temperature_extras({"temperature": 30.0}) == {"current_temp_f": 86.0}
+        assert _temperature_extras({"temperature": None}) == {}
+        assert _temperature_extras({}) == {}
+
+    def test_gps_state(self):
+        assert _gps_state({"fix": 1}) == "fix"
+        assert _gps_state({"fix": 0}) == "no_fix"
+        assert _gps_state({}) == "unknown"

--- a/tests/services/test_victron_service.py
+++ b/tests/services/test_victron_service.py
@@ -145,10 +145,10 @@ class TestUpdateFlow:
         await service._handle_update(
             VictronUpdate(
                 portal_id=PORTAL,
-                service_type="temperature",
-                instance="21",
-                path="Temperature",
-                value=20.5,
+                service_type="ble",
+                instance="0",
+                path="State",
+                value=1,
             )
         )
         assert service._pending == {}
@@ -173,6 +173,33 @@ class TestUpdateFlow:
         assert (
             entity_manager_service.get_entity_manager().get_entity("victron_solar_280") is not None
         )
+
+    async def test_temperature_sensor_derives_fahrenheit_and_custom_name(self):
+        service, entity_manager_service, _, _ = make_service()
+        for path, value in (
+            ("Temperature", 30.0),
+            ("Humidity", 81.65),
+            ("CustomName", "Outside"),
+        ):
+            await service._handle_update(
+                VictronUpdate(
+                    portal_id=PORTAL,
+                    service_type="temperature",
+                    instance="21",
+                    path=path,
+                    value=value,
+                )
+            )
+        await service._flush_entity("victron_temperature")
+
+        entity = entity_manager_service.get_entity_manager().get_entity("victron_temperature")
+        assert entity is not None
+        state = entity.get_state()
+        # Climate page reads current_temp_f; RuuviTag custom name becomes the label.
+        assert state.value["current_temp_f"] == 86.0
+        assert state.value["humidity"] == 81.65
+        assert state.friendly_name == "Outside"
+        assert state.state == "ok"
 
     async def test_battery_state_derivation(self):
         service, entity_manager_service, _, _ = make_service()


### PR DESCRIPTION
## Summary

Closes the gap between CoachIQ and the VRM dashboard — the four Venus OS services we weren't consuming yet.

### New data
| Service | Entity | Where it shows |
|---|---|---|
| `generator/0` | `victron_generator` | New **Generator** power card: state badge, autostart, run today, total runtime |
| `dcsystem/277` (SmartShunt) | `victron_dc_loads` | New **DC Loads** power card: watts headline, V/A |
| `temperature/21-23` (RuuviTags) | `victron_temperature[_*]` | Climate page **Sensors** row — automatically, with °F conversion and the RuuviTag custom names (Bedroom / Outside / Living Room) as entity names |
| `gps/0` | `victron_gps` | API/devices only (fix, lat/lon, speed, course, altitude, satellites) |

### Mechanics
- Catalog gains an optional `derive_fn` per entity (used for °C → `current_temp_f`, the field the climate UI reads).
- Devices carrying a user-assigned `CustomName` on the bus override the generic catalog friendly name at flush time.
- Home zone grid now excludes **all** `protocol: victron` entities (not just power device types) — the new sensor entities can never fall into DeviceRow's toggle-switch rendering.
- Power grid moves to 3 columns for the 6 cards.

### Verification (live against cerbo.holtel.io)
- All **10 devices bind** (vebus, battery, solar, system, generator, dcsystem, 3× RuuviTag, GPS).
- Generator card matches VRM exactly (332.2 h accumulated runtime); DC Loads 170 W tracks VRM's DC Power card.
- RuuviTags render on the climate Sensors row with custom names and Fahrenheit.
- Home page's only switch is the actual light entity.
- 39 backend tests pass (new: generator/dc/temperature/gps state fns, °F derive, custom-name flow); tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)