### PR TITLE
feat(rvc): become coach time master and broadcast GPS from the Pi

### DIFF
--- a/backend/core/composition_root.py
+++ b/backend/core/composition_root.py
@@ -169,6 +169,7 @@ class CompositionServices:
     victron_service: Any = None
     trip_log_repository: Any = None
     trip_log_service: Any = None
+    time_sync_service: Any = None
     router_sidecar_service: Any = None
 
 
@@ -261,6 +262,7 @@ class CompositionRoot:
         "entity_domain_service",
         "victron_service",
         "trip_log_service",
+        "time_sync_service",
     )
     _ROUTER_SIDECAR_SERVICE_ORDER = ("router_sidecar_service",)
 
@@ -1036,6 +1038,29 @@ class CompositionRoot:
             )
             await trip_log_service.start()
             self._set_root_constructed_service("trip_log_service", trip_log_service)
+
+        # Optional RV-C time master / GPS broadcaster: same gating pattern.
+        time_sync_settings = (
+            self.require_service("app_settings").time_sync
+            if "time_sync_service" in self._service_catalog
+            else None
+        )
+        if (
+            time_sync_settings is not None
+            and time_sync_settings.enabled
+            and self._should_construct("time_sync_service")
+        ):
+            from backend.services.time_sync.time_sync_service import TimeSyncService
+
+            app_settings = self.require_service("app_settings")
+            time_sync_service = TimeSyncService(
+                settings=time_sync_settings,
+                can_facade=self.require_service("can_facade"),
+                source_address=int(app_settings.controller_source_addr, 16),
+                position_provider=self.get_optional_service("trip_log_service"),
+            )
+            await time_sync_service.start()
+            self._set_root_constructed_service("time_sync_service", time_sync_service)
 
     async def _construct_lower_can_services(self) -> None:  # noqa: C901
         """Construct lower-CAN prerequisites before CANFacade."""

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -1289,6 +1289,26 @@ class TripLogSettings(BaseSettings):
     )
 
 
+class TimeSyncSettings(BaseSettings):
+    """RV-C time master + GPS broadcast settings.
+
+    Broadcasts DATE_TIME_STATUS (becoming the coach time master by source-
+    address arbitration) and the GPS DGNs, sourced from the Pi's GPS-
+    disciplined clock and gpsd position.
+    """
+
+    model_config = SettingsConfigDict(env_prefix="COACHIQ_TIME_SYNC__", case_sensitive=False)
+
+    enabled: bool = Field(default=False, description="Enable RV-C time/GPS broadcasting")
+    interface: str = Field(default="house", description="Logical CAN interface to transmit on")
+    broadcast_interval_seconds: float = Field(
+        default=1.0, description="DATE_TIME_STATUS / GPS broadcast interval", gt=0
+    )
+    send_gps: bool = Field(
+        default=True, description="Also broadcast GPS_POSITION/GPS_STATUS/GPS_TIME_STATUS"
+    )
+
+
 class J1939Settings(BaseSettings):
     """J1939 protocol configuration settings."""
 
@@ -2004,6 +2024,7 @@ class Settings(BaseSettings):
     firefly: FireflySettings = Field(default_factory=FireflySettings)
     victron: VictronSettings = Field(default_factory=VictronSettings)
     trip_log: TripLogSettings = Field(default_factory=TripLogSettings)
+    time_sync: TimeSyncSettings = Field(default_factory=TimeSyncSettings)
     spartan_k2: SpartanK2Settings = Field(default_factory=SpartanK2Settings)
     multi_network: MultiNetworkSettings = Field(default_factory=MultiNetworkSettings)
     persistence: PersistenceSettings = Field(default_factory=PersistenceSettings)

