### PR TITLE
fix(frontend): stop SSE entity updates from fanning out into /entities refetch storms (429s)

### DIFF
--- a/frontend/src/contexts/__tests__/realtime-cache.test.ts
+++ b/frontend/src/contexts/__tests__/realtime-cache.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Tests for applyEntityUpdate — SSE entity updates must patch the query
+ * cache in place instead of invalidating collections, so a chatty CAN bus
+ * doesn't fan out into refetch storms that trip the backend rate limit.
+ */
+
+import { QueryClient } from '@tanstack/react-query'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import type { EntityCollectionSchema, EntitySchema } from '@/api/types/domains'
+import { applyEntityUpdate } from '../realtime-cache'
+import { entitiesQueryKeys } from '@/hooks/useEntities'
+
+function makeEntity(id: string, overrides: Partial<EntitySchema> = {}): EntitySchema {
+  return {
+    entity_id: id,
+    name: id,
+    device_type: 'climate',
+    protocol: 'rvc',
+    state: {},
+    area: null,
+    last_updated: '2026-07-08T00:00:00Z',
+    available: true,
+    ...overrides,
+  } as EntitySchema
+}
+
+function makeCollection(entities: EntitySchema[]): EntityCollectionSchema {
+  return {
+    entities,
+    total_count: entities.length,
+    page: 1,
+    page_size: 100,
+    has_next: false,
+  } as EntityCollectionSchema
+}
+
+describe('applyEntityUpdate', () => {
+  let client: QueryClient
+
+  beforeEach(() => {
+    client = new QueryClient()
+  })
+
+  it('writes the entity into its individual-entity cache entry', () => {
+    const updated = makeEntity('thermostat_1', { state: { temp: 72 } })
+    applyEntityUpdate(client, { entity_id: 'thermostat_1', entity_data: updated })
+
+    expect(client.getQueryData(entitiesQueryKeys.entity('thermostat_1'))).toEqual(updated)
+  })
+
+  it('patches the entity into every cached collection containing it', () => {
+    const stale = makeEntity('thermostat_1', { state: { temp: 68 } })
+    const other = makeEntity('thermostat_2')
+    const keyA = entitiesQueryKeys.collection({ device_type: 'climate' })
+    const keyB = entitiesQueryKeys.collection({ device_type: 'climate', page_size: 100 })
+    client.setQueryData(keyA, makeCollection([stale, other]))
+    client.setQueryData(keyB, makeCollection([stale]))
+
+    const updated = makeEntity('thermostat_1', { state: { temp: 72 } })
+    applyEntityUpdate(client, { entity_id: 'thermostat_1', entity_data: updated })
+
+    const collectionA = client.getQueryData<EntityCollectionSchema>(keyA)
+    expect(collectionA?.entities).toEqual([updated, other])
+    const collectionB = client.getQueryData<EntityCollectionSchema>(keyB)
+    expect(collectionB?.entities).toEqual([updated])
+  })
+
+  it('leaves collections that do not contain the entity untouched', () => {
+    const tanks = makeCollection([makeEntity('fresh_tank', { device_type: 'tank' })])
+    const key = entitiesQueryKeys.collection({ device_type: 'tank' })
+    client.setQueryData(key, tanks)
+    const before = client.getQueryState(key)?.dataUpdatedAt
+
+    applyEntityUpdate(client, {
+      entity_id: 'thermostat_1',
+      entity_data: makeEntity('thermostat_1'),
+    })
+
+    expect(client.getQueryData(key)).toBe(tanks)
+    expect(client.getQueryState(key)?.dataUpdatedAt).toBe(before)
+  })
+
+  it('does not mark any collection query as invalidated', () => {
+    const key = entitiesQueryKeys.collection({ device_type: 'climate' })
+    client.setQueryData(key, makeCollection([makeEntity('thermostat_1')]))
+
+    applyEntityUpdate(client, {
+      entity_id: 'thermostat_1',
+      entity_data: makeEntity('thermostat_1', { state: { temp: 75 } }),
+    })
+
+    expect(client.getQueryState(key)?.isInvalidated).toBe(false)
+  })
+})

