### PR TITLE
feat(rvc): periodic SET_DATE_TIME_COMMAND nudge for non-compliant clocks

### DIFF
--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -1307,6 +1307,14 @@ class TimeSyncSettings(BaseSettings):
     send_gps: bool = Field(
         default=True, description="Also broadcast GPS_POSITION/GPS_STATUS/GPS_TIME_STATUS"
     )
+    set_command_interval_seconds: float = Field(
+        default=300.0,
+        description=(
+            "Interval for SET_DATE_TIME_COMMAND nudges that force non-spec-"
+            "compliant clocks to correct (0 disables)"
+        ),
+        ge=0,
+    )
 
 
 class J1939Settings(BaseSettings):

--- a/backend/services/time_sync/time_sync_service.py
+++ b/backend/services/time_sync/time_sync_service.py
@@ -22,6 +22,7 @@ has decided the clock source is trustworthy, e.g. NTP).
 
 import asyncio
 import contextlib
+import time
 from datetime import datetime
 from typing import Any, Protocol
 
@@ -33,6 +34,7 @@ from backend.integrations.rvc.time_broadcast import (
     DGN_GPS_POSITION,
     DGN_GPS_STATUS,
     DGN_GPS_TIME_STATUS,
+    DGN_SET_DATE_TIME_COMMAND,
     encode_date_time,
     encode_gps_position,
     encode_gps_status,
@@ -47,7 +49,7 @@ logger = get_logger(__name__, "TimeSyncService")
 # GPS_DATE_TIME_STATUS and SET_DATE_TIME use priority 5 per spec; status
 # broadcasts use the default 6.
 _PRIORITY_STATUS = 6
-_PRIORITY_GPS_DATE_TIME = 5
+_PRIORITY_COMMAND = 5
 
 
 class PositionProvider(Protocol):
@@ -74,6 +76,7 @@ class TimeSyncService:
         self._running = False
         self._task: asyncio.Task | None = None
         self._announced_gps_time = False
+        self._last_set_command_at = 0.0
         self._tx_count = 0
         self._tx_errors = 0
 
@@ -139,11 +142,25 @@ class TimeSyncService:
         if not self._announced_gps_time:
             await self._send(
                 rvc_arbitration_id(
-                    DGN_GPS_DATE_TIME_STATUS, self._source_address, _PRIORITY_GPS_DATE_TIME
+                    DGN_GPS_DATE_TIME_STATUS, self._source_address, _PRIORITY_COMMAND
                 ),
                 encode_date_time(now_local, timezone_code()),
             )
             self._announced_gps_time = True
+
+        # Some nodes (the coach's Firefly time master among them) ignore the
+        # spec's follow-the-highest-SA rule for DATE_TIME_STATUS but do obey
+        # SET_DATE_TIME_COMMAND — nudge them periodically so their own
+        # rebroadcasts carry the correct time too.
+        set_interval = self._settings.set_command_interval_seconds
+        if set_interval > 0 and time.time() - self._last_set_command_at >= set_interval:
+            await self._send(
+                rvc_arbitration_id(
+                    DGN_SET_DATE_TIME_COMMAND, self._source_address, _PRIORITY_COMMAND
+                ),
+                encode_date_time(now_local, timezone_code()),
+            )
+            self._last_set_command_at = time.time()
 
         if self._settings.send_gps and has_fix and position is not None:
             await self._send_gps_frames(position, now_utc)

--- a/tests/services/test_time_sync_service.py
+++ b/tests/services/test_time_sync_service.py
@@ -35,9 +35,11 @@ class FakePositionProvider:
 
 
 def make_service(
-    *, fix: bool | None = True, send_gps: bool = True
+    *, fix: bool | None = True, send_gps: bool = True, set_interval: float = 0.0
 ) -> tuple[TimeSyncService, FakeCanFacade]:
-    settings = TimeSyncSettings(enabled=True, send_gps=send_gps)
+    settings = TimeSyncSettings(
+        enabled=True, send_gps=send_gps, set_command_interval_seconds=set_interval
+    )
     facade = FakeCanFacade()
     provider = FakePositionProvider(fix) if fix is not None else None
     service = TimeSyncService(
@@ -93,6 +95,18 @@ class TestBroadcast:
         sent = dgns(facade)
         assert 0x1FFFF in sent
         assert 0x0FEF3 not in sent
+
+    async def test_set_command_nudge_rate_limited(self):
+        service, facade = make_service(fix=True, set_interval=300.0)
+        await service._broadcast_once()
+        await service._broadcast_once()
+        # One SET on the first broadcast, then suppressed until the interval.
+        assert dgns(facade).count(0x1FFFE) == 1
+
+    async def test_set_command_disabled_at_zero(self):
+        service, facade = make_service(fix=True, set_interval=0.0)
+        await service._broadcast_once()
+        assert 0x1FFFE not in dgns(facade)
 
     async def test_tx_errors_counted(self):
         service, facade = make_service(fix=True)


### PR DESCRIPTION
Follow-up to #214: with the dead GPS node now **physically disconnected** (it was spamming wrong SETs at 1 Hz, making the Firefly display bounce between Oct 2025 and Jul 2026), the remaining problem is the Firefly time master (`0x9C`): it ignores the spec's follow-the-highest-SA rule for `DATE_TIME_STATUS` but **provably obeys `SET_DATE_TIME_COMMAND`** — it tracked the dead node's wrong SETs for months.

This adds a rate-limited SET nudge (default every 300 s, `COACHIQ_TIME_SYNC__SET_COMMAND_INTERVAL_SECONDS`, 0 disables): first broadcast sends one immediately, then the interval applies. Uncontested now that the spammer is unplugged, so no clock flapping — `0x9C` should adopt GPS time and its own rebroadcasts become correct.

2 new tests (rate limiting, disable-at-zero); 17 pass in the touched suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)