--- a/backend/integrations/rvc/time_broadcast.py
+++ b/backend/integrations/rvc/time_broadcast.py
@@ -1,0 +1,129 @@
+"""
+RV-C date/time and GPS frame encoders (spec section 6.4 and 6.34).
+
+Pure encoding functions for the frames the time sync service transmits:
+
+- DATE_TIME_STATUS (1FFFF): the coach-wide clock. Master arbitration is by
+  source address — the highest SA broadcasting this DGN is the system time
+  master and all other nodes set their clocks to match.
+- GPS_DATE_TIME_STATUS (1FEA0): same payload, announces a GPS-quality time
+  source on unit initialization.
+- GPS_POSITION (0FEF3): lat/lon, 1e-7 degree resolution, +210° offset.
+- GPS_STATUS (1FED3): heading, speed, altitude, satellites, fix type.
+- GPS_TIME_STATUS (1FDDF): UTC date/time + HDOP.
+
+Wire-verified against the coach's existing (broken) GPS node: its
+SET_DATE_TIME_COMMAND payload for 2025-10-03 (a Friday) 16:32:04 EST was
+``19 0A 03 06 10 20 04 05`` — matching this encoding, including the
+1=Sunday day-of-week convention.
+"""
+
+import time
+from datetime import UTC, datetime
+
+DGN_DATE_TIME_STATUS = 0x1FFFF
+DGN_SET_DATE_TIME_COMMAND = 0x1FFFE
+DGN_GPS_DATE_TIME_STATUS = 0x1FEA0
+DGN_GPS_POSITION = 0x0FEF3
+DGN_GPS_STATUS = 0x1FED3
+DGN_GPS_TIME_STATUS = 0x1FDDF
+
+# RV-C timezone codes confirmed from spec table 6.4.2b (fragments); zones we
+# cannot map are sent as 255 (not available).
+_TZ_CODES = {
+    "GMT": 0,
+    "UTC": 0,
+    "EDT": 4,
+    "EST": 5,
+    "PDT": 7,
+    "PST": 8,
+}
+TZ_NOT_AVAILABLE = 0xFF
+
+_NOT_AVAILABLE_U8 = 0xFF
+
+
+def rvc_arbitration_id(dgn: int, source_address: int, priority: int = 6) -> int:
+    """Build the 29-bit arbitration id for a DGN broadcast."""
+    return (priority << 26) | (dgn << 8) | (source_address & 0xFF)
+
+
+def rvc_day_of_week(dt: datetime) -> int:
+    """RV-C day of week: 1 = Sunday … 7 = Saturday."""
+    return dt.isoweekday() % 7 + 1
+
+
+def timezone_code(tm: time.struct_time | None = None) -> int:
+    """Best-effort RV-C timezone code for the system's local timezone."""
+    tm = tm if tm is not None else time.localtime()
+    return _TZ_CODES.get(tm.tm_zone or "", TZ_NOT_AVAILABLE)
+
+
+def encode_date_time(dt_local: datetime, tz_code: int) -> bytes:
+    """Payload shared by DATE_TIME_STATUS / SET_DATE_TIME / GPS_DATE_TIME."""
+    return bytes(
+        [
+            max(0, dt_local.year - 2000) & 0xFF,
+            dt_local.month,
+            dt_local.day,
+            rvc_day_of_week(dt_local),
+            dt_local.hour,
+            dt_local.minute,
+            dt_local.second,
+            tz_code & 0xFF,
+        ]
+    )
+
+
+def encode_gps_position(latitude: float, longitude: float) -> bytes:
+    """GPS_POSITION payload: two uint32 LE, 1e-7 deg, offset -210°."""
+
+    def encode(degrees: float) -> int:
+        raw = round((degrees + 210.0) * 1e7)
+        return max(0, min(raw, 0xFFFF_FFFE))
+
+    return encode(latitude).to_bytes(4, "little") + encode(longitude).to_bytes(4, "little")
+
+
+def encode_gps_status(
+    heading_deg: float | None,
+    speed_mps: float | None,
+    altitude_m: float | None,
+    satellites: int | None,
+    fix_mode: int,
+) -> bytes:
+    """GPS_STATUS payload (heading/speed 1/128 units, altitude 0.1 m -500 offset)."""
+    heading_raw = min(round(heading_deg * 128), 0xFFFE) if heading_deg is not None else 0xFFFF
+    speed_raw = min(round(speed_mps * 3.6 * 128), 0xFFFE) if speed_mps is not None else 0xFFFF
+    altitude_raw = (
+        max(0, min(round((altitude_m + 500.0) * 10), 0xFFFE)) if altitude_m is not None else 0xFFFF
+    )
+    # gpsd mode 2/3 matches the RV-C fix-type encoding (2 = 2D, 3 = 3D).
+    fix = fix_mode if fix_mode in (2, 3) else 0
+    return (
+        heading_raw.to_bytes(2, "little")
+        + speed_raw.to_bytes(2, "little")
+        + altitude_raw.to_bytes(2, "little")
+        + bytes([satellites if satellites is not None else _NOT_AVAILABLE_U8, fix])
+    )
+
+
+def encode_gps_time_status(dt_utc: datetime) -> bytes:
+    """GPS_TIME_STATUS payload: UTC date/time; byte 3 and HDOP not available."""
+    return bytes(
+        [
+            max(0, dt_utc.year - 2000) & 0xFF,
+            dt_utc.month,
+            dt_utc.day,
+            _NOT_AVAILABLE_U8,
+            dt_utc.hour,
+            dt_utc.minute,
+            dt_utc.second,
+            _NOT_AVAILABLE_U8,
+        ]
+    )
+
+
+def utc_now() -> datetime:
+    """UTC now (wrapped for test monkeypatching)."""
+    return datetime.now(UTC)

