### PR TITLE
fix(auth): refresh tokens before use and gate the WebSocket on auth

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -12,6 +12,8 @@
  * Production: Uses relative paths assuming reverse proxy configuration
  */
 
+import { tokenStorage } from '@/lib/token-storage';
+
 import type { APIError } from './types';
 
 /**
@@ -71,8 +73,32 @@ export const WS_BASE = (() => {
  * Gets authorization header with JWT token
  */
 function getAuthHeader(): Record<string, string> {
-  const token = localStorage.getItem('auth_token');
+  const token = tokenStorage.getAccessToken();
   return token ? { 'Authorization': `Bearer ${token}` } : {};
+}
+
+/**
+ * Refresh a soon-to-expire (or already expired) access token *before* a
+ * request goes out.
+ *
+ * The only other refresh trigger is a `setTimeout` scheduled at login
+ * (token-storage.scheduleTokenRefresh). On a tablet/phone panel that timer is
+ * throttled or skipped while the tab is backgrounded or the device sleeps, so
+ * the access token silently expires and the next request carries a dead token
+ * → 401 → AuthGuard bounces the user to /login. Doing a request-time refresh
+ * closes that gap. Only refresh when we actually hold a valid refresh token;
+ * otherwise fall through and let the request proceed (auth-disabled coaches
+ * have no token data and must not block here).
+ */
+async function ensureFreshAccessToken(): Promise<void> {
+  if (!tokenStorage.needsRefresh()) return;
+  if (!tokenStorage.isRefreshTokenValid()) return;
+  try {
+    await tokenStorage.attemptTokenRefresh();
+  } catch {
+    // Refresh failure is handled by token-storage's callbacks; don't block the
+    // request — it will surface its own 401 if the token really is dead.
+  }
 }
 
 /** Common fetch options for all API requests */
