### PR TITLE
feat(victron): manual generator start/stop control

### DIFF
--- a/backend/api/routers/victron.py
+++ b/backend/api/routers/victron.py
@@ -47,6 +47,12 @@ class InputCurrentLimitRequest(BaseModel):
     amps: float = Field(..., description="Input current limit in amps", ge=0)
 
 
+class GeneratorManualRequest(BaseModel):
+    """Request a manual generator start or stop."""
+
+    run: bool = Field(..., description="True starts the generator, False stops it")
+
+
 def _require_victron_service(service: Any) -> Any:
     if service is None:
         raise HTTPException(
@@ -92,6 +98,32 @@ async def set_inverter_mode(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc)
         ) from exc
     logger.info("Victron inverter mode set: %s", result)
+    return {"success": True, **result}
+
+
+@router.post(
+    "/generator/manual",
+    summary="Manual generator start/stop",
+    description=(
+        "Request a manual generator run via the Cerbo's genset controller "
+        "(equivalent to VRM's manual start; the Cerbo performs the crank/stop "
+        "sequence and its own stop conditions still apply)"
+    ),
+    dependencies=[Depends(get_admin_user)],
+)
+async def set_generator_manual(
+    request: GeneratorManualRequest,
+    victron_service: Annotated[Any, Depends(get_optional_victron_service)],
+) -> dict[str, Any]:
+    """Command a manual generator start or stop over MQTT."""
+    service = _require_victron_service(victron_service)
+    try:
+        result = await service.set_generator_manual(request.run)
+    except RuntimeError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc)
+        ) from exc
+    logger.info("Victron generator manual request: %s", result)
     return {"success": True, **result}
 
 

--- a/backend/services/victron/victron_service.py
+++ b/backend/services/victron/victron_service.py
@@ -286,11 +286,25 @@ class VictronService:
         await self._client.write_value("vebus", instance, "Ac/ActiveIn/CurrentLimit", float(amps))
         return {"input_current_limit": float(amps)}
 
+    async def set_generator_manual(self, run: bool) -> dict[str, Any]:
+        """Request a manual generator start (True) or stop (False).
+
+        Writes the Cerbo's dbus-generator /ManualStart — the same control the
+        VRM 'manual start' button uses. The Cerbo's genset logic performs the
+        actual crank/stop sequence and its own stop conditions still apply.
+        """
+        instance = self._instance_for("generator")
+        await self._client.write_value("generator", instance, "ManualStart", 1 if run else 0)
+        return {"manual_start": run}
+
     def _vebus_instance(self) -> str:
-        for service_type, instance in self._instance_bindings:
-            if service_type == "vebus":
+        return self._instance_for("vebus")
+
+    def _instance_for(self, service_type: str) -> str:
+        for bound_type, instance in self._instance_bindings:
+            if bound_type == service_type:
                 return instance
-        msg = "No VE.Bus device discovered yet; cannot send Victron command"
+        msg = f"No Victron {service_type} device discovered yet; cannot send command"
         raise RuntimeError(msg)
 
     # ------------------------------------------------------------------

--- a/frontend/src/api/victron.ts
+++ b/frontend/src/api/victron.ts
@@ -42,3 +42,9 @@ export async function setInputCurrentLimit(
 ): Promise<{ success: boolean; input_current_limit: number }> {
   return apiPost('/api/victron/inverter/input-current-limit', { amps });
 }
+
+export async function setGeneratorManual(
+  run: boolean
+): Promise<{ success: boolean; manual_start: boolean }> {
+  return apiPost('/api/victron/generator/manual', { run });
+}

--- a/frontend/src/pages/power.tsx
+++ b/frontend/src/pages/power.tsx
@@ -15,6 +15,7 @@ import { useState } from "react"
 import type { EntitySchema } from "@/api/types/domains"
 import {
   fetchVictronStatus,
+  setGeneratorManual,
   setInputCurrentLimit,
   setInverterMode,
   type InverterMode,
@@ -291,12 +292,115 @@ function ShoreLimitCard({ inverter, controlsDisabled }: Readonly<IControlsProps>
   )
 }
 