--- a/backend/services/time_sync/__init__.py
+++ b/backend/services/time_sync/__init__.py
@@ -1,0 +1,5 @@
+"""RV-C time master + GPS broadcast service."""
+
+from backend.services.time_sync.time_sync_service import TimeSyncService
+
+__all__ = ["TimeSyncService"]

--- a/backend/services/time_sync/time_sync_service.py
+++ b/backend/services/time_sync/time_sync_service.py
@@ -1,0 +1,201 @@
+"""
+Time Sync Service - RV-C time master and GPS broadcaster.
+
+Takes over the coach's timekeeping from the (dead) factory GPS node:
+
+- Broadcasts DATE_TIME_STATUS (1FFFF) every second from this controller's
+  source address. Master arbitration is by source address — ours (0xF9)
+  outranks the factory panel (0x9C) and the broken GPS (0x75), so every
+  spec-compliant node continuously re-syncs to our GPS-disciplined clock,
+  even while the broken node keeps spamming stale SET commands.
+- Broadcasts GPS_POSITION / GPS_STATUS / GPS_TIME_STATUS at the same
+  cadence whenever the local gpsd has a fix (position comes from the trip
+  log service's live fix; time comes from the chrony-disciplined system
+  clock, which is itself GPS-backed).
+- Announces GPS_DATE_TIME_STATUS once at startup per spec 6.4.4.
+
+The system time is only trustworthy because chrony disciplines it from the
+same GPS — so time broadcasting is gated on the position provider reporting
+a fix unless GPS sending is disabled entirely (in which case the operator
+has decided the clock source is trustworthy, e.g. NTP).
+"""
+
+import asyncio
+import contextlib
+from datetime import datetime
+from typing import Any, Protocol
+
+from backend.core.config import TimeSyncSettings
+from backend.core.structured_logging import get_logger
+from backend.integrations.rvc.time_broadcast import (
+    DGN_DATE_TIME_STATUS,
+    DGN_GPS_DATE_TIME_STATUS,
+    DGN_GPS_POSITION,
+    DGN_GPS_STATUS,
+    DGN_GPS_TIME_STATUS,
+    encode_date_time,
+    encode_gps_position,
+    encode_gps_status,
+    encode_gps_time_status,
+    rvc_arbitration_id,
+    timezone_code,
+    utc_now,
+)
+
+logger = get_logger(__name__, "TimeSyncService")
+
+# GPS_DATE_TIME_STATUS and SET_DATE_TIME use priority 5 per spec; status
+# broadcasts use the default 6.
+_PRIORITY_STATUS = 6
+_PRIORITY_GPS_DATE_TIME = 5
+
+
+class PositionProvider(Protocol):
+    """Anything that can report the current GPS fix (the trip log service)."""
+
+    def get_current_position(self) -> dict[str, Any]: ...
+
+
+class TimeSyncService:
+    """Broadcast coach time and GPS data onto the RV-C bus."""
+
+    def __init__(
+        self,
+        settings: TimeSyncSettings,
+        can_facade: Any,
+        source_address: int,
+        position_provider: PositionProvider | None = None,
+    ) -> None:
+        self._settings = settings
+        self._can_facade = can_facade
+        self._source_address = source_address
+        self._position_provider = position_provider
+
+        self._running = False
+        self._task: asyncio.Task | None = None
+        self._announced_gps_time = False
+        self._tx_count = 0
+        self._tx_errors = 0
+
+    async def start(self) -> None:
+        """Start the broadcast loop."""
+        if self._running:
+            return
+        logger.info(
+            "Starting Time Sync Service",
+            source_address=f"0x{self._source_address:02X}",
+            interface=self._settings.interface,
+        )
+        self._running = True
+        self._task = asyncio.create_task(self._broadcast_loop())
+        logger.info("Time Sync Service started")
+
+    async def stop(self) -> None:
+        """Stop broadcasting (the previous master resumes per spec)."""
+        if not self._running:
+            return
+        self._running = False
+        if self._task:
+            self._task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._task
+            self._task = None
+        logger.info("Time Sync Service stopped")
+
+    # ------------------------------------------------------------------
+
+    async def _broadcast_loop(self) -> None:
+        while self._running:
+            try:
+                await self._broadcast_once()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("Error broadcasting time/GPS frames")
+            await asyncio.sleep(self._settings.broadcast_interval_seconds)
+
+    async def _broadcast_once(self) -> None:
+        position = (
+            self._position_provider.get_current_position()
+            if self._position_provider is not None
+            else None
+        )
+        has_fix = bool(position and position.get("fix"))
+
+        # Clock trustworthiness: chrony disciplines the system clock from
+        # this same GPS. Without a fix (and with GPS sending configured) we
+        # stay quiet rather than propagate a possibly free-running clock.
+        if self._settings.send_gps and self._position_provider is not None and not has_fix:
+            return
+
+        now_utc = utc_now()
+        now_local = now_utc.astimezone()
+
+        await self._send(
+            rvc_arbitration_id(DGN_DATE_TIME_STATUS, self._source_address, _PRIORITY_STATUS),
+            encode_date_time(now_local, timezone_code()),
+        )
+
+        if not self._announced_gps_time:
+            await self._send(
+                rvc_arbitration_id(
+                    DGN_GPS_DATE_TIME_STATUS, self._source_address, _PRIORITY_GPS_DATE_TIME
+                ),
+                encode_date_time(now_local, timezone_code()),
+            )
+            self._announced_gps_time = True
+
+        if self._settings.send_gps and has_fix and position is not None:
+            await self._send_gps_frames(position, now_utc)
+
+    async def _send_gps_frames(self, position: dict[str, Any], now_utc: datetime) -> None:
+        latitude = position.get("latitude")
+        longitude = position.get("longitude")
+        if latitude is None or longitude is None:
+            return
+        await self._send(
+            rvc_arbitration_id(DGN_GPS_POSITION, self._source_address, _PRIORITY_STATUS),
+            encode_gps_position(latitude, longitude),
+        )
+        await self._send(
+            rvc_arbitration_id(DGN_GPS_STATUS, self._source_address, _PRIORITY_STATUS),
+            encode_gps_status(
+                heading_deg=position.get("course_deg"),
+                speed_mps=position.get("speed_mps"),
+                altitude_m=position.get("altitude_m"),
+                satellites=None,  # not exposed by the position provider
+                fix_mode=3,
+            ),
+        )
+        await self._send(
+            rvc_arbitration_id(DGN_GPS_TIME_STATUS, self._source_address, _PRIORITY_STATUS),
+            encode_gps_time_status(now_utc),
+        )
+
+    async def _send(self, arbitration_id: int, data: bytes) -> None:
+        result = await self._can_facade.send_raw_message(
+            arbitration_id=arbitration_id,
+            data=data,
+            interface=self._settings.interface,
+        )
+        if result.get("success"):
+            self._tx_count += 1
+        else:
+            self._tx_errors += 1
+            logger.warning(
+                "Time sync TX failed: %s (id=0x%08X)",
+                result.get("error", "unknown"),
+                arbitration_id,
+            )
+
+    # ------------------------------------------------------------------
+
+    def get_health_status(self) -> dict[str, Any]:
+        """Health for the composition root."""
+        return {
+            "service": "TimeSyncService",
+            "healthy": self._running,
+            "running": self._running,
+            "frames_sent": self._tx_count,
+            "tx_errors": self._tx_errors,
+        }

