### PR TITLE
fix(ws): stop tearing down the socket every render (the real STALE cause)

### DIFF
--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -142,6 +142,17 @@ export function useWebSocket<T = unknown>(options: IUseWebSocketOptions<T>): IUs
     onError,
   } = options;
 
+  // Keep the latest message handlers in refs so `memoizedOnMessage` can stay
+  // referentially STABLE. Callers routinely pass an inline `onMessage` or a
+  // fresh `subscriptions` array every render (e.g. useEntityWebSocket), which
+  // would otherwise change the handler identity each render, re-run the
+  // connection-creation effect, and tear the socket down before it finishes
+  // connecting — the coach then never leaves the "connecting" state on load.
+  const onMessageRef = useRef(onMessage);
+  onMessageRef.current = onMessage;
+  const propSubscriptionsRef = useRef(subscriptions);
+  propSubscriptionsRef.current = subscriptions;
+
   // Always call useContext (React hooks must be called unconditionally)
   const contextValue = useContext(WebSocketContext);
   const wsContext = useWebSocketContext ? contextValue : null;
@@ -241,8 +252,8 @@ export function useWebSocket<T = unknown>(options: IUseWebSocketOptions<T>): IUs
       lastMessage: new Date(),
     }));
 
-    // Call generic handler
-    onMessage?.(message as T);
+    // Call generic handler (via ref so this callback stays stable)
+    onMessageRef.current?.(message as T);
 
     // Call subscribed handlers
     subscriptionsRef.current.forEach(sub => {
@@ -255,8 +266,8 @@ export function useWebSocket<T = unknown>(options: IUseWebSocketOptions<T>): IUs
       }
     });
 
-    // Also handle subscriptions from props
-    subscriptions.forEach(sub => {
+    // Also handle subscriptions from props (via ref, for the same reason)
+    propSubscriptionsRef.current.forEach(sub => {
       if (sub.type && typeof message === 'object' && message && 'type' in message) {
         if ((message as unknown as Record<string, unknown>).type === sub.type) {
           sub.handler(message as T);
@@ -265,7 +276,7 @@ export function useWebSocket<T = unknown>(options: IUseWebSocketOptions<T>): IUs
         sub.handler(message as T);
       }
     });
-  }, [onMessage, subscriptions]);
+  }, []);
 
   // Memoize config with exponential backoff settings
   const config = useMemo(() => ({


### PR DESCRIPTION
## Summary
The definitive fix for the persistent **STALE** banner, found by live in-browser debugging of the deployed app.

**Symptom:** on load the coach never left `connecting`. Both WS clients sat at `state: "disconnected"` with **no socket**, and **zero sockets were ever created** — `connect()` never landed — even though auth was ready (`authReady` true) and CAN telemetry was fresh (`canbus: "active"`). Only a manual **Retry** recovered it.

## Root cause
`useWebSocket`'s connection-creation effect depends on the memoized message handler, whose identity **changes every render**: callers pass an inline handler / a fresh array each render —
- `useEntityWebSocket` → `subscriptions: [{ type: 'entity_update', handler: … }]`
- `useSystemStatusWebSocket` → inline `onMessage: () => …`

So the effect re-ran on **every render**, releasing and recreating the connection, while the one-shot autoConnect effect (keyed only on `[autoConnect]`) never re-fired to reconnect the fresh client. The socket was torn down before it could finish connecting. Manual Retry calls `connect()` directly, which is why it recovered — the "loads disconnected, force connect" behavior.

This is a pre-existing latent bug; my earlier #208/#213 (WS auth-gating + token refresh) just added re-renders that made it fire *reliably*.

## Fix
Hold `onMessage` and the prop `subscriptions` in refs and make `memoizedOnMessage` referentially **stable** (empty deps). The connection is created once and survives re-renders, so the autoConnect effect connects a stable client on load.

## Verification
- `tsc --noEmit` and production `vite build` pass; changed lines have no new ESLint findings.
- **Verified live in-browser after deploy**: on a fresh hard-reload the coach reaches LIVE on its own — `websocket: "connected"`, a real socket is created and stays open, no manual Retry. (Results in the PR thread / session.)

Follow-up still worth doing: migrate the entity/telemetry stream to SSE so the browser owns reconnection and this class of lifecycle bug goes away for good.

🤖 Generated with [Claude Code](https://claude.com/claude-code)