### PR TITLE
fix(ws): connect synchronously so the socket actually auto-connects

### DIFF
--- a/frontend/src/api/websocket.ts
+++ b/frontend/src/api/websocket.ts
@@ -115,33 +115,16 @@ export class RVCWebSocketClient {
     }
 
     this.cleanup();
-    // Mark connecting synchronously so callers (e.g. the autoConnect effect,
-    // which checks `state !== 'connecting'`) don't fire a duplicate dial while
-    // the async token refresh below is in flight.
     this._state = 'connecting';
-    void this.openWithFreshToken();
-  }
 
-  /**
-   * Refresh a soon-to-expire access token, then open the socket. The token is
-   * passed as a query param, so a stale one gets the connection rejected on the
-   * first attempt — and the reconnect path only re-dials sockets that were
-   * previously connected, so a rejected first dial would otherwise sit down
-   * until a manual retry. Refreshing here (same gap the scheduled timer misses
-   * after a backgrounded tab) lets the auto-reconnect recover on its own.
-   */
-  private async openWithFreshToken(): Promise<void> {
-    try {
-      if (tokenStorage.needsRefresh() && tokenStorage.isRefreshTokenValid()) {
-        await tokenStorage.attemptTokenRefresh();
-      }
-    } catch {
-      // Dial with whatever token we have; the server will reject if it's dead.
-    }
-
-    // A disconnect() may have raced in while the refresh was awaiting.
-    if (this._state !== 'connecting') return;
-
+    // Open the socket SYNCHRONOUSLY. An earlier version awaited a token refresh
+    // before dialing, which made connect() async — and that opened a race: the
+    // auto-connect effect fires connect() once when auth becomes ready, but if
+    // the async path left the client parked at state==='connecting' without a
+    // live socket, the effect (which guards on state!=='connecting') never
+    // retried, so the coach sat STALE until a manual Retry. A soon-to-expire
+    // access token is not worth that: /ws accepts token-less connections, and a
+    // mid-session expiry is already recovered by the 4401 close handler below.
     const token = tokenStorage.getAccessToken();
     const baseUrl = `${WS_BASE}${this.endpoint}`;
     const wsUrl = token ? `${baseUrl}?token=${encodeURIComponent(token)}` : baseUrl;

--- a/frontend/src/components/connection-banner.tsx
+++ b/frontend/src/components/connection-banner.tsx
@@ -20,7 +20,7 @@ function formatLastData(date: Date | null): string {
 }
 
 export function ConnectionBanner() {
-  const { coach, lastDataAt, retry } = useCoachConnection()
+  const { coach, lastDataAt, reason, retry } = useCoachConnection()
 
   if (coach === "LIVE") return null
 
@@ -45,7 +45,7 @@ export function ConnectionBanner() {
       <span className="flex-1">
         {isOffline
           ? `Can't reach the coach — controls disabled. Last data ${time}.`
-          : `Coach data is stale — no CAN traffic since ${time}. Showing last known state.`}
+          : `${reason} — showing last known state (last data ${time}).`}
       </span>
       <Button
         size="sm"


### PR DESCRIPTION
## Summary
Live-diagnosed (in-browser, authenticated) the persistent **STALE** banner. CAN telemetry and auth were healthy the entire time — `canbus === "active"`, fresh 114–120 fps, REST queries 200 — but the app's WebSocket was stuck at `state: "connecting"` / `isConnected: false`. The socket *opened* at the network level, yet `isConnected` never flipped, so the coach never reached `LIVE`. Only a manual **Retry** (`connectAll`) established it.

## Cause (regression from #208)
#208 made `connect()` **async** — `openWithFreshToken` awaited a token refresh before dialing. The auto-connect effect calls `connect()` once when auth becomes ready; the async path could park the client at `state === "connecting"` with no live socket, and that effect guards on `state !== "connecting"`, so it never retried. Manual Retry calls `connect()` directly and gets through — which is exactly the "loads disconnected, force connect" behavior.

## Fix
- **Restore synchronous socket creation** in `connect()` — no pre-dial await, no race. The pre-dial refresh isn't needed: `/ws` accepts token-less connections and mid-session expiry is already recovered by the `4401` close handler.
- **Fix the ConnectionBanner** to show the context's real `reason` (e.g. "Realtime connection is being established") instead of the hardcoded "no CAN traffic since …", which disguised this realtime-connection fault as a CAN outage and sent debugging down the wrong path for a while.

Auth-aware WS gating (connect after login, *with* a token) from #208 is **kept** — only the async race is removed.

## Verification
- `tsc --noEmit`, ESLint (no new findings on changed lines), production `vite build` all pass.
- Will be **verified live in-browser after deploy**: confirm the coach reaches LIVE on a fresh load with no manual Retry, and that `websocket === "connected"`.

## Note
The whole episode is a good argument for eventually moving the entity/telemetry stream to **SSE** — the browser's `EventSource` owns reconnection, which would delete this entire class of lifecycle bug. Tracked separately, not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)