--- a/tests/integrations/rvc/test_time_broadcast.py
+++ b/tests/integrations/rvc/test_time_broadcast.py
@@ -1,0 +1,74 @@
+"""Tests for RV-C time/GPS frame encoders.
+
+The date/time golden vector comes off the live coach bus: the factory GPS
+node's SET_DATE_TIME_COMMAND for Friday 2025-10-03 16:32:04 EST was
+``19 0A 03 06 10 20 04 05``.
+"""
+
+from datetime import UTC, datetime
+
+from backend.integrations.rvc.time_broadcast import (
+    DGN_DATE_TIME_STATUS,
+    DGN_GPS_POSITION,
+    encode_date_time,
+    encode_gps_position,
+    encode_gps_status,
+    encode_gps_time_status,
+    rvc_arbitration_id,
+    rvc_day_of_week,
+)
+
+
+class TestArbitrationId:
+    def test_date_time_status_matches_observed_master_pattern(self):
+        # Observed on-wire: 19FFFF9C = DATE_TIME_STATUS, priority 6, SA 0x9C.
+        assert rvc_arbitration_id(DGN_DATE_TIME_STATUS, 0x9C) == 0x19FFFF9C
+        assert rvc_arbitration_id(DGN_DATE_TIME_STATUS, 0xF9) == 0x19FFFFF9
+
+    def test_gps_position_uses_low_dgn_page(self):
+        assert rvc_arbitration_id(DGN_GPS_POSITION, 0xF9) == 0x18FEF3F9
+
+
+class TestDateTimeEncoding:
+    def test_golden_vector_from_coach_bus(self):
+        # Friday 2025-10-03 16:32:04, tz code 5 (EST). Naive datetime is the
+        # contract: encode_date_time takes local wall time.
+        dt = datetime(2025, 10, 3, 16, 32, 4)  # noqa: DTZ001
+        assert encode_date_time(dt, 5) == bytes.fromhex("190A030610200405")
+
+    def test_day_of_week_sunday_is_one(self):
+        assert rvc_day_of_week(datetime(2026, 7, 5)) == 1  # noqa: DTZ001 - a Sunday
+        assert rvc_day_of_week(datetime(2026, 7, 6)) == 2  # noqa: DTZ001 - Monday
+        assert rvc_day_of_week(datetime(2026, 7, 4)) == 7  # noqa: DTZ001 - Saturday
+
+
+class TestGpsEncoding:
+    def test_position_round_trips(self):
+        payload = encode_gps_position(35.578453, -75.465530)
+        lat = int.from_bytes(payload[0:4], "little") / 1e7 - 210
+        lon = int.from_bytes(payload[4:8], "little") / 1e7 - 210
+        assert abs(lat - 35.578453) < 1e-6
+        assert abs(lon - -75.465530) < 1e-6
+
+    def test_equator_reference_value(self):
+        """The spec pins the equator at a raw value of 2,100,000,000."""
+        payload = encode_gps_position(0.0, 0.0)
+        assert int.from_bytes(payload[0:4], "little") == 2_100_000_000
+
+    def test_status_encoding(self):
+        payload = encode_gps_status(
+            heading_deg=180.0, speed_mps=25.0, altitude_m=2.0, satellites=12, fix_mode=3
+        )
+        assert int.from_bytes(payload[0:2], "little") == 180 * 128
+        assert int.from_bytes(payload[2:4], "little") == round(25.0 * 3.6 * 128)
+        assert int.from_bytes(payload[4:6], "little") == round(502.0 * 10)
+        assert payload[6] == 12
+        assert payload[7] == 3
+
+    def test_status_not_available_markers(self):
+        payload = encode_gps_status(None, None, None, None, 0)
+        assert payload == bytes.fromhex("FFFFFFFFFFFFFF00")
+
+    def test_time_status_utc(self):
+        payload = encode_gps_time_status(datetime(2026, 7, 5, 18, 30, 15, tzinfo=UTC))
+        assert payload == bytes([26, 7, 5, 0xFF, 18, 30, 15, 0xFF])

