### PR TITLE
fix(connection): gate networks/status poll on auth to stop login STALE

### DIFF
--- a/frontend/src/contexts/coach-connection.tsx
+++ b/frontend/src/contexts/coach-connection.tsx
@@ -30,6 +30,7 @@ import {
   type ICoachConnectionState,
   type WebSocketHealth,
 } from '@/contexts/coach-connection-context';
+import { useAuth } from '@/contexts/auth-context';
 import { useWebSocketContext } from '@/contexts/use-websocket-context';
 import { entitiesQueryKeys } from '@/hooks/useEntities';
 import { tokenStorage } from '@/lib/token-storage';
@@ -207,11 +208,19 @@ function useAuthCloseListener(
   }, [onRefreshed, onRefreshFailed]);
 }
 
-/** Poll /api/v1/networks/status on the shared interval. */
-function useNetworksStatusQuery(): UseQueryResult<NetworkSummarySchema, Error> {
+/**
+ * Poll /api/v1/networks/status on the shared interval, but only once auth is
+ * ready. This provider mounts above the AuthGuard, so an ungated query fires
+ * on the login page, 401s, and then sits in an errored/stale state — the coach
+ * reads STALE ("no CAN traffic since …") until the user hits Retry. Gating on
+ * `enabled` means the first request goes out with a valid token right after
+ * login and lands fresh telemetry on its own.
+ */
+function useNetworksStatusQuery(enabled: boolean): UseQueryResult<NetworkSummarySchema, Error> {
   return useQuery({
     queryKey: networksStatusQueryKey,
     queryFn: () => apiGet<NetworkSummarySchema>('/api/v1/networks/status'),
+    enabled,
     refetchInterval: NETWORKS_POLL_INTERVAL_MS,
     refetchIntervalInBackground: true,
     staleTime: 5_000,
@@ -230,7 +239,12 @@ export function CoachConnectionProvider({ children }: { readonly children: React
   // Re-evaluate time-window checks (activity recency) periodically.
   useActivityTick(NETWORKS_POLL_INTERVAL_MS);
 
-  const networksQuery = useNetworksStatusQuery();
+  // Only poll telemetry once the session is confirmed (or auth is disabled),
+  // matching the WebSocket's auth gating — an unauthenticated poll on the login
+  // page would 401 and leave the coach stuck STALE until a manual Retry.
+  const { isAuthenticated, authStatus } = useAuth();
+  const authReady = authStatus?.mode === 'none' || isAuthenticated;
+  const networksQuery = useNetworksStatusQuery(authReady);
 
   // ===== Auth-close handling (WS close code 4401) =====
   const connectAll = wsContext.connectAll;


### PR DESCRIPTION
## Summary
On login the coach showed a persistent **"Coach data is stale — no CAN traffic since …. Showing last known state."** banner that only cleared when the user hit **Retry**.

Root cause is a frontend one: `CoachConnectionProvider` mounts **above** the `AuthGuard`, so its `/api/v1/networks/status` poll fires on the login page with no token → 401 → the query sits errored/stale. After login it didn't recover promptly, so the coach verdict stayed `STALE` (canbus silent) until Retry force-refetched it.

That Retry-fixes-it behavior is the tell: Retry just invalidates + refetches the *same* endpoint, so fresh telemetry was available server-side the whole time. Confirmed on the Pi — the SocketCAN `rx/tx_packets` counters are climbing (~130 frames/s) and the rolling telemetry sampler that feeds `last_activity` is sound; the endpoint reads straight from it. So this was never a backend/CAN problem.

## Fix
Gate the poll on auth readiness (`isAuthenticated`, or `mode === "none"` for auth-disabled coaches), mirroring the WebSocket gating from #208. The first request now goes out with a valid token right after login and lands fresh telemetry on its own — the coach comes up LIVE without a manual Retry. The banner lives in `AppShell` (inside the AuthGuard), so it only renders post-login anyway; gating keeps the query and banner coherent.

## Verification
- `tsc --noEmit`, ESLint (no new findings), production `vite build` all pass.
- Couldn't exercise the authed endpoint live (disabling auth on the deployed service wasn't authorized), but the mechanism is unambiguous and the "Retry fixes it" evidence pins it to the ungated pre-auth query. Live-verify after deploy: log in fresh and confirm the coach reaches LIVE on its own, no Retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)