### PR TITLE
fix(can): emit real 29-bit arbitration ids from CAN simulation

### DIFF
--- a/backend/services/can/can_bus_service.py
+++ b/backend/services/can/can_bus_service.py
@@ -1451,8 +1451,11 @@ class CANBusService(GuardrailParticipant):
         # Counter for cycling through different message types
         counter = 0
 
-        # Get a list of available decoders for more realistic simulation
-        available_decoders = list(self.decoder_map.keys()) if self.decoder_map else []
+        # Get a list of available decoders for more realistic simulation.
+        # Must use the wire-captured 29-bit ids: decoder_map (dgn_dict) keys
+        # are (priority << 18) | pgn, so a frame built from one never survives
+        # the RX path's (id >> 8) & 0x3FFFF PGN extraction.
+        available_decoders = list(self.decoder_frame_id_map.keys())
 
         while self._running:
             try:
@@ -1462,7 +1465,7 @@ class CANBusService(GuardrailParticipant):
                 if available_decoders:
                     # Use real decoder entries
                     decoder_key = available_decoders[counter % len(available_decoders)]
-                    entry = self.decoder_map[decoder_key]
+                    entry = self.decoder_frame_id_map[decoder_key]
 
                     arbitration_id = decoder_key
                     entry_length = entry.get("length", 8)
@@ -1506,27 +1509,28 @@ class CANBusService(GuardrailParticipant):
                     )
 
                 else:
-                    # Fallback to hardcoded simulation messages
+                    # Fallback to hardcoded simulation messages: full 29-bit
+                    # ids (priority 6, source 0x80), not bare PGNs.
                     msg_type = counter % 4
 
                     if msg_type == 0:
-                        # Simulate a temperature message (DGN 1FEA5 / 130725)
-                        arbitration_id = 0x1FEA5
+                        # Simulate a temperature message (PGN 1FEA5 / 130725)
+                        arbitration_id = 0x19FEA580
                         # Temperature of 72.5°F (22.5°C)
                         data = bytes([0x02, 0x01, 0x00, 0x00, 0xE1, 0x01, 0x00, 0xFF])
                     elif msg_type == 1:
-                        # Simulate a battery state message (DGN 1FFFD / 131069)
-                        arbitration_id = 0x1FFFD
+                        # Simulate a battery state message (PGN 1FFFD / 131069)
+                        arbitration_id = 0x19FFFD80
                         # Battery at 80% charge
                         data = bytes([0x01, 0x50, 0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF])
                     elif msg_type == LIGHT_STATUS_SIMULATION_TYPE:
-                        # Simulate a light status message (DGN 1FEED / 130797)
-                        arbitration_id = 0x1FEED
+                        # Simulate a light status message (PGN 1FEED / 130797)
+                        arbitration_id = 0x19FEED80
                         # Light is on
                         data = bytes([0x01, 0x01, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF])
                     else:
-                        # Simulate a tank level message (DGN 1FF9D / 130973)
-                        arbitration_id = 0x1FF9D
+                        # Simulate a tank level message (PGN 1FF9D / 130973)
+                        arbitration_id = 0x19FF9D80
                         # Tank at 65% capacity
                         data = bytes([0x01, 0x41, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF])
 

--- a/tests/services/test_can_rx_pipeline_wiring.py
+++ b/tests/services/test_can_rx_pipeline_wiring.py
@@ -12,10 +12,12 @@ Covers the root-cause fixes for live-data gaps in the RX pipeline:
   29-bit arbitration id (``frame_id_dict``), not ``dgn_dict`` whose keys are
   ``(priority << 18) | pgn`` with an assumed priority 6 and therefore can
   never equal a real arbitration id.
+- Simulation frame ids: ``_simulate_can_messages`` must emit wire-captured
+  29-bit ids so simulated frames round-trip through the RX decode path.
 """
 
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -192,6 +194,44 @@ class TestFrameIdDictWiring:
         assert len(rvc_config.frame_id_dict) >= len(rvc_config.dgn_dict)
         for entry in rvc_config.dgn_dict.values():
             assert rvc_config.frame_id_dict[entry["id"]] == entry
+
+
+class TestSimulationFrameIds:
+    """Simulated frames must carry ids the RX decode path can round-trip."""
+
+    ATS_ARBITRATION_ID = 0x0DFFAD4F
+    ATS_PGN = 0x1FFAD
+
+    @pytest.mark.asyncio
+    async def test_simulated_frame_id_decodes_back_to_entry_pgn(self):
+        service = _make_service(None)
+        entry = {"name": "ATS_AC_STATUS_1", "pgn": "0x1FFAD", "length": 8}
+        # Both maps populated: simulation must pick the wire id, not the
+        # synthesized (priority << 18) | pgn dgn_dict key.
+        service.decoder_frame_id_map = {self.ATS_ARBITRATION_ID: entry}
+        service.decoder_map = {(6 << 18) | self.ATS_PGN: entry}
+        service._running = True
+
+        simulated: list[dict] = []
+
+        async def capture(msg: dict) -> None:
+            simulated.append(msg)
+            service._running = False
+
+        service._process_message = capture
+
+        with patch("backend.services.can.can_bus_service.asyncio.sleep", new=AsyncMock()):
+            await service._simulate_can_messages()
+
+        [msg] = simulated
+        arbitration_id = msg["arbitration_id"]
+        assert arbitration_id == self.ATS_ARBITRATION_ID
+
+        # The RX path's PGN extraction must recover the entry's PGN, and the
+        # decoder lookup must land back on the same entry.
+        pgn = (arbitration_id >> 8) & 0x3FFFF
+        assert pgn == int(entry["pgn"], 16)
+        assert service._get_decoder_entry(arbitration_id, pgn) is entry
 
 
 class TestDiagnosticsRepositoryUpserts:


### PR DESCRIPTION
## Summary
- `_simulate_can_messages()` used `dgn_dict` keys (`(priority << 18) | pgn`, e.g. `0x19FEDA`) as CAN arbitration ids, so simulated frames never round-tripped through the RX path's `(id >> 8) & 0x3FFFF` PGN extraction. It now iterates the wire-captured 29-bit `decoder_frame_id_map` instead.
- The hardcoded fallback frames (used when no decoders are loaded) had the same defect — bare PGNs as ids — and now carry well-formed ids (priority 6, source 0x80).
- Adds `TestSimulationFrameIds` to `tests/services/test_can_rx_pipeline_wiring.py`: runs one simulation iteration with both decoder maps populated and asserts the emitted arbitration id decodes back to the entry's PGN and lands on the same decoder entry.

Simulation is off by default (`config["simulate"] = False`), so no runtime behavior change for deployed instances.

## Test plan
- [x] `pytest tests/services/test_can_rx_pipeline_wiring.py` — 17 passed (16 existing + 1 new)
- [x] `ruff format` / `ruff check` clean on touched files
- [x] pyright: 0 errors on `can_bus_service.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)