--- a/tests/services/test_time_sync_service.py
+++ b/tests/services/test_time_sync_service.py
@@ -1,0 +1,106 @@
+"""Tests for the TimeSyncService broadcast behavior (CAN facade is faked)."""
+
+from typing import Any
+
+from backend.core.config import TimeSyncSettings
+from backend.services.time_sync.time_sync_service import TimeSyncService
+
+
+class FakeCanFacade:
+    def __init__(self) -> None:
+        self.sent: list[tuple[int, bytes, str]] = []
+
+    async def send_raw_message(
+        self, arbitration_id: int, data: bytes, interface: str
+    ) -> dict[str, Any]:
+        self.sent.append((arbitration_id, data, interface))
+        return {"success": True}
+
+
+class FakePositionProvider:
+    def __init__(self, fix: bool) -> None:
+        self._fix = fix
+
+    def get_current_position(self) -> dict[str, Any]:
+        if not self._fix:
+            return {"fix": False, "latitude": None, "longitude": None}
+        return {
+            "fix": True,
+            "latitude": 35.578453,
+            "longitude": -75.465530,
+            "speed_mps": 25.0,
+            "course_deg": 180.0,
+            "altitude_m": 2.0,
+        }
+
+
+def make_service(
+    *, fix: bool | None = True, send_gps: bool = True
+) -> tuple[TimeSyncService, FakeCanFacade]:
+    settings = TimeSyncSettings(enabled=True, send_gps=send_gps)
+    facade = FakeCanFacade()
+    provider = FakePositionProvider(fix) if fix is not None else None
+    service = TimeSyncService(
+        settings=settings,
+        can_facade=facade,
+        source_address=0xF9,
+        position_provider=provider,
+    )
+    return service, facade
+
+
+def dgns(facade: FakeCanFacade) -> list[int]:
+    return [(arb >> 8) & 0x3FFFF for arb, _, _ in facade.sent]
+
+
+class TestBroadcast:
+    async def test_with_fix_sends_time_and_gps(self):
+        service, facade = make_service(fix=True)
+        await service._broadcast_once()
+        sent = dgns(facade)
+        assert sent[0] == 0x1FFFF  # DATE_TIME_STATUS first
+        assert 0x1FEA0 in sent  # GPS_DATE_TIME announced on first broadcast
+        assert 0x0FEF3 in sent
+        assert 0x1FED3 in sent
+        assert 0x1FDDF in sent
+        # All from our source address on the house interface.
+        assert all(arb & 0xFF == 0xF9 for arb, _, _ in facade.sent)
+        assert all(interface == "house" for _, _, interface in facade.sent)
+
+    async def test_gps_announce_only_once(self):
+        service, facade = make_service(fix=True)
+        await service._broadcast_once()
+        await service._broadcast_once()
+        assert dgns(facade).count(0x1FEA0) == 1
+        assert dgns(facade).count(0x1FFFF) == 2
+
+    async def test_no_fix_sends_nothing(self):
+        # Chrony gets its time from this GPS; without a fix, stay silent.
+        service, facade = make_service(fix=False)
+        await service._broadcast_once()
+        assert facade.sent == []
+
+    async def test_gps_disabled_sends_time_only(self):
+        service, facade = make_service(fix=False, send_gps=False)
+        await service._broadcast_once()
+        sent = dgns(facade)
+        assert 0x1FFFF in sent
+        assert 0x0FEF3 not in sent
+
+    async def test_no_provider_sends_time_only(self):
+        service, facade = make_service(fix=None)
+        await service._broadcast_once()
+        sent = dgns(facade)
+        assert 0x1FFFF in sent
+        assert 0x0FEF3 not in sent
+
+    async def test_tx_errors_counted(self):
+        service, facade = make_service(fix=True)
+
+        async def failing_send(**kwargs: Any) -> dict[str, Any]:
+            return {"success": False, "error": "bus off"}
+
+        facade.send_raw_message = failing_send  # type: ignore[assignment]
+        await service._broadcast_once()
+        health = service.get_health_status()
+        assert health["tx_errors"] > 0


