### PR TITLE
feat(rvc): synthesize COMPASS_BEARING_STATUS from GPS course

### DIFF
--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -1315,6 +1315,15 @@ class TimeSyncSettings(BaseSettings):
         ),
         ge=0,
     )
+    send_compass: bool = Field(
+        default=True,
+        description="Synthesize COMPASS_BEARING_STATUS from GPS course while moving",
+    )
+    compass_min_speed_mps: float = Field(
+        default=1.5,
+        description="Minimum speed for GPS course to update the compass bearing",
+        ge=0,
+    )
 
 
 class J1939Settings(BaseSettings):

--- a/backend/integrations/rvc/time_broadcast.py
+++ b/backend/integrations/rvc/time_broadcast.py
@@ -27,6 +27,7 @@ DGN_GPS_DATE_TIME_STATUS = 0x1FEA0
 DGN_GPS_POSITION = 0x0FEF3
 DGN_GPS_STATUS = 0x1FED3
 DGN_GPS_TIME_STATUS = 0x1FDDF
+DGN_COMPASS_BEARING_STATUS = 0x1FFA0
 
 # RV-C timezone codes confirmed from spec table 6.4.2b (fragments); zones we
 # cannot map are sent as 255 (not available).
@@ -105,6 +106,22 @@ def encode_gps_status(
         + speed_raw.to_bytes(2, "little")
         + altitude_raw.to_bytes(2, "little")
         + bytes([satellites if satellites is not None else _NOT_AVAILABLE_U8, fix])
+    )
+
+
+def encode_compass_bearing(bearing_deg: float | None) -> bytes:
+    """COMPASS_BEARING_STATUS payload (spec 6.34.2).
+
+    Bearing uint16 at 1/128°, calibration offset 0 (GPS course has none),
+    calibration status 00b = calibrated. Bytes 5-7 are undefined (0xFF).
+    """
+    bearing_raw = (
+        min(round((bearing_deg % 360.0) * 128), 0xFFFE) if bearing_deg is not None else 0xFFFF
+    )
+    return (
+        bearing_raw.to_bytes(2, "little")
+        + (0).to_bytes(2, "little")
+        + bytes([0b1111_1100, 0xFF, 0xFF, 0xFF])
     )
 
 

--- a/backend/services/time_sync/time_sync_service.py
+++ b/backend/services/time_sync/time_sync_service.py
@@ -29,12 +29,14 @@ from typing import Any, Protocol
 from backend.core.config import TimeSyncSettings
 from backend.core.structured_logging import get_logger
 from backend.integrations.rvc.time_broadcast import (
+    DGN_COMPASS_BEARING_STATUS,
     DGN_DATE_TIME_STATUS,
     DGN_GPS_DATE_TIME_STATUS,
     DGN_GPS_POSITION,
     DGN_GPS_STATUS,
     DGN_GPS_TIME_STATUS,
     DGN_SET_DATE_TIME_COMMAND,
+    encode_compass_bearing,
     encode_date_time,
     encode_gps_position,
     encode_gps_status,
@@ -77,6 +79,9 @@ class TimeSyncService:
         self._task: asyncio.Task | None = None
         self._announced_gps_time = False
         self._last_set_command_at = 0.0
+        # GPS course is only meaningful in motion; the compass bearing holds
+        # its last moving value while parked (like a real compass would).
+        self._held_bearing_deg: float | None = None
         self._tx_count = 0
         self._tx_errors = 0
 
@@ -188,6 +193,21 @@ class TimeSyncService:
             rvc_arbitration_id(DGN_GPS_TIME_STATUS, self._source_address, _PRIORITY_STATUS),
             encode_gps_time_status(now_utc),
         )
