### PR TITLE
fix(auth): survive token refresh races so sessions actually persist

### DIFF
--- a/frontend/src/contexts/auth-context.tsx
+++ b/frontend/src/contexts/auth-context.tsx
@@ -32,7 +32,7 @@ import {
 } from '@/lib/token-storage';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import type { ReactNode } from 'react';
-import { createContext, useContext, useEffect, useMemo } from 'react';
+import { createContext, useContext, useEffect, useMemo, useState } from 'react';
 
 interface AuthContextType {
   // Current state
@@ -218,10 +218,17 @@ export function AuthProvider({ children }: AuthProviderProps) {
     mutationFn: getAdminCredentials,
   });
 
+  // Session restore gate: while a stored session may still be revived (token
+  // refresh in flight during initializeTokenStorage), AuthGuard must not
+  // treat "no valid user yet" as unauthenticated and bounce to /login.
+  const [restoringSession, setRestoringSession] = useState(true);
+
   // Initialize token storage and set up refresh callbacks on mount
   useEffect(() => {
-    // Initialize token storage
-    void initializeTokenStorage();
+    // Initialize token storage; this awaits an immediate token refresh when
+    // the stored access token is stale, so clearing the gate afterwards means
+    // the session is either revived or genuinely dead.
+    void initializeTokenStorage().finally(() => setRestoringSession(false));
 
     // Set up refresh callbacks
     setRefreshCallbacks({
@@ -253,7 +260,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
     };
   }, [queryClient]);
 
-  const isLoading = statusLoading || userLoading;
+  const isLoading = statusLoading || userLoading || restoringSession;
 
   const contextValue: AuthContextType = useMemo(() => ({
     // Current state

--- a/frontend/src/lib/__tests__/token-storage.test.ts
+++ b/frontend/src/lib/__tests__/token-storage.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Tests for the token refresh lifecycle: coalescing of concurrent refreshes
+ * and survival of the server's refresh-token rotation race.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { RefreshTokenResponse } from '@/api/types'
+
+const refreshTokenAPI = vi.fn<(token: string) => Promise<RefreshTokenResponse>>()
+
+vi.mock('@/api/endpoints', () => ({
+  refreshToken: (token: string) => refreshTokenAPI(token),
+  revokeRefreshToken: vi.fn().mockResolvedValue(undefined),
+  getAuthStatus: vi.fn().mockResolvedValue({ enabled: true, mode: 'multi' }),
+}))
+
+// Import AFTER the mock so the module under test binds to the mocked API.
+const { tokenStorage } = await import('@/lib/token-storage')
+
+function seedTokens({
+  accessExpired = true,
+  refreshToken = 'refresh-original',
+}: { accessExpired?: boolean; refreshToken?: string } = {}) {
+  const now = Date.now()
+  localStorage.setItem('auth_token', 'access-original')
+  localStorage.setItem('refresh_token', refreshToken)
+  localStorage.setItem('token_expiry', String(accessExpired ? now - 1_000 : now + 600_000))
+  localStorage.setItem('refresh_token_expiry', String(now + 7 * 24 * 3_600_000))
+}
+
+function refreshResponse(suffix: string): RefreshTokenResponse {
+  return {
+    access_token: `access-${suffix}`,
+    refresh_token: `refresh-${suffix}`,
+    token_type: 'bearer',
+    expires_in: 900,
+    refresh_expires_in: 30 * 24 * 3600,
+  } as RefreshTokenResponse
+}
+
+describe('tokenStorage.attemptTokenRefresh', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    refreshTokenAPI.mockReset()
+    tokenStorage.setRefreshCallbacks({})
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+    tokenStorage.cleanup()
+  })
+
+  it('coalesces concurrent callers onto a single refresh request', async () => {
+    seedTokens()
+    let resolveRefresh!: (value: RefreshTokenResponse) => void
+    refreshTokenAPI.mockImplementation(
+      () => new Promise((resolve) => { resolveRefresh = resolve })
+    )
+
+    // Simulates page load: request-time refresh, boot init, and the SSE 401
+    // handler all firing together.
+    const first = tokenStorage.attemptTokenRefresh()
+    const second = tokenStorage.attemptTokenRefresh()
+    const third = tokenStorage.attemptTokenRefresh()
+
+    resolveRefresh(refreshResponse('rotated'))
+    const results = await Promise.all([first, second, third])
+
+    expect(results).toEqual([true, true, true])
+    expect(refreshTokenAPI).toHaveBeenCalledTimes(1)
+    expect(tokenStorage.getAccessToken()).toBe('access-rotated')
+  })
+
+  it('starts a new refresh after the previous one settles', async () => {
+    seedTokens()
+    refreshTokenAPI.mockResolvedValue(refreshResponse('one'))
+    await tokenStorage.attemptTokenRefresh()
+
+    // Force the freshly stored access token to look stale again.
+    localStorage.setItem('token_expiry', String(Date.now() - 1_000))
+    refreshTokenAPI.mockResolvedValue(refreshResponse('two'))
+    await tokenStorage.attemptTokenRefresh()
+
+    expect(refreshTokenAPI).toHaveBeenCalledTimes(2)
+    expect(tokenStorage.getAccessToken()).toBe('access-two')
+  })
+
+  it('adopts tokens rotated by another tab instead of killing the session', async () => {
+    seedTokens()
+    const onTokenExpired = vi.fn()
+    tokenStorage.setRefreshCallbacks({ onTokenExpired })
+
+    refreshTokenAPI.mockImplementation(() => {
+      // While our request is in flight, "another tab" wins the rotation race:
+      // it stores the rotated pair, and the server rejects our now-revoked
+      // token with a 4xx.
+      const now = Date.now()
+      localStorage.setItem('auth_token', 'access-winner')
+      localStorage.setItem('refresh_token', 'refresh-winner')
+      localStorage.setItem('token_expiry', String(now + 600_000))
+      localStorage.setItem('refresh_token_expiry', String(now + 7 * 24 * 3_600_000))
+      const error = new Error('Refresh token has been revoked') as Error & { status: number }
+      error.status = 401
+      return Promise.reject(error)
+    })
+
+    const result = await tokenStorage.attemptTokenRefresh()
+
+    expect(result).toBe(true)
+    expect(onTokenExpired).not.toHaveBeenCalled()
+    expect(tokenStorage.getAccessToken()).toBe('access-winner')
+    expect(tokenStorage.getRefreshToken()).toBe('refresh-winner')
+  })
+
+  it('signals expiry when the refresh token is genuinely dead', async () => {
+    seedTokens()
+    const onTokenExpired = vi.fn()
+    tokenStorage.setRefreshCallbacks({ onTokenExpired })
+
+    const error = new Error('Refresh token has been revoked') as Error & { status: number }
+    error.status = 401
+    refreshTokenAPI.mockRejectedValue(error)
+
+    const result = await tokenStorage.attemptTokenRefresh()
+
+    expect(result).toBe(false)
+    expect(onTokenExpired).toHaveBeenCalled()
+  })
+})

--- a/frontend/src/lib/token-storage.ts
+++ b/frontend/src/lib/token-storage.ts
@@ -45,7 +45,7 @@ export interface TokenRefreshCallbacks {
 class TokenStorageManager {
   private refreshTimeout: NodeJS.Timeout | null = null
   private refreshCallbacks: TokenRefreshCallbacks = {}
-  private isRefreshing = false
+  private refreshPromise: Promise<boolean> | null = null
   private authEnabled: boolean | null = null
   private refreshRetryCount = 0
 
@@ -177,13 +177,24 @@ class TokenStorageManager {
   }
 
   /**
-   * Attempt to refresh the access token
+   * Attempt to refresh the access token.
+   *
+   * Coalesces concurrent callers onto one in-flight refresh: the request-time
+   * refresh (client.ts), the scheduled timer, the SSE client's 401 handler,
+   * and app boot can all fire together on page load. The old implementation
+   * returned false to whoever lost that race, so their request went out with
+   * the stale token, got a 401, and AuthGuard bounced the user to /login on
+   * nearly every visit. Awaiting the shared promise means every caller
+   * proceeds only once the fresh token is actually stored.
    */
   async attemptTokenRefresh(): Promise<boolean> {
-    if (this.isRefreshing) {
-      return false // Already refreshing
-    }
+    this.refreshPromise ??= this.performTokenRefresh().finally(() => {
+      this.refreshPromise = null
+    })
+    return this.refreshPromise
+  }
 
+  private async performTokenRefresh(): Promise<boolean> {
     // Skip refresh if auth is disabled
     if (this.authEnabled === false) {
       return false
@@ -194,8 +205,6 @@ class TokenStorageManager {
       this.refreshCallbacks.onTokenExpired?.()
       return false
     }
-
-    this.isRefreshing = true
 
     try {
       const response: RefreshTokenResponse = await refreshTokenAPI(tokenData.refreshToken)
@@ -213,11 +222,25 @@ class TokenStorageManager {
         this.authEnabled = false
         return false
       }
+      // Rotation race: the server rotates AND revokes the refresh token on
+      // every use, so if another tab (or PWA window) refreshed first, the
+      // token this call sent is already revoked — a 4xx here does NOT mean
+      // the session is dead. If localStorage now holds a different, live
+      // token pair (stored by the winner), adopt it instead of wiping the
+      // session and forcing a re-login.
+      const storedRefreshToken = this.getRefreshToken()
+      if (
+        storedRefreshToken &&
+        storedRefreshToken !== tokenData.refreshToken &&
+        this.isAccessTokenValid()
+      ) {
+        console.warn('Token refresh superseded by another tab; adopting its tokens')
+        this.refreshRetryCount = 0
+        return true
+      }
       console.error('Token refresh failed:', error)
       this.handleRefreshFailure(error as Error)
       return false
-    } finally {
-      this.isRefreshing = false
     }
   }
 
@@ -243,8 +266,9 @@ class TokenStorageManager {
 
     if (canRetry) {
       this.refreshRetryCount += 1
+      // By the time this fires, the failed attempt's shared promise has been
+      // cleared, so this starts a fresh coalesced refresh.
       setTimeout(() => {
-        this.isRefreshing = false
         void this.attemptTokenRefresh()
       }, REFRESH_RETRY_DELAY_MS)
     } else {
@@ -295,8 +319,6 @@ class TokenStorageManager {
       clearTimeout(this.refreshTimeout)
       this.refreshTimeout = null
     }
-
-    this.isRefreshing = false
   }
 
   /**
@@ -324,8 +346,10 @@ class TokenStorageManager {
       // Check if tokens are still valid
       if (this.isRefreshTokenValid()) {
         if (this.needsRefresh()) {
-          // Immediately refresh if needed
-          void this.attemptTokenRefresh()
+          // Refresh now and make callers (the auth provider's session-restore
+          // gate) wait for it, so AuthGuard can't bounce to /login while the
+          // stored session is still being revived.
+          await this.attemptTokenRefresh()
         } else {
           // Schedule refresh for later
           this.scheduleTokenRefresh(tokenData)


### PR DESCRIPTION
## Summary

Fixes "I have to log in every time I open the page." Sessions were already designed to persist — PocketID login issues a 15-minute access token plus a **7-day DB-backed refresh token**, both in localStorage — but two frontend defects killed the session on nearly every visit:

### 1. Refresh calls raced and the losers proceeded with a stale token
`attemptTokenRefresh()` returned `false` immediately when a refresh was already in flight. On page load three callers fire together: the request-time refresh (`ensureFreshAccessToken`), app boot (`initializeTokenStorage`), and the SSE client's 401 handler. Every loser sent its request with the expired access token → `/api/auth/me` 401 (configured `retry: false`) → `isAuthenticated` false → AuthGuard bounced to `/login`.

**Fix:** refreshes coalesce onto one shared promise that every caller awaits; requests only proceed once the fresh token is stored.

### 2. The rotation race nuked the session irrecoverably
The server **rotates and revokes** the refresh token on every use (`manager.py: refresh_access_token`). When two tabs/PWA windows raced, the loser's now-revoked token got a 4xx, which `handleRefreshFailure` treated as a dead session — `onTokenExpired` then **cleared the winner's freshly rotated tokens** from localStorage. Genuine logout, every time the race fired.

**Fix:** on refresh failure, re-read localStorage first; if another tab already stored a rotated, live token pair, adopt it instead of clearing.

### Plus a session-restore gate
`initializeTokenStorage()` now awaits its boot-time refresh, and `AuthProvider` exposes that window as loading, so AuthGuard structurally cannot redirect to `/login` while a stored session is still being revived. (The login page already bounces back once `isAuthenticated` flips.)

### Tests
New `token-storage.test.ts`: concurrent-caller coalescing (one API call), sequential refreshes still work, cross-tab rotation adoption, and genuine-expiry still signals `onTokenExpired`.

Deployment note: pairs with a nix-config bump setting `COACHIQ_AUTH__REFRESH_TOKEN_EXPIRE_DAYS=30` so sessions last a month between visits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)