### PR TITLE
feat(discovery): passive topology + coach node directory (friendly names)

### DIFF
--- a/backend/services/can/can_bus_service.py
+++ b/backend/services/can/can_bus_service.py
@@ -696,6 +696,16 @@ class CANBusService(GuardrailParticipant):
             except Exception as e:
                 logger.debug("Failed to send to protocol analyzer: %s", e)
 
+            # Feed passive device discovery so the network topology reflects
+            # every source address seen on the bus, not just actively polled
+            # or J1939-identified devices.
+            try:
+                discovery_service = self._device_discovery_service
+                if discovery_service:
+                    discovery_service.process_can_message(message)
+            except Exception as e:
+                logger.debug("Failed to send to device discovery: %s", e)
+
             # Send to message filter if available (same running-flag gate as
             # the analyzer above).
             try:

--- a/backend/services/discovery/device_discovery_service.py
+++ b/backend/services/discovery/device_discovery_service.py
@@ -34,6 +34,8 @@ class DeviceInfo:
 
     source_address: int
     protocol: str
+    friendly_name: str | None = None
+    notes: str | None = None
     device_type: str | None = None
     manufacturer: str | None = None
     product_id: str | None = None
@@ -98,6 +100,18 @@ class DeviceDiscoveryService:
         self.active_polls: dict[str, PollRequest] = {}
         self.poll_schedules: dict[str, dict[str, Any]] = {}
         self.discovery_active = False
+
+        # Our own transmit source address (frames from it are not "devices").
+        try:
+            self._own_source_address = int(
+                getattr(self.config, "controller_source_addr", "0xF9"), 16
+            )
+        except (TypeError, ValueError):
+            self._own_source_address = 0xF9
+
+        # Coach-specific node directory: friendly names for source addresses,
+        # from the coach mapping's optional top-level `nodes:` section.
+        self._node_directory = self._load_node_directory()
 
         # Configuration from feature flags
         self.enable_device_polling = getattr(self.config, "device_discovery", {}).get(
@@ -175,6 +189,46 @@ class DeviceDiscoveryService:
             f"DeviceDiscoveryService initialized with polling_interval={self.polling_interval}s"
         )
 