+        if self._settings.send_compass:
+            speed = position.get("speed_mps")
+            course = position.get("course_deg")
+            if (
+                speed is not None
+                and course is not None
+                and speed >= self._settings.compass_min_speed_mps
+            ):
+                self._held_bearing_deg = course
+            await self._send(
+                rvc_arbitration_id(
+                    DGN_COMPASS_BEARING_STATUS, self._source_address, _PRIORITY_STATUS
+                ),
+                encode_compass_bearing(self._held_bearing_deg),
+            )
 
     async def _send(self, arbitration_id: int, data: bytes) -> None:
         result = await self._can_facade.send_raw_message(

--- a/tests/integrations/rvc/test_time_broadcast.py
+++ b/tests/integrations/rvc/test_time_broadcast.py
@@ -10,6 +10,7 @@ from datetime import UTC, datetime
 from backend.integrations.rvc.time_broadcast import (
     DGN_DATE_TIME_STATUS,
     DGN_GPS_POSITION,
+    encode_compass_bearing,
     encode_date_time,
     encode_gps_position,
     encode_gps_status,
@@ -72,3 +73,15 @@ class TestGpsEncoding:
     def test_time_status_utc(self):
         payload = encode_gps_time_status(datetime(2026, 7, 5, 18, 30, 15, tzinfo=UTC))
         assert payload == bytes([26, 7, 5, 0xFF, 18, 30, 15, 0xFF])
+
+    def test_compass_bearing_south(self):
+        payload = encode_compass_bearing(180.0)
+        assert int.from_bytes(payload[0:2], "little") == 180 * 128
+        assert int.from_bytes(payload[2:4], "little") == 0  # no calibration offset
+        assert payload[4] & 0b11 == 0  # calibrated
+
+    def test_compass_bearing_wraps_and_not_available(self):
+        wrapped = encode_compass_bearing(370.0)
+        assert int.from_bytes(wrapped[0:2], "little") == 10 * 128
+        unavailable = encode_compass_bearing(None)
+        assert unavailable[0:2] == b"\xff\xff"

--- a/tests/services/test_time_sync_service.py
+++ b/tests/services/test_time_sync_service.py
@@ -20,6 +20,8 @@ class FakeCanFacade:
 class FakePositionProvider:
     def __init__(self, fix: bool) -> None:
         self._fix = fix
+        self.speed_mps: float | None = 25.0
+        self.course_deg: float | None = 180.0
 
     def get_current_position(self) -> dict[str, Any]:
         if not self._fix:
@@ -28,15 +30,15 @@ class FakePositionProvider:
             "fix": True,
             "latitude": 35.578453,
             "longitude": -75.465530,
-            "speed_mps": 25.0,
-            "course_deg": 180.0,
+            "speed_mps": self.speed_mps,
+            "course_deg": self.course_deg,
             "altitude_m": 2.0,
         }
 
 
 def make_service(
     *, fix: bool | None = True, send_gps: bool = True, set_interval: float = 0.0
-) -> tuple[TimeSyncService, FakeCanFacade]:
+) -> tuple[TimeSyncService, FakeCanFacade, FakePositionProvider | None]:
     settings = TimeSyncSettings(
         enabled=True, send_gps=send_gps, set_command_interval_seconds=set_interval
     )
@@ -48,7 +50,7 @@ def make_service(
         source_address=0xF9,
         position_provider=provider,
     )
-    return service, facade
+    return service, facade, provider
 
 
 def dgns(facade: FakeCanFacade) -> list[int]:
@@ -57,7 +59,7 @@ def dgns(facade: FakeCanFacade) -> list[int]:
 
 class TestBroadcast:
     async def test_with_fix_sends_time_and_gps(self):
-        service, facade = make_service(fix=True)
+        service, facade, _ = make_service(fix=True)
         await service._broadcast_once()
         sent = dgns(facade)
         assert sent[0] == 0x1FFFF  # DATE_TIME_STATUS first
@@ -70,7 +72,7 @@ class TestBroadcast:
         assert all(interface == "house" for _, _, interface in facade.sent)
 
     async def test_gps_announce_only_once(self):
-        service, facade = make_service(fix=True)
+        service, facade, _ = make_service(fix=True)
         await service._broadcast_once()
         await service._broadcast_once()
         assert dgns(facade).count(0x1FEA0) == 1
@@ -78,38 +80,65 @@ class TestBroadcast:
 
     async def test_no_fix_sends_nothing(self):
         # Chrony gets its time from this GPS; without a fix, stay silent.