@@ -148,6 +174,8 @@ export async function apiRequest<T>(
   options: RequestInit = {}
 ): Promise<T> {
   const fullUrl = url.startsWith('/') ? url : `${API_BASE}/${url}`;
+
+  await ensureFreshAccessToken();
 
   const response = await fetch(fullUrl, {
     ...defaultOptions,

--- a/frontend/src/api/websocket.ts
+++ b/frontend/src/api/websocket.ts
@@ -115,12 +115,34 @@ export class RVCWebSocketClient {
     }
 
     this.cleanup();
+    // Mark connecting synchronously so callers (e.g. the autoConnect effect,
+    // which checks `state !== 'connecting'`) don't fire a duplicate dial while
+    // the async token refresh below is in flight.
     this._state = 'connecting';
+    void this.openWithFreshToken();
+  }
 
-    // Get authentication token from token storage
+  /**
+   * Refresh a soon-to-expire access token, then open the socket. The token is
+   * passed as a query param, so a stale one gets the connection rejected on the
+   * first attempt — and the reconnect path only re-dials sockets that were
+   * previously connected, so a rejected first dial would otherwise sit down
+   * until a manual retry. Refreshing here (same gap the scheduled timer misses
+   * after a backgrounded tab) lets the auto-reconnect recover on its own.
+   */
+  private async openWithFreshToken(): Promise<void> {
+    try {
+      if (tokenStorage.needsRefresh() && tokenStorage.isRefreshTokenValid()) {
+        await tokenStorage.attemptTokenRefresh();
+      }
+    } catch {
+      // Dial with whatever token we have; the server will reject if it's dead.
+    }
+
+    // A disconnect() may have raced in while the refresh was awaiting.
+    if (this._state !== 'connecting') return;
+
     const token = tokenStorage.getAccessToken();
-
-    // Build WebSocket URL with token as query parameter
     const baseUrl = `${WS_BASE}${this.endpoint}`;
     const wsUrl = token ? `${baseUrl}?token=${encodeURIComponent(token)}` : baseUrl;
 

--- a/frontend/src/contexts/websocket-provider.tsx
+++ b/frontend/src/contexts/websocket-provider.tsx
@@ -5,6 +5,7 @@
  * Manages entity updates, system status, and other real-time data streams.
  */
 
+import { useAuth } from '@/contexts/auth-context';
 import { useWebSocketManager } from '@/hooks/useWebSocket';
 import React, { useEffect, useState, useMemo } from 'react';
 import { WebSocketContext, type ConnectionMetrics, type WebSocketContextType } from './websocket-context';
@@ -25,10 +26,19 @@ export function WebSocketProvider({
   enableSystemStatus = true,
   enableCANScan = false
 }: WebSocketProviderProps) {
+  // Don't dial the sockets until auth is settled. The token rides in the WS
+  // URL query param, so connecting before login (or before the user query
+  // confirms the session) sends a missing/stale token, the server rejects it,
+  // and — because the reconnect path only re-dials previously-connected
+  // sockets — it sits down until a manual retry. Auth-disabled coaches
+  // (mode "none") have no token and are ready as soon as status loads.
+  const { isAuthenticated, authStatus } = useAuth();
+  const authReady = authStatus?.mode === 'none' || isAuthenticated;
+
   const webSocketManager = useWebSocketManager({
-    enableEntityUpdates,
-    enableSystemStatus,
-    enableCANScan,
+    enableEntityUpdates: enableEntityUpdates && authReady,
+    enableSystemStatus: enableSystemStatus && authReady,
+    enableCANScan: enableCANScan && authReady,
   });
 
   const [metrics, setMetrics] = useState<ConnectionMetrics>({


### PR DESCRIPTION
## Summary
Fixes two long-standing papercuts on the coach panel that share one root cause: **requests (HTTP and WS) went out with whatever access token was in `localStorage`, never checking validity, and the only proactive refresh was a `setTimeout` scheduled at login** — which a backgrounded/slept tablet throttles or skips.

### Symptom 1 — page always loads disconnected, needs a manual "connect"
`WebSocketProvider` mounts **above** `AuthGuard` and auto-dials the entity/system sockets at boot, before auth settles. The token rides in the WS URL query param, so a missing/stale token gets the socket rejected — and the reconnect path only re-dials *previously-connected* sockets, so it stayed down until a manual retry.

### Symptom 2 — navigating to the climate page re-prompts for auth
A refetch (`refetchOnWindowFocus`/mount) fires `getCurrentUser` with an expired access token → **401** → `isAuthenticated` flips false → `AuthGuard` redirects to `/login`. Not truly climate-specific — climate is just the heaviest page (6 entity collections + the networks poll) and the one you keep returning to, so it's where an aged token gets exercised first.

## Changes
- **`api/client.ts`** — `ensureFreshAccessToken()` refreshes a soon-to-expire/expired access token before every request (single choke point `apiRequest`); read the token via `tokenStorage` instead of a raw `localStorage` key. A request-time refresh survives sleep where the timer doesn't.
- **`api/websocket.ts`** — refresh before dialing (`openWithFreshToken`) so an auto-reconnect after a slept tab doesn't dial with a dead token; `_state = 'connecting'` is still set synchronously so callers don't double-dial.
- **`contexts/websocket-provider.tsx`** — gate the socket auto-connect on auth readiness (`isAuthenticated`, or `mode === "none"` for auth-disabled coaches). It never dials pre-auth and connects on its own once the session is confirmed, removing the "boots disconnected" state.

## Notes / verification
- `tsc --noEmit`, ESLint (no new findings on changed lines), and a production `vite build` all pass.
- No dedicated unit tests exist for these modules; `useWebSocket.test.tsx` fails **identically (8/12) on `main` before this change** — pre-existing, untouched here.
- The new `client → token-storage → endpoints → client` import edge is call-time only (no top-level use); the bundler resolves it and the build is clean.
- Blast radius is the auth layer — live-verify after deploy that login still works and the climate page no longer re-prompts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)