--- a/frontend/src/contexts/realtime-cache.ts
+++ b/frontend/src/contexts/realtime-cache.ts
@@ -1,0 +1,42 @@
+/**
+ * Cache-patching helpers for SSE entity events.
+ *
+ * Kept out of realtime-provider.tsx so that file only exports components
+ * (react-refresh) and so the cache logic is unit-testable without React.
+ */
+
+import type { QueryClient } from '@tanstack/react-query'
+
+import type { EntityCollectionSchema, EntitySchema } from '@/api/types/domains'
+import { entitiesQueryKeys } from '@/hooks/useEntities'
+
+export interface IEntityUpdatePayload {
+  entity_id: string
+  entity_data: Record<string, unknown>
+}
+
+/**
+ * Apply an entity_update to the query cache without network traffic.
+ *
+ * Invalidating collections here is not an option: pages mount several
+ * collection queries at once (Climate has six), and entity updates arrive
+ * continuously from the CAN bus, so per-event invalidation fans out into
+ * enough GET /api/entities traffic to trip the backend rate limit (429s).
+ * Instead, patch the entity into every cached collection that contains it.
+ * Entities never enter or leave a collection on update — that only happens
+ * on entity_created, which still invalidates.
+ */
+export function applyEntityUpdate(client: QueryClient, payload: IEntityUpdatePayload): void {
+  const entity = payload.entity_data as EntitySchema
+  client.setQueryData(entitiesQueryKeys.entity(payload.entity_id), entity)
+  client.setQueriesData<EntityCollectionSchema>(
+    { queryKey: entitiesQueryKeys.collections() },
+    (collection) => {
+      if (!collection?.entities.some((e) => e.entity_id === payload.entity_id)) return undefined
+      return {
+        ...collection,
+        entities: collection.entities.map((e) => (e.entity_id === payload.entity_id ? entity : e)),
+      }
+    }
+  )
+}

--- a/frontend/src/contexts/realtime-provider.tsx
+++ b/frontend/src/contexts/realtime-provider.tsx
@@ -15,13 +15,9 @@ import React, { useEffect, useMemo, useRef, useState } from 'react'
 
 import { CoachEventStream, type StreamState } from '@/api/sse'
 import { useAuth } from '@/contexts/auth-context'
+import { applyEntityUpdate, type IEntityUpdatePayload } from './realtime-cache'
 import { RealtimeContext, type IRealtimeContext, type RealtimeHealth } from './realtime-context'
 import { entitiesQueryKeys } from '@/hooks/useEntities'
-
-interface IEntityUpdatePayload {
-  entity_id: string
-  entity_data: Record<string, unknown>
-}
 
 function toRealtimeHealth(state: StreamState): RealtimeHealth {
   switch (state) {
@@ -56,9 +52,7 @@ export function RealtimeProvider({ children }: { readonly children: React.ReactN
     onEvent: (event, data) => {
       const client = queryClientRef.current
       if (event === 'entity_update') {
-        const payload = data as IEntityUpdatePayload
-        client.setQueryData(entitiesQueryKeys.entity(payload.entity_id), payload.entity_data)
-        void client.invalidateQueries({ queryKey: entitiesQueryKeys.collections() })
+        applyEntityUpdate(client, data as IEntityUpdatePayload)
       } else if (event === 'entity_created' || event === 'halt_command_emission') {
         void client.invalidateQueries({ queryKey: entitiesQueryKeys.collections() })
       }


### PR DESCRIPTION
## Problem

The Climate page (and any page with entity collection queries) was surfacing browser console errors:

```
Failed to load resource: the server responded with a status of 429 () (entities, line 0)
```

Every `entity_update` SSE event invalidated **all** entity collection queries, which immediately refetches every active one. Climate mounts six collection queries (climate zones, ACs, water heaters, AC loads, tanks, temperature sensors), so steady CAN-bus chatter multiplied into hundreds of `GET /api/entities` requests per minute — blowing through the backend's default 100 req/min slowapi limit.

The invalidation was also mostly redundant: the same handler already wrote the updated entity into the cache via `setQueryData`.

## Fix

New `applyEntityUpdate()` in `frontend/src/contexts/realtime-cache.ts`: on `entity_update`, write the entity's individual cache entry **and** patch it in place into every cached collection containing it (`setQueriesData`). Zero HTTP requests per event. Entities can't enter/leave a filtered collection on a state update, so cache surgery is safe.

Collection invalidation remains only where membership can change: `entity_created`, `halt_command_emission`, and stream (re)connect as the consistency backstop.

## Testing

- 4 new unit tests (`realtime-cache.test.ts`): entity cache write, in-place patch across multiple cached collections, non-matching collections untouched (same reference, no timestamp bump), no query marked invalidated.
- `tsc --noEmit` and ESLint clean on changed files.
- Full frontend suite: 73 pass; the 3 failures in `useWebSocket.test.tsx` fail identically on a clean checkout (pre-existing).
- Real-world proof pending deploy: Climate page on the coach with no 429s in console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)