-        service, facade = make_service(fix=False)
+        service, facade, _ = make_service(fix=False)
         await service._broadcast_once()
         assert facade.sent == []
 
     async def test_gps_disabled_sends_time_only(self):
-        service, facade = make_service(fix=False, send_gps=False)
+        service, facade, _ = make_service(fix=False, send_gps=False)
         await service._broadcast_once()
         sent = dgns(facade)
         assert 0x1FFFF in sent
         assert 0x0FEF3 not in sent
 
     async def test_no_provider_sends_time_only(self):
-        service, facade = make_service(fix=None)
+        service, facade, _ = make_service(fix=None)
         await service._broadcast_once()
         sent = dgns(facade)
         assert 0x1FFFF in sent
         assert 0x0FEF3 not in sent
 
     async def test_set_command_nudge_rate_limited(self):
-        service, facade = make_service(fix=True, set_interval=300.0)
+        service, facade, _ = make_service(fix=True, set_interval=300.0)
         await service._broadcast_once()
         await service._broadcast_once()
         # One SET on the first broadcast, then suppressed until the interval.
         assert dgns(facade).count(0x1FFFE) == 1
 
     async def test_set_command_disabled_at_zero(self):
-        service, facade = make_service(fix=True, set_interval=0.0)
+        service, facade, _ = make_service(fix=True, set_interval=0.0)
         await service._broadcast_once()
         assert 0x1FFFE not in dgns(facade)
 
+    async def test_compass_follows_course_while_moving(self):
+        service, facade, provider = make_service(fix=True)
+        assert provider is not None
+        await service._broadcast_once()
+        compass = [data for arb, data, _ in facade.sent if (arb >> 8) & 0x3FFFF == 0x1FFA0]
+        assert int.from_bytes(compass[-1][0:2], "little") == 180 * 128
+
+    async def test_compass_holds_last_bearing_while_parked(self):
+        service, facade, provider = make_service(fix=True)
+        assert provider is not None
+        await service._broadcast_once()  # moving south at 25 m/s
+
+        # Parked: GPS course becomes noise; the bearing must hold at 180°.
+        provider.speed_mps = 0.0
+        provider.course_deg = 37.0
+        await service._broadcast_once()
+        compass = [data for arb, data, _ in facade.sent if (arb >> 8) & 0x3FFFF == 0x1FFA0]
+        assert int.from_bytes(compass[-1][0:2], "little") == 180 * 128
+
+    async def test_compass_not_available_before_first_movement(self):
+        service, facade, provider = make_service(fix=True)
+        assert provider is not None
+        provider.speed_mps = 0.0
+        await service._broadcast_once()
+        compass = [data for arb, data, _ in facade.sent if (arb >> 8) & 0x3FFFF == 0x1FFA0]
+        assert compass[-1][0:2] == b"\xff\xff"
+
     async def test_tx_errors_counted(self):
-        service, facade = make_service(fix=True)
+        service, facade, _ = make_service(fix=True)
 
         async def failing_send(**kwargs: Any) -> dict[str, Any]:
             return {"success": False, "error": "bus off"}


### PR DESCRIPTION
Follow-up to the time saga: the unplugged dead GPS module was also the coach's **compass** source (`COMPASS_BEARING_STATUS` 1FFA0), so the Firefly compass display went blank. This synthesizes it from GPS course over ground:

- Bearing follows gpsd track **while moving** (≥ 1.5 m/s, configurable) and **holds its last value while parked** — GPS course is pure noise at rest, and a real compass keeps its reading when you stop.
- `0xFFFF` (not available) until the first movement after startup.
- Spec 6.34.2 payload: 1/128° bearing, zero calibration offset, status = calibrated.
- 1 Hz alongside the GPS frames; `COACHIQ_TIME_SYNC__SEND_COMPASS=false` disables.

5 new tests; 127 pass in the touched suites. Wire verification after deploy: `19FFA0F9` frames, bearing NA while parked (no movement since boot), then real heading on the next drive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)