+const GENERATOR_RUNNING_STATES = new Set(["running", "warm_up"])
+
+function generatorConfirmLabel(pending: boolean, confirming: "start" | "stop" | null): string {
+  if (pending) return "Sending…"
+  return confirming === "start" ? "Start Generator" : "Stop Generator"
+}
+
+function GeneratorControlCard({
+  generator,
+  controlsDisabled,
+}: Readonly<{ generator: EntitySchema | undefined; controlsDisabled: boolean }>) {
+  const queryClient = useQueryClient()
+  const [confirming, setConfirming] = useState<"start" | "stop" | null>(null)
+
+  const state = generator?.state ?? {}
+  const statusLabel = typeof state.status === "string" ? state.status.replace(/_/g, " ") : "unknown"
+  const isRunning = GENERATOR_RUNNING_STATES.has(String(state.status))
+
+  const mutation = useMutation({
+    mutationFn: (run: boolean) => setGeneratorManual(run),
+    onSuccess: (result) => {
+      toast({
+        title: result.manual_start
+          ? "Generator start requested"
+          : "Generator stop requested",
+        description: "The Cerbo's genset controller is handling the sequence.",
+      })
+      void queryClient.invalidateQueries({ queryKey: entitiesQueryKeys.all })
+    },
+    onError: (error: Error) => {
+      toast({
+        variant: "destructive",
+        title: "Generator command failed",
+        description: error.message,
+      })
+    },
+    onSettled: () => setConfirming(null),
+  })
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="flex items-center justify-between text-base">
+          Generator
+          <Badge variant="secondary" className="capitalize">
+            {statusLabel}
+          </Badge>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <p className="text-xs text-muted-foreground">
+          Manual run via the Cerbo&apos;s genset controller — its own stop conditions
+          (autostart rules, quiet hours) still apply.
+        </p>
+        <div className="grid grid-cols-2 gap-2">
+          <Button
+            disabled={controlsDisabled || mutation.isPending || isRunning}
+            onClick={() => setConfirming("start")}
+          >
+            Start
+          </Button>
+          <Button
+            variant="outline"
+            disabled={controlsDisabled || mutation.isPending || !isRunning}
+            onClick={() => setConfirming("stop")}
+          >
+            Stop
+          </Button>
+        </div>
+      </CardContent>
+
+      <Dialog open={confirming !== null} onOpenChange={(open) => !open && setConfirming(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <IconAlertTriangle className="size-5 text-amber-500" aria-hidden />
+              {confirming === "start" ? "Start the generator?" : "Stop the generator?"}
+            </DialogTitle>
+            <DialogDescription>
+              {confirming === "start"
+                ? "The generator will crank and start producing AC power. Make sure nothing is blocking the exhaust and the coach is clear to run it."
+                : "The generator will shut down. AC loads fall back to shore power or the inverter."}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setConfirming(null)}>
+              Cancel
+            </Button>
+            <Button
+              variant={confirming === "start" ? "default" : "destructive"}
+              disabled={mutation.isPending}
+              onClick={() => mutation.mutate(confirming === "start")}
+            >
+              {generatorConfirmLabel(mutation.isPending, confirming)}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </Card>
+  )
+}
+
 export default function PowerPage() {
   const { data: victronStatus } = useVictronStatus()
   const { data: entityCollection } = useEntities({ page_size: 100 })
 
   const entities = entityCollection?.entities ?? []
   const inverter = entities.find((entity) => entity.device_type === "inverter_charger")
+  const generator = entities.find((entity) => entity.device_type === "generator")
 
   // Victron commands travel over the Cerbo's MQTT link (IP), independent of
   // the RV-C CAN bus — so gate on that link, not on coach CAN liveness.
@@ -315,9 +419,10 @@ export default function PowerPage() {
             Controls are disabled — the Cerbo GX is not reachable.
           </p>
         )}
-        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
           <InverterModeCard inverter={inverter} controlsDisabled={controlsDisabled} />
           <ShoreLimitCard inverter={inverter} controlsDisabled={controlsDisabled} />
+          <GeneratorControlCard generator={generator} controlsDisabled={controlsDisabled} />
         </div>
       </div>
     </div>

--- a/tests/services/test_victron_service.py
+++ b/tests/services/test_victron_service.py
@@ -246,7 +246,7 @@ class TestControlPath:
     async def test_set_inverter_mode_without_discovered_vebus(self):
         service, _, _, _ = make_service()
         service._client = FakeMqttClient()
-        with pytest.raises(RuntimeError, match="No VE.Bus device"):
+        with pytest.raises(RuntimeError, match="No Victron vebus device"):
             await service.set_inverter_mode("on")
 
     async def test_current_limit_validated_against_broker_range(self):
@@ -268,6 +268,33 @@ class TestControlPath:
         await service._handle_update(vebus_update("State", 3))
         with pytest.raises(ValueError, match="outside adjustable range"):
             await service.set_input_current_limit(150.0)
+
+
+class TestGeneratorControl:
+    async def test_manual_start_and_stop_write_manualstart(self):
+        service, _, _, _ = make_service()
+        service._client = FakeMqttClient()
+        await service._handle_update(
+            VictronUpdate(
+                portal_id=PORTAL,
+                service_type="generator",
+                instance="0",
+                path="State",
+                value=0,
+            )
+        )
+        assert await service.set_generator_manual(True) == {"manual_start": True}
+        assert await service.set_generator_manual(False) == {"manual_start": False}
+        assert service._client.writes == [
+            ("generator", "0", "ManualStart", 1),
+            ("generator", "0", "ManualStart", 0),
+        ]
+
+    async def test_manual_start_without_discovered_generator(self):
+        service, _, _, _ = make_service()
+        service._client = FakeMqttClient()
+        with pytest.raises(RuntimeError, match="No Victron generator device"):
+            await service.set_generator_manual(True)
 
 
 class TestHealth:


### PR DESCRIPTION
## Summary

Adds the generator to the Power page control surface — the last piece of hands-on power management. Uses the Cerbo genset controller's `ManualStart` (what VRM's manual-start button drives); the **Cerbo owns the actual crank/stop sequence** and its autostart rules and quiet-hours conditions still apply.

### Changes
- **Backend**: `VictronService.set_generator_manual(run)` → `W generator/<inst>/ManualStart`; admin-gated `POST /api/victron/generator/manual`.
- **Frontend**: Generator control card — Start/Stop, each behind a **confirmation dialog** naming the consequence ("the generator will crank and start producing AC power…"). Buttons gate on the live run state (Stop disabled while stopped, Start disabled while running) and on the Cerbo connection.

### Safety
Admin auth + Cerbo-link gating + explicit confirm dialog, same layered pattern as the inverter-mode control. This is a real engine start, so the dialog copy calls out exhaust/clearance.

### Verification
- Live against the Cerbo: card shows real genset state (Stopped, autostart Enabled, 338.9 h total), Start-confirm dialog opens and **cancels without sending** (did not start the actual generator from a preview).
- 16 Victron service tests pass; tsc + eslint clean.

### Deploy note
No new config — rides the existing `COACHIQ_VICTRON__ENABLED`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)