### PR TITLE
fix(can): start the CAN message injector at construction

### DIFF
--- a/backend/core/composition_root.py
+++ b/backend/core/composition_root.py
@@ -526,13 +526,13 @@ class CompositionRoot:
             EntityRuntimeStateRepository,
         )
         from backend.repositories.persistence_repository import PersistenceRepository
-        from backend.repositories.trip_log_repository import TripLogRepository
         from backend.repositories.security_audit_repository import SecurityAuditRepository
         from backend.repositories.security_config_repository import SecurityConfigRepository
         from backend.repositories.security_event_repository import (
             SecurityEventRepository,
             SecurityListenerRepository,
         )
+        from backend.repositories.trip_log_repository import TripLogRepository
         from backend.services.auth.tokens import TokenService
         from backend.services.entities.entity_manager_service import EntityManagerService
 
@@ -1062,7 +1062,7 @@ class CompositionRoot:
             await time_sync_service.start()
             self._set_root_constructed_service("time_sync_service", time_sync_service)
 
-    async def _construct_lower_can_services(self) -> None:  # noqa: C901
+    async def _construct_lower_can_services(self) -> None:  # noqa: C901, PLR0915
         """Construct lower-CAN prerequisites before CANFacade."""
         from backend.integrations.can.anomaly_detector import CANAnomalyDetector
         from backend.integrations.can.can_bus_recorder import CANBusRecorder
@@ -1092,12 +1092,14 @@ class CompositionRoot:
                 if security_audit and hasattr(security_audit, "log_injection"):
                     await security_audit.log_injection(request, result)
 
-            self._set_root_constructed_service(
-                "can_message_injector",
-                CANMessageInjector(
-                    safety_level=SafetyLevel.MODERATE, audit_callback=audit_injection
-                ),
+            can_message_injector = CANMessageInjector(
+                safety_level=SafetyLevel.MODERATE, audit_callback=audit_injection
             )
+            # The injector's safety precondition rejects every send while the
+            # service is not running, and nothing else starts it (CANFacade
+            # .start() is not part of the root startup path).
+            await can_message_injector.start()
+            self._set_root_constructed_service("can_message_injector", can_message_injector)
 
         if self._should_construct("can_message_filter"):
 


### PR DESCRIPTION
Second (and final) layer of the never-exercised facade TX path, uncovered live by the time sync service after #215: the injector's safety precondition rejects every send while `_is_running` is False, and **nothing ever called `start()`** — the composition root only constructs the injector, and `CANFacade.start()` both skips the injector and isn't part of root startup. On the coach every send failed with `Safety interlock violation: injection blocked` (journal-confirmed).

Fix: `await can_message_injector.start()` at construction, matching how the root starts its other lifecycle services. `start()` only sets the running flag and guardrail status — no I/O.

Composition-root and facade test suites pass (127 + 44).

🤖 Generated with [Claude Code](https://claude.com/claude-code)