### PR TITLE
feat(climate): label main-zone heat as Heat Pump; document heat-source model

### DIFF
--- a/docs/can-re-findings.md
+++ b/docs/can-re-findings.md
@@ -103,6 +103,26 @@ stepped these instances in order):
 - 5 = **Bay**, 6 = **Floor** — identified live 2026-07-05: the Mira's Bay
   setpoint button stepped zone 5, the Floor button stepped zone 6.
 
+**Heat modes (mapped live 2026-07-05 by cycling the Mira mode buttons):**
+`operating_mode` (low nibble of byte 1): 0=off, 1=cool, **2=heat (drives the
+rooftop HEAT PUMP on the main zones)**, 3=auto (a *setting* — the status
+reports the resolved mode, so a heating zone still shows 2). fan_mode nibble:
+0=auto, 1=on.
+
+The coach has two independent heat sources per zone, and they can run
+together:
+- **Heat Pump** = the main zone's own instance in mode 2. All three main
+  zones (Front/Mid/Rear) have a heat pump.
+- **Aqua-Hot heat** = the counterpart zone in mode 2 — **inst 3 = Front,
+  inst 4 = Rear** (Mid has no Aqua-Hot), plus inst 5 = Bay, 6 = Floor. These
+  are the `climate_*_heat` entities. Pressing "Aqua-Hot" for Front lit inst 3
+  while Front's own inst 0 stayed in heat-pump mode 2 — confirming they're
+  separate, stackable sources.
+
+So heat-pump control needs no new code (the "heat" command already sends
+mode 2, the exact frame the Mira emits), and Aqua-Hot heat is the existing
+counterpart-zone cards.
+
 **`1FF9C` ambient instances are SENSOR CHANNELS, not zone instances** —
 discovered when the UI showed the rear temperature on the Mid card
 (2026-07-05). Verified against the Mira display plus a thumb-on-sensor test

--- a/frontend/src/pages/climate.tsx
+++ b/frontend/src/pages/climate.tsx
@@ -55,10 +55,13 @@ const MODE_LABELS = new Map<number, string>([
   [4, "fan_only"],
   [5, "aux_heat"],
 ])
+// operating_mode 2 ("heat") drives the rooftop heat pump on this coach — all
+// three zones have one (verified 2026-07-05). Aqua-Hot heat is a separate
+// heat source on the counterpart zones (climate_front_heat / _rear_heat).
 const MODE_DISPLAY = new Map<string, string>([
   ["off", "Off"],
   ["cool", "Cool"],
-  ["heat", "Heat"],
+  ["heat", "Heat Pump"],
   ["auto", "Auto"],
   ["fan_only", "Fan Only"],
   ["aux_heat", "Aux Heat"],


### PR DESCRIPTION
## Summary

Completes the heating side of the climate work by mapping the Mira's heat modes on the wire (2026-07-05) and applying the one label fix that follows.

Cycling the Mira mode buttons and watching `THERMOSTAT_STATUS_1.operating_mode`:

| value | meaning |
|---|---|
| 0 | off |
| 1 | cool |
| 2 | **heat — drives the rooftop HEAT PUMP** on the main zones |
| 3 | auto (a *setting*; status reports the resolved mode, so a heating zone still reads 2) |

The coach has **two independent, stackable heat sources per zone**:
- **Heat Pump** = the main zone's own instance in `mode 2` (all three main zones have one)
- **Aqua-Hot heat** = the counterpart zone in `mode 2` — inst 3 = Front, inst 4 = Rear (Mid has none), plus 5 = Bay, 6 = Floor. These are the existing `climate_*_heat` entities / "Aqua-Hot Heat" cards. Pressing "Aqua-Hot" on Front lit inst 3 while Front's own inst 0 stayed in heat-pump `mode 2` — proving they're separate and can run together.

**So heating needs essentially no new code:** the "heat" command already sends `mode 2` — the exact frame the Mira emits — so heat-pump control works with the proven mechanism, and Aqua-Hot heat is the counterpart-zone cards already on the page. The only gap was cosmetic: the main-zone selector said generic "Heat" where this coach specifically means "Heat Pump."

## Changes

- Main-zone mode selector shows **"Heat Pump"** for `mode 2` (with a comment explaining why).
- docs: the full heat-mode enum + two-heat-source model.

## Test plan

- [x] eslint + production build clean
- [ ] After deploy: Front/Mid/Rear mode selector reads "Heat Pump"; selecting it commands `mode 2` (same verified path as cool); Aqua-Hot Heat cards drive the counterpart zones

🤖 Generated with [Claude Code](https://claude.com/claude-code)