### PR TITLE
fix(lights): draggable brightness slider; stop rendering dead controls

### DIFF
--- a/frontend/src/pages/devices.tsx
+++ b/frontend/src/pages/devices.tsx
@@ -149,7 +149,14 @@ function derivedCapabilities(entity: EntitySchema): string[] {
 }
 
 function isControllable(entity: EntitySchema): boolean {
-  return ["light", "switch", "fan", "lock"].includes(entity.device_type)
+  // Only `light` has a working generic on/off/toggle path. The backend's
+  // control_entity dispatches light / climate / ac_load, but climate and
+  // ac_load are parameterized and live on their own pages — the generic
+  // on/off/toggle buttons here only fit a light. switch / fan / lock have no
+  // service-layer handler, so rendering their buttons sent commands the
+  // backend rejects (e.g. the read-only entrance door lock 500'd on press).
+  // Re-add a type here only once control_entity actually dispatches it.
+  return entity.device_type === "light"
 }
 
 //

--- a/frontend/src/pages/lights.tsx
+++ b/frontend/src/pages/lights.tsx
@@ -9,6 +9,7 @@
 
 import { IconBulb, IconBulbOff } from "@tabler/icons-react"
 import { formatDistanceToNow } from "date-fns"
+import { useEffect, useState } from "react"
 import { Link } from "react-router-dom"
 
 import type { EntitySchema, OperationResultSchema } from "@/api/types/domains"
@@ -120,6 +121,17 @@ function LightRow({ entity, controlsDisabled, disabledReason }: Readonly<ILightR
   const isAvailable = entity.available !== false
   const dimmable = lightIsDimmable(entity)
   const brightness = lightBrightnessPct(entity)
+  // A Radix Slider given `value` without `onValueChange` pins its thumb — it
+  // can't be dragged, so it reads as "read-only". Track the in-flight drag
+  // locally, commit the CAN command on release, and drop the local value once
+  // the entity's real brightness catches up.
+  const [pendingBrightness, setPendingBrightness] = useState<number | null>(null)
+  useEffect(() => {
+    if (pendingBrightness !== null && brightness === pendingBrightness) {
+      setPendingBrightness(null)
+    }
+  }, [pendingBrightness, brightness])
+  const shownBrightness = pendingBrightness ?? brightness
   const rowDisabled = controlsDisabled || !isAvailable
   const rowReason = !isAvailable
     ? "Light is not responding on the CAN bus"
@@ -174,10 +186,14 @@ function LightRow({ entity, controlsDisabled, disabledReason }: Readonly<ILightR
       </div>
       {dimmable && isOn && (
         <Slider
-          value={[brightness]}
+          value={[shownBrightness]}
           max={100}
           step={5}
-          disabled={rowDisabled || control.isPending}
+          disabled={rowDisabled}
+          onValueChange={(value) => {
+            const level = value[0]
+            if (level !== undefined) setPendingBrightness(level)
+          }}
           onValueCommit={(value) => {
             const level = value[0]
             if (level !== undefined) {


### PR DESCRIPTION
## Summary
Two control-validity fixes found while auditing the heating/cooling and lights buttons/sliders against the backend command handlers (`control_entity` → `control_light`/`control_climate`/`control_ac_load`).

### 1. Brightness slider was effectively read-only
The Radix `Slider` was controlled (`value={[brightness]}`) with **no `onValueChange`**, which pins the thumb — dragging did nothing and `onValueCommit` fired with the *unchanged* value, so no real command went out. Now it tracks the drag in local state, commits the CAN command on release, and drops the local value once the entity's real brightness catches up — the same pattern the climate setpoint stepper already uses.

### 2. Devices page rendered controls with no backend handler
`isControllable` allowed `light/switch/fan/lock`, but the backend `control_entity` only dispatches `light/climate/ac_load`. The **read-only entrance-door lock** therefore showed on/off/toggle buttons that 500'd on press (*"Control not supported for device type 'lock'"*) — the same "control with no valid backend template" pattern as the Victron power items. Restricted the generic controls to `light` (climate/ac_load are parameterized and have their own pages). The lock now shows as a read-only status row.

## Audit result (context)
All heating/cooling and lights controls otherwise check out — every setpoint/mode/fan/Aqua-Hot/AC-load/toggle/brightness control maps to a real handler with correct params. The bool→`"on"/"off"` state coercion is centralized in `control_entity_safe`, so the AC-load switches work like the light switches.

## Verification
- `tsc --noEmit`, ESLint (no new findings), and production `vite build` all pass.
- Slider drag can't be exercised in the local dev server (no backend/coach data) — live-verify on the coach after deploy: drag a dimmable light's slider and confirm it moves and the light dims; confirm the entrance-door lock no longer shows on/off buttons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)