### PR TITLE
fix(nix): update npmDepsHash for leaflet dependencies

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -139,7 +139,7 @@
     inherit version;
     src = frontendSrc;
 
-    npmDepsHash = "sha256-/m2Y2A/+BTJVnW/8Fs234DngHNejzBDDZP0FC6otdM4=";
+    npmDepsHash = "sha256-KKZwhEJlSnj9qpHS0/fu9gni+5uFqoqdnc8sA3jq6lw=";
 
     # Handle React 19 peer dependency conflicts
     npmFlags = [ "--legacy-peer-deps" ];


### PR DESCRIPTION
PR #207 added leaflet/react-leaflet/@types/leaflet to `package-lock.json` but missed the frontend derivation's `npmDepsHash` — the nix build fails with a hash mismatch, blocking nixpi deploys. Hash recomputed with `prefetch-npm-deps`.

One-line build fix; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)