### PR DESCRIPTION
## Summary

The coach-wide clock is **nine months wrong**: the factory GPS node (SA `0x75`) is dead — it broadcasts a frozen 2025-10-03 timestamp as `SET_DATE_TIME_COMMAND` every second (plus two frozen proprietary DGNs), and the time master (`0x9C`) dutifully accepts it. Every clock on the bus follows.

### Approach
RV-C 6.4.2 arbitrates the time master **by source address — highest wins**. CoachIQ transmits from `0xF9`, outranking both `0x9C` and `0x75`. So instead of fighting the bad SET commands, we simply become the master: broadcast `DATE_TIME_STATUS` at 1 Hz with the Pi's GPS-disciplined time, and every spec-compliant node re-syncs each second — self-healing even while the broken node keeps spamming.

Also broadcasts the GPS suite the dead node should have provided (spec 6.34): `GPS_POSITION` (lat/lon), `GPS_STATUS` (heading/speed/altitude/fix), `GPS_TIME_STATUS` (UTC), and a `GPS_DATE_TIME_STATUS` announcement at startup.

### Safety gating
- Time frames only transmit while gpsd has a fix (chrony disciplines the clock from that same GPS — no fix, no broadcast, prior master resumes per spec).
- GPS frames additionally require lat/lon.
- Disabled by default; enabled per-host via `COACHIQ_TIME_SYNC__ENABLED`.

### Verification
- Golden test vector captured off the live bus: the dead node's payload `19 0A 03 06 10 20 04 05` (Friday 2025-10-03 16:32:04 EST) matches our encoder byte-for-byte, pinning the 1=Sunday DOW convention and arbitration-id format (`0x19FFFF9C` observed ⇒ `0x19FFFFF9` for us).
- 15 new tests; 173 pass in the touched areas. Real proof comes at deploy: candump should show `19FFFFF9` at 1 Hz, `0x9C` should stop broadcasting (spec: lower-SA master yields), and the coach clocks should jump forward nine months.

### Deploy note
Needs `COACHIQ_TIME_SYNC__ENABLED=true` on nixpi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)