+    def _load_node_directory(self) -> dict[int, dict[str, Any]]:
+        """Load friendly node names from the coach mapping's `nodes:` section.
+
+        Keys are source addresses ("0x75" or decimal); values carry
+        `name`/`device_type`/`notes`. Missing file or section is fine.
+        """
+        try:
+            import yaml
+
+            from backend.integrations.rvc.config_loader import get_default_paths
+
+            _, mapping_path = get_default_paths()
+            with open(mapping_path, encoding="utf-8") as handle:
+                mapping = yaml.safe_load(handle) or {}
+            raw_nodes = mapping.get("nodes") or {}
+            directory: dict[int, dict[str, Any]] = {}
+            for key, value in raw_nodes.items():
+                try:
+                    address = int(str(key), 0)
+                except (TypeError, ValueError):
+                    logger.warning("Ignoring unparseable node address %r in coach mapping", key)
+                    continue
+                directory[address] = value if isinstance(value, dict) else {"name": str(value)}
+            if directory:
+                logger.info("Loaded %d coach node names from %s", len(directory), mapping_path)
+            return directory
+        except Exception as e:
+            logger.warning("Could not load coach node directory: %s", e)
+            return {}
+
+    def _apply_node_directory(self, device: DeviceInfo) -> None:
+        """Stamp coach-directory metadata onto a device entry."""
+        entry = self._node_directory.get(device.source_address)
+        if not entry:
+            return
+        device.friendly_name = entry.get("name") or device.friendly_name
+        device.notes = entry.get("notes") or device.notes
+        if entry.get("device_type"):
+            device.device_type = entry["device_type"]
+
     def record_component_identification(
         self,
         source_address: int,
@@ -186,6 +240,7 @@ class DeviceDiscoveryService:
         device = self.topology.devices.get(source_address)
         if device is None:
             device = DeviceInfo(source_address=source_address, protocol="j1939", first_seen=now)
+            self._apply_node_directory(device)
             self.topology.devices[source_address] = device
         elif device.protocol == "unknown":
             device.protocol = "j1939"
@@ -1201,6 +1256,8 @@ class DeviceDiscoveryService:
             protocol_groups[device.protocol].append(
                 {
                     "source_address": device.source_address,
+                    "friendly_name": device.friendly_name,
+                    "notes": device.notes,
                     "device_type": device.device_type,
                     "manufacturer": device.manufacturer,
                     "product_id": device.product_id,
@@ -1413,12 +1470,14 @@ class DeviceDiscoveryService:
             message: Received CAN message
         """
         try:
-            # Extract source address and PGN from CAN ID
+            # Extract source address and DGN from the 29-bit CAN ID. RV-C
+            # DGNs are 17 bits — the previous 16-bit mask truncated them, so
+            # the device-type inference below could never match.
             source_address = message.arbitration_id & 0xFF
-            pgn = (message.arbitration_id >> 8) & 0xFFFF
+            pgn = (message.arbitration_id >> 8) & 0x3FFFF
 
             # Skip messages from our own source address
-            if source_address == 0xE0:
+            if source_address == self._own_source_address:
                 return
 
             # Check if this is a response to one of our polls
@@ -1500,11 +1559,13 @@ class DeviceDiscoveryService:
         if source_address not in self.topology.devices:
             # Use detected protocol or default to 'unknown'
             protocol = detected_protocol or "unknown"
-            self.topology.devices[source_address] = DeviceInfo(
+            new_device = DeviceInfo(
                 source_address=source_address,
                 protocol=protocol,
                 first_seen=now,
             )
+            self._apply_node_directory(new_device)
+            self.topology.devices[source_address] = new_device
         else:
             # Update protocol if we have better detection
             device = self.topology.devices[source_address]

--- a/config/2021_Entegra_Aspire_44R.yml
+++ b/config/2021_Entegra_Aspire_44R.yml
@@ -29,6 +29,64 @@ dgn_pairs:
   "1FEF9": "1FFE2" # Thermostat command -> thermostat status
   "1FFF6": "1FFF7" # Water heater command -> water heater status (RV-C 6.9.3 ACK)
 
+# RV-C node directory: friendly names per source address, shown on the
+# Network Map page. Identified from a live house-bus DGN census (2026-07-07):
+# each entry notes the characteristic DGNs that pinned it down.
+nodes:
+  "0x4F":
+    name: "Transfer Switch (ATS)"
+    device_type: ats
+    notes: "Broadcasts ATS_AC_STATUS_1-4; reads Quattro output as 'shore' (Victron sits upstream)"
+  "0x75":
+    name: "Aspire Head Unit"
+    device_type: infotainment
+    notes: "Dash infotainment: GPS/compass/time source + steering-wheel media over RV-C. Clock wedged Oct 2025-Jul 2026; fixed by power cycle."
+  "0x8E":
+    name: "Lighting Module A"
+    device_type: dimmer
+    notes: "DC_DIMMER_STATUS_3 broadcaster (Firefly output module)"
+  "0x8F":
+    name: "Lighting Module B"
+    device_type: dimmer
+    notes: "DC_DIMMER_STATUS_3 broadcaster (Firefly output module, busiest)"
+  "0x94":
+    name: "Firefly Module (0x94)"
+    notes: "DM_RV heartbeat only in census; function TBD"
+  "0x95":
+    name: "Switch Panel"
+    device_type: switch_panel
+    notes: "Sends DC_DIMMER_COMMAND_2 - a physical control panel"
+  "0x96":
+    name: "A/C Zone Controller 1"
+    device_type: air_conditioner
+    notes: "AIR_CONDITIONER_STATUS broadcaster"
+  "0x97":
+    name: "A/C Zone Controller 2"
+    device_type: air_conditioner
+    notes: "AIR_CONDITIONER_STATUS broadcaster"
+  "0x98":
+    name: "A/C Zone Controller 3"
+    device_type: air_conditioner
+    notes: "AIR_CONDITIONER_STATUS broadcaster"
+  "0x99":
+    name: "A/C Zone Controller 4"
+    device_type: air_conditioner
+    notes: "AIR_CONDITIONER_STATUS broadcaster"
+  "0x9A":
+    name: "Firefly Module (0x9A)"
+    notes: "DM_RV heartbeat only in census; function TBD"
+  "0x9B":
+    name: "Firefly Module (0x9B)"
+    notes: "DM_RV heartbeat only in census; function TBD"
+  "0x9C":
+    name: "Firefly System Controller"
+    device_type: multiplex_controller
+    notes: "Vegatouch/G12 master: coach time master, Aqua-Hot commands, bulk of house traffic"
+  "0xF9":
+    name: "CoachIQ (nixpi)"
+    device_type: gateway
+    notes: "This system: time master, GPS/compass broadcast, entity gateway"
+
 defaults:
   interface: house # Logical CAN interface; resolved via COACHIQ_CAN__INTERFACE_MAPPINGS
   protocol: rvc

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1205,6 +1205,8 @@ export interface PerformanceAnalyticsStats {
 export interface DeviceInfo {
   source_address: number;
   protocol: string;
+  friendly_name?: string | null;
+  notes?: string | null;
   device_type?: string;
   status: "discovered" | "online" | "offline" | "error";
   last_seen: number;

--- a/frontend/src/components/network/DeviceDiscoveryTable.tsx
+++ b/frontend/src/components/network/DeviceDiscoveryTable.tsx
@@ -30,6 +30,8 @@ import { useMutation, useQueryClient } from "@tanstack/react-query"
 
 interface DeviceTableEntry {
   address: string
+  name: string
+  notes: string | null
   protocol: string
   deviceType: string
   status: "online" | "offline" | "warning" | "error"
@@ -156,6 +158,8 @@ export function DeviceDiscoveryTable({
 
         entries.push({
           address: hexAddress,
+          name: device.friendly_name || `Unknown (${hexAddress})`,
+          notes: device.notes ?? null,
           protocol: device.protocol || protocol,
           deviceType: device.device_type || "Unknown",
           status,
@@ -180,6 +184,7 @@ export function DeviceDiscoveryTable({
       const term = searchTerm.toLowerCase()
       filtered = filtered.filter(entry =>
         entry.address.toLowerCase().includes(term) ||
+        entry.name.toLowerCase().includes(term) ||
         entry.protocol.toLowerCase().includes(term) ||
         entry.deviceType.toLowerCase().includes(term)
       )
@@ -237,8 +242,9 @@ export function DeviceDiscoveryTable({
   // Export device list as CSV
   const handleExport = () => {
     const csvContent = [
-      ["Address", "Protocol", "Device Type", "Status", "Last Seen", "Response Time"].join(","),
+      ["Device", "Address", "Protocol", "Device Type", "Status", "Last Seen", "Response Time"].join(","),
       ...filteredAndSortedEntries.map(entry => [
+        entry.name,
         entry.address,
         entry.protocol,
         entry.deviceType,
@@ -389,6 +395,12 @@ export function DeviceDiscoveryTable({
                 <TableRow>
                   <TableHead
                     className="cursor-pointer hover:bg-muted/50"
+                    onClick={() => handleSort("name")}
+                  >
+                    Device {sortField === "name" && (sortDirection === "asc" ? "↑" : "↓")}
+                  </TableHead>
+                  <TableHead
+                    className="cursor-pointer hover:bg-muted/50"
                     onClick={() => handleSort("address")}
                   >
                     Address {sortField === "address" && (sortDirection === "asc" ? "↑" : "↓")}
@@ -429,6 +441,9 @@ export function DeviceDiscoveryTable({
               <TableBody>
                 {filteredAndSortedEntries.map((entry) => (
                   <TableRow key={entry.address}>
+                    <TableCell className="font-medium" title={entry.notes ?? undefined}>
+                      {entry.name}
+                    </TableCell>
                     <TableCell className="font-mono text-sm">{entry.address}</TableCell>
                     <TableCell>
                       <Badge variant="outline" className="capitalize">

--- a/tests/services/test_device_discovery_names.py
+++ b/tests/services/test_device_discovery_names.py
@@ -1,0 +1,87 @@
+"""Tests for passive discovery and the coach node directory (friendly names)."""
+
+from unittest.mock import Mock, patch
+
+import can
+
+from backend.services.discovery.device_discovery_service import DeviceDiscoveryService
+
+NODES = {
+    0x75: {"name": "Aspire Head Unit", "device_type": "infotainment", "notes": "dash"},
+    0x4F: {"name": "Transfer Switch (ATS)", "device_type": "ats"},
+}
+
+
+def make_service() -> DeviceDiscoveryService:
+    config = Mock()
+    config.device_discovery = {}
+    config.rvc_enabled = True
+    config.j1939 = None
+    config.j1939_enabled = False
+    config.controller_source_addr = "0xF9"
+    with patch.object(DeviceDiscoveryService, "_load_node_directory", return_value=dict(NODES)):
+        return DeviceDiscoveryService(can_facade=None, config=config)
+
+
+def frame(arbitration_id: int, data: bytes = bytes(8)) -> can.Message:
+    return can.Message(arbitration_id=arbitration_id, data=data, is_extended_id=True)
+
+
+class TestPassiveDiscovery:
+    def test_message_creates_named_device(self):
+        service = make_service()
+        # DATE_TIME-ish frame from the head unit.
+        service.process_can_message(frame(0x19FFFE75))
+        device = service.topology.devices[0x75]
+        assert device.friendly_name == "Aspire Head Unit"
+        assert device.device_type == "infotainment"
+        assert device.notes == "dash"
+        assert device.status == "online"
+
+    def test_unnamed_address_still_tracked(self):
+        service = make_service()
+        service.process_can_message(frame(0x19FEDA8E))
+        device = service.topology.devices[0x8E]
+        assert device.friendly_name is None
+        # 17-bit DGN mask regression: 1FEDA (DC_DIMMER_STATUS_3) classifies
+        # the device as a light; the old 16-bit mask made this unreachable.
+        assert device.device_type == "light"
+
+    def test_own_source_address_skipped(self):
+        service = make_service()
+        service.process_can_message(frame(0x19FFFFF9))
+        assert 0xF9 not in service.topology.devices
+
+    def test_topology_response_carries_names(self):
+        import asyncio
+
+        service = make_service()
+        service.process_can_message(frame(0x0DFFAD4F))  # ATS_AC_STATUS_1 from the ATS
+        topology = asyncio.get_event_loop().run_until_complete(service.get_network_topology())
+        devices = [d for group in topology["devices"].values() for d in group]
+        ats = next(d for d in devices if d["source_address"] == 0x4F)
+        assert ats["friendly_name"] == "Transfer Switch (ATS)"
+
+
+class TestNodeDirectoryParsing:
+    def test_hex_and_decimal_keys(self):
+        config = Mock()
+        config.device_discovery = {}
+        config.rvc_enabled = True
+        config.j1939 = None
+        config.j1939_enabled = False
+        config.controller_source_addr = "0xF9"
+        yaml_content = {"nodes": {"0x75": {"name": "Head Unit"}, "156": "Firefly", "bad": {}}}
+        with (
+            patch(
+                "backend.integrations.rvc.config_loader.get_default_paths",
+                return_value=("spec", "mapping.yml"),
+            ),
+            patch("builtins.open"),
+            patch("yaml.safe_load", return_value=yaml_content),
+        ):
+            service = DeviceDiscoveryService(can_facade=None, config=config)
+        assert service._node_directory[0x75] == {"name": "Head Unit"}
+        assert service._node_directory[156] == {"name": "Firefly"}
+        # Unparseable keys are skipped per-entry, never failing the rest.
+        assert len(service._node_directory) == 2


### PR DESCRIPTION
## Summary

Makes the Network Map show **actual coach objects instead of bare addresses** — and makes it show anything at all, really.

### The gap
`DeviceDiscoveryService.process_can_message` — the passive observer whose docstring says it *'should be called by the CAN message handler'* — had **zero callers**. The topology only filled from active polling and rare J1939 component-ID frames, so the page was mostly empty. Two more latent bugs inside it: a 16-bit PGN mask (RV-C DGNs are 17-bit, so its device-type inference never matched), and 'skip our own address' hardcoded to `0xE0` while we transmit from `0xF9`.

### Changes
- **Passive discovery wired**: every RX frame updates the topology (address, protocol, device-type inference, last-seen).
- **Coach node directory**: new optional `nodes:` section in the coach mapping YAML (name/device_type/notes per source address), loaded by the discovery service and stamped onto devices.
- **Seeded for the Aspire from a live DGN census** — every named entry cites the characteristic DGNs that identified it: the ATS (`0x4F`), the Aspire head unit (`0x75`), two lighting modules, a switch panel, **four A/C zone controllers** (`0x96–0x99`), the Firefly system controller (`0x9C`), and CoachIQ itself.
- **UI**: Device Discovery table gains a leading Device-name column (notes on hover), name search, CSV column.

### Verification
- 5 new tests incl. a 17-bit-mask regression test; coach mapping still loads all 43 entities with the new section; 110 pass in touched suites; tsc + eslint net-clean (error count reduced by 1).
- Local render check done (empty-state — no CAN on dev box); the real verification is post-deploy on nixpi where the bus census guarantees ~14 populated, named rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)