### PR TITLE
feat(location): trip noise guards, working GPX download, trip replay + delete

### DIFF
--- a/backend/api/routers/location.py
+++ b/backend/api/routers/location.py
@@ -74,6 +74,25 @@ async def get_trip_points(
     return {"trip": trip, "points": points}
 
 
+@router.delete("/trips/{trip_id}", summary="Delete a recorded trip")
+async def delete_trip(
+    trip_id: int,
+    trip_log_repository: Annotated[Any, Depends(get_optional_trip_log_repository)],
+) -> dict[str, Any]:
+    """Remove a trip and its breadcrumbs (e.g. a noise trip or a private one)."""
+    repository = _require(trip_log_repository, "Trip log")
+    trip = await repository.get_trip(trip_id)
+    if trip is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Trip not found")
+    if trip["ended_at"] is None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Trip is still recording; it can be deleted once it ends",
+        )
+    await repository.delete_trip(trip_id)
+    return {"deleted": trip_id}
+
+
 @router.get(
     "/trips/{trip_id}/gpx",
     summary="Export one trip as GPX",

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -1297,6 +1297,22 @@ class TripLogSettings(BaseSettings):
         description="Below this speed the RV is considered stationary",
         ge=0,
     )
+    start_confirm_seconds: float = Field(
+        default=10.0,
+        description=(
+            "Movement must persist this long before a trip starts; "
+            "filters single-fix GPS speed jitter (0 starts immediately)"
+        ),
+        ge=0,
+    )
+    min_trip_distance_m: float = Field(
+        default=100.0,
+        description=(
+            "Trips that end with less than this distance are discarded "
+            "as GPS noise (0 keeps every trip)"
+        ),
+        ge=0,
+    )
     trip_gap_minutes: float = Field(
         default=20.0,
         description="Stationary time that closes the current trip",

--- a/backend/repositories/trip_log_repository.py
+++ b/backend/repositories/trip_log_repository.py
@@ -161,6 +161,36 @@ class TripLogRepository(MonitoredRepository):
             trip = result.scalar_one_or_none()
             return _trip_to_dict(trip) if trip else None
 
+    @MonitoredRepository._monitored_operation("delete_trip")  # noqa: SLF001 - repo-standard decorator (see analytics_repository)
+    async def delete_trip(self, trip_id: int) -> bool:
+        """Delete one trip and its breadcrumbs; True if the trip existed."""
+        async with self._db_manager.get_session() as session:
+            await session.execute(delete(GpsBreadcrumb).where(GpsBreadcrumb.trip_id == trip_id))
+            result = await session.execute(delete(GpsTrip).where(GpsTrip.id == trip_id))
+            await session.commit()
+            return bool(result.rowcount)
+
+    @MonitoredRepository._monitored_operation("delete_short_trips")  # noqa: SLF001 - repo-standard decorator (see analytics_repository)
+    async def delete_short_trips(self, min_distance_m: float) -> int:
+        """Delete closed trips (and their breadcrumbs) shorter than the minimum.
+
+        Cleans up noise trips recorded before the short-trip discard guard
+        existed; active trips are never touched.
+        """
+        async with self._db_manager.get_session() as session:
+            result = await session.execute(
+                select(GpsTrip.id).where(
+                    GpsTrip.ended_at.is_not(None), GpsTrip.distance_m < min_distance_m
+                )
+            )
+            trip_ids = list(result.scalars())
+            if not trip_ids:
+                return 0
+            await session.execute(delete(GpsBreadcrumb).where(GpsBreadcrumb.trip_id.in_(trip_ids)))
+            await session.execute(delete(GpsTrip).where(GpsTrip.id.in_(trip_ids)))
+            await session.commit()
+            return len(trip_ids)
+
     @MonitoredRepository._monitored_operation("prune_older_than")  # noqa: SLF001 - repo-standard decorator (see analytics_repository)
     async def prune_older_than(self, cutoff_timestamp: float) -> int:
         """Delete breadcrumbs (and fully-pruned trips) older than the cutoff."""

--- a/backend/services/trip_log/trip_log_service.py
+++ b/backend/services/trip_log/trip_log_service.py
@@ -8,8 +8,12 @@ firehose:
 - a breadcrumb is recorded only after moving ``min_distance_m`` from the
   last recorded point (and at most every ``min_interval_seconds``),
 - nothing is recorded while parked,
+- a trip starts only after movement persists for ``start_confirm_seconds``
+  (single-fix GPS speed jitter while parked never opens a trip),
 - movement after ``trip_gap_minutes`` of stillness starts a new trip; the
-  trip closes (with distance/max-speed stats) when the RV goes still again.
+  trip closes (with distance/max-speed stats) when the RV goes still again,
+- trips that end having covered less than ``min_trip_distance_m`` are
+  discarded rather than stored.
 
 The gpsd connection reconnects with backoff, so GPS or gpsd restarts only
 pause recording.
@@ -49,6 +53,8 @@ class TripLogService:
 
         # Sampling state
         self._active_trip_id: int | None = None
+        self._active_trip_distance_m = 0.0
+        self._pending_start_at: float | None = None
         self._last_recorded: tuple[float, float] | None = None  # (lat, lon)
         self._last_recorded_at = 0.0
         self._last_movement_at = 0.0
@@ -64,6 +70,10 @@ class TripLogService:
             gpsd=f"{self._settings.gpsd_host}:{self._settings.gpsd_port}",
         )
         await self._repository.ensure_tables()
+        if self._settings.min_trip_distance_m > 0:
+            removed = await self._repository.delete_short_trips(self._settings.min_trip_distance_m)
+            if removed:
+                logger.info("Removed %d short noise trips from the log", removed)
         await self._resume_or_close_dangling_trip()
         self._running = True
         self._task = asyncio.create_task(self._watch_loop())
@@ -139,12 +149,21 @@ class TripLogService:
             self._last_movement_at = now
 
         if self._active_trip_id is None:
-            if moving:
+            if not moving:
+                self._pending_start_at = None
+                if self._last_recorded is None:
+                    # Parked: just remember where we are so the first movement
+                    # has a reference point.
+                    self._last_recorded = (tpv.lat, tpv.lon)
+                return
+            # Movement must persist before a trip opens: a single fix with
+            # phantom speed (GPS jitter while parked) would otherwise create
+            # a zero-distance trip.
+            if self._pending_start_at is None:
+                self._pending_start_at = now
+            if now - self._pending_start_at >= self._settings.start_confirm_seconds:
+                self._pending_start_at = None
                 await self._start_trip(tpv, now)
-            elif self._last_recorded is None:
-                # Parked: just remember where we are so the first movement
-                # has a reference point.
-                self._last_recorded = (tpv.lat, tpv.lon)
             return
 
         # Active trip: close it after a long stationary gap...
@@ -165,6 +184,7 @@ class TripLogService:
         if tpv.lat is None or tpv.lon is None:  # narrowed by caller; keeps pyright honest
             return
         self._active_trip_id = await self._repository.start_trip(now, tpv.lat, tpv.lon)
+        self._active_trip_distance_m = 0.0
         self._last_movement_at = now
         logger.info("Trip started", trip_id=self._active_trip_id, lat=tpv.lat, lon=tpv.lon)
         await self._record_point(tpv, now, 0.0)
@@ -182,6 +202,7 @@ class TripLogService:
             course_deg=tpv.track,
             altitude_m=tpv.alt,
         )
+        self._active_trip_distance_m += leg_distance_m
         self._last_recorded = (tpv.lat, tpv.lon)
         self._last_recorded_at = now
 
@@ -190,40 +211,60 @@ class TripLogService:
         if trip_id is None or self._last_recorded is None:
             self._active_trip_id = None
             return
-        await self._repository.end_trip(
-            trip_id,
-            ended_at=self._last_movement_at,
-            latitude=self._last_recorded[0],
-            longitude=self._last_recorded[1],
-        )
-        logger.info("Trip ended", trip_id=trip_id)
+        if self._active_trip_distance_m < self._settings.min_trip_distance_m:
+            # The RV never really went anywhere — GPS noise opened the trip.
+            await self._repository.delete_trip(trip_id)
+            logger.info(
+                "Discarded short trip",
+                trip_id=trip_id,
+                distance_m=round(self._active_trip_distance_m, 1),
+            )
+        else:
+            await self._repository.end_trip(
+                trip_id,
+                ended_at=self._last_movement_at,
+                latitude=self._last_recorded[0],
+                longitude=self._last_recorded[1],
+            )
+            logger.info("Trip ended", trip_id=trip_id)
         self._active_trip_id = None
+        self._active_trip_distance_m = 0.0
 
     async def _resume_or_close_dangling_trip(self) -> None:
         """After a restart, resume a recent active trip or close a stale one."""
         trip = await self._repository.get_active_trip()
         if trip is None:
             return
+        distance_m = trip.get("distance_m") or 0.0
+        too_short = distance_m < self._settings.min_trip_distance_m
         last_point = await self._repository.get_latest_point(trip["id"])
         gap_seconds = self._settings.trip_gap_minutes * 60
         if last_point is None:
-            await self._repository.end_trip(
-                trip["id"],
-                ended_at=trip["started_at"],
-                latitude=trip["start_latitude"],
-                longitude=trip["start_longitude"],
-            )
+            if too_short:
+                await self._repository.delete_trip(trip["id"])
+            else:
+                await self._repository.end_trip(
+                    trip["id"],
+                    ended_at=trip["started_at"],
+                    latitude=trip["start_latitude"],
+                    longitude=trip["start_longitude"],
+                )
             return
         if time.time() - last_point["timestamp"] > gap_seconds:
-            await self._repository.end_trip(
-                trip["id"],
-                ended_at=last_point["timestamp"],
-                latitude=last_point["latitude"],
-                longitude=last_point["longitude"],
-            )
-            logger.info("Closed stale trip %s from before restart", trip["id"])
+            if too_short:
+                await self._repository.delete_trip(trip["id"])
+                logger.info("Discarded stale short trip %s from before restart", trip["id"])
+            else:
+                await self._repository.end_trip(
+                    trip["id"],
+                    ended_at=last_point["timestamp"],
+                    latitude=last_point["latitude"],
+                    longitude=last_point["longitude"],
+                )
+                logger.info("Closed stale trip %s from before restart", trip["id"])
         else:
             self._active_trip_id = trip["id"]
+            self._active_trip_distance_m = distance_m
             self._last_recorded = (last_point["latitude"], last_point["longitude"])
             self._last_recorded_at = last_point["timestamp"]
             self._last_movement_at = last_point["timestamp"]

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -198,6 +198,36 @@ export async function apiGet<T>(url: string): Promise<T> {
 }
 
 /**
+ * Fetches a binary/file endpoint with auth headers and returns the Blob.
+ *
+ * File downloads can't use a plain `<a href>` because the API authenticates
+ * with a Bearer header (not a cookie), so the browser's own navigation
+ * request would arrive unauthenticated and 401.
+ */
+export async function apiGetBlob(
+  url: string
+): Promise<{ blob: Blob; filename: string | null }> {
+  const fullUrl = url.startsWith('/') ? url : `${API_BASE}/${url}`;
+
+  await ensureFreshAccessToken();
+
+  const response = await fetch(fullUrl, { headers: getAuthHeader() });
+  if (!response.ok) {
+    let errorMessage = `API Error: ${response.status}`;
+    try {
+      errorMessage = ((await response.json()) as APIError).detail || errorMessage;
+    } catch {
+      // Non-JSON error body; keep the default message.
+    }
+    throw new APIClientError(errorMessage, response.status);
+  }
+
+  const disposition = response.headers.get('content-disposition');
+  const filenameMatch = disposition?.match(/filename="?([^";]+)"?/i);
+  return { blob: await response.blob(), filename: filenameMatch?.[1] ?? null };
+}
+
+/**
  * Creates a POST request
  */
 export async function apiPost<T>(url: string, data?: unknown): Promise<T> {

--- a/frontend/src/api/location.ts
+++ b/frontend/src/api/location.ts
@@ -2,7 +2,7 @@
  * Location API client (/api/location) — current GPS position and trip log.
  */
 
-import { apiGet } from './client';
+import { apiDelete, apiGet, apiGetBlob } from './client';
 
 export interface ICurrentLocation {
   connected: boolean;
@@ -53,6 +53,19 @@ export async function fetchTripPoints(
   return apiGet(`/api/location/trips/${tripId}/points`);
 }
 
-export function tripGpxUrl(tripId: number): string {
-  return `/api/location/trips/${tripId}/gpx`;
+/** Fetch a trip's GPX (with auth headers) and hand it to the browser as a download. */
+export async function downloadTripGpx(tripId: number): Promise<void> {
+  const { blob, filename } = await apiGetBlob(`/api/location/trips/${tripId}/gpx`);
+  const objectUrl = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = objectUrl;
+  anchor.download = filename ?? `coachiq-trip-${tripId}.gpx`;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(objectUrl);
+}
+
+export async function deleteTrip(tripId: number): Promise<void> {
+  await apiDelete(`/api/location/trips/${tripId}`);
 }

--- a/frontend/src/pages/location.tsx
+++ b/frontend/src/pages/location.tsx
@@ -3,26 +3,38 @@
  *
  * Live position from gpsd (via the trip log service) on a Leaflet map with
  * OpenStreetMap tiles, plus the recorded trip list. Selecting a trip draws
- * its breadcrumb polyline; every trip exports as GPX for other tools.
+ * its breadcrumb polyline and offers a timeline replay; every trip exports
+ * as GPX for other tools.
  */
 
 import "leaflet/dist/leaflet.css"
 
-import { IconDownload, IconRoute, IconSatellite } from "@tabler/icons-react"
-import { useQuery } from "@tanstack/react-query"
-import { useEffect, useState } from "react"
+import {
+  IconDownload,
+  IconPlayerPause,
+  IconPlayerPlay,
+  IconRoute,
+  IconSatellite,
+  IconTrash,
+} from "@tabler/icons-react"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { useEffect, useMemo, useState } from "react"
 import { CircleMarker, MapContainer, Polyline, TileLayer, useMap } from "react-leaflet"
+import { toast } from "sonner"
 
 import {
+  deleteTrip,
+  downloadTripGpx,
   fetchCurrentLocation,
   fetchTripPoints,
   fetchTrips,
-  tripGpxUrl,
   type ITrip,
+  type ITripPoint,
 } from "@/api/location"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Slider } from "@/components/ui/slider"
 import { cn } from "@/lib/utils"
 
 const METERS_PER_MILE = 1609.344
@@ -48,6 +60,13 @@ function fmtTripDate(seconds: number): string {
   return new Date(seconds * 1000).toLocaleString([], {
     month: "short",
     day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  })
+}
+
+function fmtClock(seconds: number): string {
+  return new Date(seconds * 1000).toLocaleTimeString([], {
     hour: "numeric",
     minute: "2-digit",
   })
@@ -88,13 +107,191 @@ function gpsStatusLabel(fix: boolean, connected: boolean): string {
   return connected ? "Waiting for fix" : "gpsd unreachable"
 }
 
-/** Map card: selected trail polyline + start/current markers. */
+// ---------------------------------------------------------------------------
+// Trip replay
+// ---------------------------------------------------------------------------
+
+const REPLAY_SPEEDS = [10, 30, 60, 120]
+const REPLAY_TICK_MS = 100
+
+interface IReplayPosition {
+  lat: number
+  lon: number
+  speedMps: number | null
+  /** Index of the breadcrumb at or before the replay cursor. */
+  index: number
+}
+
+/** Position along the trail at an absolute timestamp, interpolated between breadcrumbs. */
+function interpolatePosition(points: ITripPoint[], atTimestamp: number): IReplayPosition {
+  let lo = 0
+  let hi = points.length - 1
+  while (lo < hi) {
+    const mid = (lo + hi + 1) >> 1
+    if ((points.at(mid) as ITripPoint).timestamp <= atTimestamp) lo = mid
+    else hi = mid - 1
+  }
+  const from = points.at(lo) as ITripPoint
+  const to = points.at(lo + 1)
+  if (!to || atTimestamp <= from.timestamp) {
+    return { lat: from.latitude, lon: from.longitude, speedMps: from.speed_mps, index: lo }
+  }
+  const span = to.timestamp - from.timestamp
+  const frac = span > 0 ? Math.min(1, (atTimestamp - from.timestamp) / span) : 1
+  return {
+    lat: from.latitude + (to.latitude - from.latitude) * frac,
+    lon: from.longitude + (to.longitude - from.longitude) * frac,
+    speedMps: to.speed_mps ?? from.speed_mps,
+    index: lo,
+  }
+}
+
+interface ITripReplay {
+  active: boolean
+  playing: boolean
+  elapsed: number
+  duration: number
+  startTs: number
+  multiplier: number
+  position: IReplayPosition | null
+  traveled: [number, number][]
+  toggle: () => void
+  seek: (seconds: number) => void
+  cycleSpeed: () => void
+}
+
+/** Replay cursor over a trip's breadcrumbs, advanced on a wall-clock interval. */
+function useTripReplay(points: ITripPoint[]): ITripReplay {
+  const [playing, setPlaying] = useState(false)
+  const [speedIndex, setSpeedIndex] = useState(1) // 30x
+  const [elapsed, setElapsed] = useState(0)
+
+  const startTs = points[0]?.timestamp ?? 0
+  const duration =
+    points.length > 1 ? (points[points.length - 1] as ITripPoint).timestamp - startTs : 0
+  const multiplier = REPLAY_SPEEDS.at(speedIndex) ?? 30
+  const active = duration > 0
+
+  // A different trip was selected: rewind.
+  useEffect(() => {
+    setElapsed(0)
+    setPlaying(false)
+  }, [points])
+
+  useEffect(() => {
+    if (!playing || duration <= 0) return
+    // Advance by measured wall time, not the nominal tick, so replay speed
+    // stays accurate when the browser throttles timers.
+    let lastTick = performance.now()
+    const id = window.setInterval(() => {
+      const now = performance.now()
+      const wallSeconds = (now - lastTick) / 1000
+      lastTick = now
+      setElapsed((prev) => Math.min(prev + wallSeconds * multiplier, duration))
+    }, REPLAY_TICK_MS)
+    return () => window.clearInterval(id)
+  }, [playing, duration, multiplier])
+
+  // Pause at the end of the trail.
+  useEffect(() => {
+    if (playing && duration > 0 && elapsed >= duration) setPlaying(false)
+  }, [playing, elapsed, duration])
+
+  const position = useMemo(
+    () => (active ? interpolatePosition(points, startTs + elapsed) : null),
+    [active, points, startTs, elapsed]
+  )
+
+  const traveled = useMemo<[number, number][]>(() => {
+    if (!position) return []
+    const path: [number, number][] = points
+      .slice(0, position.index + 1)
+      .map((point) => [point.latitude, point.longitude])
+    path.push([position.lat, position.lon])
+    return path
+  }, [points, position])
+
+  return {
+    active,
+    playing,
+    elapsed,
+    duration,
+    startTs,
+    multiplier,
+    position,
+    traveled,
+    toggle: () => {
+      if (!playing && elapsed >= duration) setElapsed(0) // replay from the top
+      setPlaying((prev) => !prev)
+    },
+    seek: (seconds: number) => setElapsed(Math.min(Math.max(seconds, 0), duration)),
+    cycleSpeed: () => setSpeedIndex((prev) => (prev + 1) % REPLAY_SPEEDS.length),
+  }
+}
+
+function ReplayBar({ replay }: Readonly<{ replay: ITripReplay }>) {
+  return (
+    <div className="flex items-center gap-3 border-t bg-card px-3 py-2">
+      <Button
+        variant="ghost"
+        size="icon"
+        className="size-8 shrink-0"
+        aria-label={replay.playing ? "Pause replay" : "Play replay"}
+        onClick={replay.toggle}
+      >
+        {replay.playing ? (
+          <IconPlayerPause className="size-4" />
+        ) : (
+          <IconPlayerPlay className="size-4" />
+        )}
+      </Button>
+      <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
+        {fmtClock(replay.startTs + replay.elapsed)}
+      </span>
+      <Slider
+        value={[replay.elapsed]}
+        max={replay.duration}
+        step={1}
+        onValueChange={(values) => replay.seek(values[0] ?? 0)}
+        className="flex-1"
+        aria-label="Replay position"
+      />
+      <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
+        {fmtClock(replay.startTs + replay.duration)}
+      </span>
+      <span className="w-16 shrink-0 text-right text-sm font-medium tabular-nums">
+        {fmtMph(replay.position?.speedMps ?? null)}
+      </span>
+      <Button
+        variant="outline"
+        size="sm"
+        className="w-14 shrink-0 tabular-nums"
+        onClick={replay.cycleSpeed}
+        aria-label={`Replay speed ${replay.multiplier}x`}
+      >
+        {replay.multiplier}×
+      </Button>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Map
+// ---------------------------------------------------------------------------
+
+/** Map card: selected trail polyline, replay overlay, start/current markers. */
 function TrailMap({
   trail,
   here,
-}: Readonly<{ trail: [number, number][]; here: [number, number] | null }>) {
+  replay,
+}: Readonly<{
+  trail: [number, number][]
+  here: [number, number] | null
+  replay: ITripReplay
+}>) {
   let fitTargets: [number, number][] = trail
   if (fitTargets.length === 0 && here) fitTargets = [here]
+  const replaying = replay.active && replay.position !== null
 
   return (
     <MapContainer
@@ -111,13 +308,26 @@ function TrailMap({
       <InvalidateOnResize />
       <FitBounds positions={fitTargets} />
       {trail.length > 1 && (
-        <Polyline positions={trail} pathOptions={{ color: "#2563eb", weight: 4 }} />
+        <Polyline
+          positions={trail}
+          pathOptions={{ color: replaying ? "#93c5fd" : "#2563eb", weight: 4 }}
+        />
+      )}
+      {replaying && replay.traveled.length > 1 && (
+        <Polyline positions={replay.traveled} pathOptions={{ color: "#2563eb", weight: 4 }} />
       )}
       {trail.length > 0 && (
         <CircleMarker
           center={trail[0] as [number, number]}
           radius={6}
           pathOptions={{ color: "#16a34a", fillColor: "#16a34a", fillOpacity: 0.9 }}
+        />
+      )}
+      {replaying && replay.position && (
+        <CircleMarker
+          center={[replay.position.lat, replay.position.lon]}
+          radius={7}
+          pathOptions={{ color: "#7c3aed", fillColor: "#7c3aed", fillOpacity: 0.9 }}
         />
       )}
       {here && (
@@ -166,23 +376,45 @@ function CurrentPositionCard() {
   )
 }
 
+// ---------------------------------------------------------------------------
+// Trip list
+// ---------------------------------------------------------------------------
+
 interface ITripRowProps {
   trip: ITrip
   selected: boolean
   onSelect: () => void
+  onDelete: () => void
 }
 
-function TripRow({ trip, selected, onSelect }: Readonly<ITripRowProps>) {
+function TripRow({ trip, selected, onSelect, onDelete }: Readonly<ITripRowProps>) {
+  const [confirmingDelete, setConfirmingDelete] = useState(false)
+
+  // Un-arm the delete confirmation if it isn't followed through.
+  useEffect(() => {
+    if (!confirmingDelete) return
+    const id = setTimeout(() => setConfirmingDelete(false), 3_000)
+    return () => clearTimeout(id)
+  }, [confirmingDelete])
+
+  const handleDownload = async () => {
+    try {
+      await downloadTripGpx(trip.id)
+    } catch (error) {
+      toast.error(
+        `GPX download failed: ${error instanceof Error ? error.message : String(error)}`
+      )
+    }
+  }
+
   return (
-    <button
-      type="button"
-      onClick={onSelect}
+    <div
       className={cn(
-        "flex w-full items-center justify-between gap-2 rounded-md px-2 py-2 text-left text-sm transition-colors hover:bg-muted",
+        "flex w-full items-center justify-between gap-2 rounded-md px-2 py-2 text-sm transition-colors hover:bg-muted",
         selected && "bg-muted"
       )}
     >
-      <div className="min-w-0">
+      <button type="button" onClick={onSelect} className="min-w-0 flex-1 text-left">
         <p className="truncate font-medium">
           {fmtTripDate(trip.started_at)}
           {trip.active && (
@@ -194,28 +426,52 @@ function TripRow({ trip, selected, onSelect }: Readonly<ITripRowProps>) {
         <p className="text-xs text-muted-foreground">
           {fmtDuration(trip.started_at, trip.ended_at)} · max {fmtMph(trip.max_speed_mps)}
         </p>
-      </div>
-      <div className="flex shrink-0 items-center gap-2">
-        <span className="font-medium tabular-nums">{fmtMiles(trip.distance_m)}</span>
+      </button>
+      <div className="flex shrink-0 items-center gap-1">
+        <span className="mr-1 font-medium tabular-nums">{fmtMiles(trip.distance_m)}</span>
         <Button
           variant="ghost"
           size="icon"
           className="size-7 text-muted-foreground"
           aria-label="Download GPX"
-          asChild
-          onClick={(event) => event.stopPropagation()}
+          onClick={() => void handleDownload()}
         >
-          <a href={tripGpxUrl(trip.id)} download>
-            <IconDownload className="size-4" />
-          </a>
+          <IconDownload className="size-4" />
         </Button>
+        {!trip.active && (
+          <Button
+            variant="ghost"
+            size="icon"
+            className={cn(
+              "size-7 text-muted-foreground",
+              confirmingDelete && "bg-destructive/10 text-destructive"
+            )}
+            aria-label={confirmingDelete ? "Tap again to delete trip" : "Delete trip"}
+            title={confirmingDelete ? "Tap again to delete" : "Delete trip"}
+            onClick={() => {
+              if (confirmingDelete) {
+                setConfirmingDelete(false)
+                onDelete()
+              } else {
+                setConfirmingDelete(true)
+              }
+            }}
+          >
+            <IconTrash className="size-4" />
+          </Button>
+        )}
       </div>
-    </button>
+    </div>
   )
 }
 
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
 export default function LocationPage() {
   const [selectedTripId, setSelectedTripId] = useState<number | null>(null)
+  const queryClient = useQueryClient()
 
   const { data: current } = useQuery({
     queryKey: ["location", "current"],
@@ -235,15 +491,38 @@ export default function LocationPage() {
     enabled: selectedTripId !== null,
   })
 
+  const deleteMutation = useMutation({
+    mutationFn: deleteTrip,
+    onSuccess: (_data, tripId) => {
+      setSelectedTripId((prev) => (prev === tripId ? null : prev))
+      void queryClient.invalidateQueries({ queryKey: ["location", "trips"] })
+    },
+    onError: (error) => {
+      toast.error(
+        `Failed to delete trip: ${error instanceof Error ? error.message : String(error)}`
+      )
+    },
+  })
+
   const trips = tripData?.trips ?? []
-  const trail: [number, number][] = (pointData?.points ?? []).map((point) => [
-    point.latitude,
-    point.longitude,
-  ])
-  const here: [number, number] | null =
-    current?.fix && current.latitude !== null && current.longitude !== null
-      ? [current.latitude, current.longitude]
-      : null
+  const points = useMemo(
+    () => (selectedTripId !== null ? (pointData?.points ?? []) : []),
+    [selectedTripId, pointData]
+  )
+  // Memoized so FitBounds doesn't re-fit on every poll/replay render.
+  const trail = useMemo<[number, number][]>(
+    () => points.map((point) => [point.latitude, point.longitude]),
+    [points]
+  )
+  const here = useMemo<[number, number] | null>(
+    () =>
+      current?.fix && current.latitude !== null && current.longitude !== null
+        ? [current.latitude, current.longitude]
+        : null,
+    [current?.fix, current?.latitude, current?.longitude]
+  )
+
+  const replay = useTripReplay(points)
 
   return (
     <div className="flex-1 space-y-4 p-4 pt-6 lg:px-6">
@@ -251,7 +530,8 @@ export default function LocationPage() {
 
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
         <Card className="overflow-hidden lg:col-span-2">
-          <TrailMap trail={trail} here={here} />
+          <TrailMap trail={trail} here={here} replay={replay} />
+          {replay.active && <ReplayBar replay={replay} />}
         </Card>
 
         <Card>
@@ -275,6 +555,7 @@ export default function LocationPage() {
                 onSelect={() =>
                   setSelectedTripId(selectedTripId === trip.id ? null : trip.id)
                 }
+                onDelete={() => deleteMutation.mutate(trip.id)}
               />
             ))}
           </CardContent>

--- a/tests/services/test_trip_log_service.py
+++ b/tests/services/test_trip_log_service.py
@@ -23,6 +23,7 @@ class FakeTripLogRepository:
             "ended_at": None,
             "start_latitude": latitude,
             "start_longitude": longitude,
+            "distance_m": 0.0,
         }
         return trip_id
 
@@ -33,6 +34,23 @@ class FakeTripLogRepository:
 
     async def add_point(self, **kwargs: Any) -> None:
         self.points.append(kwargs)
+        self.trips[kwargs["trip_id"]]["distance_m"] += kwargs.get("leg_distance_m", 0.0)
+
+    async def delete_trip(self, trip_id: int) -> bool:
+        existed = trip_id in self.trips
+        self.trips.pop(trip_id, None)
+        self.points = [point for point in self.points if point["trip_id"] != trip_id]
+        return existed
+
+    async def delete_short_trips(self, min_distance_m: float) -> int:
+        doomed = [
+            trip_id
+            for trip_id, trip in self.trips.items()
+            if trip["ended_at"] is not None and trip["distance_m"] < min_distance_m
+        ]
+        for trip_id in doomed:
+            await self.delete_trip(trip_id)
+        return len(doomed)
 
     async def get_active_trip(self) -> dict[str, Any] | None:
         for trip in reversed(self.trips.values()):  # type: ignore[call-overload]
@@ -52,14 +70,19 @@ class FakeTripLogRepository:
 
 
 def make_service(**overrides: Any) -> tuple[TripLogService, FakeTripLogRepository]:
-    settings = TripLogSettings(
-        enabled=True,
-        min_distance_m=50.0,
-        min_interval_seconds=0.0,  # let distance drive the tests
-        stationary_speed_mps=1.0,
-        trip_gap_minutes=20.0,
-        **overrides,
-    )
+    kwargs: dict[str, Any] = {
+        "enabled": True,
+        "min_distance_m": 50.0,
+        "min_interval_seconds": 0.0,  # let distance drive the tests
+        "stationary_speed_mps": 1.0,
+        "trip_gap_minutes": 20.0,
+        # Immediate start / keep-everything defaults so lifecycle tests can
+        # drive trips with single fixes; the guard tests override these.
+        "start_confirm_seconds": 0.0,
+        "min_trip_distance_m": 0.0,
+    }
+    kwargs.update(overrides)
+    settings = TripLogSettings(**kwargs)
     repository = FakeTripLogRepository()
     return TripLogService(settings, repository), repository
 
@@ -140,6 +163,69 @@ class TestTripLifecycle:
         await service._resume_or_close_dangling_trip()
         assert service._active_trip_id is None
         assert repository.trips[trip_id]["ended_at"] is not None
+
+
+class TestNoiseGuards:
+    """The debounced start and short-trip discard that keep GPS noise out."""
+
+    async def test_single_speed_blip_does_not_start_trip(self):
+        service, repository = make_service(start_confirm_seconds=10.0)
+        await service._handle_fix(fix(LAT, LON, speed=0.0))  # parked reference
+        await service._handle_fix(fix(LAT, LON, speed=2.0))  # phantom-speed blip
+        await service._handle_fix(fix(LAT, LON, speed=0.0))  # still again
+        await service._handle_fix(fix(LAT, LON, speed=1.5))  # another blip
+        assert repository.trips == {}
+        assert repository.points == []
+
+    async def test_sustained_movement_starts_trip_after_confirm_window(self):
+        service, repository = make_service(start_confirm_seconds=10.0)
+        await service._handle_fix(fix(LAT, LON, speed=5.0))
+        assert repository.trips == {}  # pending, not yet confirmed
+
+        # Movement persists past the confirm window.
+        service._pending_start_at = time.time() - 11.0
+        await service._handle_fix(fix(LAT + 0.0002, LON, speed=5.0))
+        assert len(repository.trips) == 1
+        assert len(repository.points) == 1
+
+    async def test_short_trip_discarded_when_it_ends(self):
+        service, repository = make_service(min_trip_distance_m=100.0)
+        await service._handle_fix(fix(LAT, LON, speed=5.0))  # opens a trip
+        trip_id = service._active_trip_id
+        assert trip_id is not None
+
+        # Goes still past the gap without ever covering 100 m.
+        service._last_movement_at = time.time() - 21 * 60
+        await service._handle_fix(fix(LAT, LON, speed=0.0))
+        assert service._active_trip_id is None
+        assert trip_id not in repository.trips
+        assert repository.points == []
+
+    async def test_real_trip_survives_the_short_trip_guard(self):
+        service, repository = make_service(min_trip_distance_m=100.0)
+        await service._handle_fix(fix(LAT, LON, speed=5.0))
+        trip_id = service._active_trip_id
+        # Two ~111 m legs -> ~222 m total.
+        await service._handle_fix(fix(LAT + 0.001, LON, speed=15.0))
+        await service._handle_fix(fix(LAT + 0.002, LON, speed=15.0))
+
+        service._last_movement_at = time.time() - 21 * 60
+        await service._handle_fix(fix(LAT + 0.002, LON, speed=0.0))
+        assert repository.trips[trip_id]["ended_at"] is not None
+
+    async def test_stale_short_dangling_trip_deleted_on_restart(self):
+        service, repository = make_service(min_trip_distance_m=100.0)
+        trip_id = await repository.start_trip(time.time() - 7200, LAT, LON)
+        await repository.add_point(
+            trip_id=trip_id,
+            timestamp=time.time() - 7000,
+            latitude=LAT,
+            longitude=LON,
+            leg_distance_m=0.0,
+        )
+        await service._resume_or_close_dangling_trip()
+        assert service._active_trip_id is None
+        assert trip_id not in repository.trips
 
 
 class TestReadSide:


### PR DESCRIPTION
## Problem

- The trips sidebar fills up with **0.0-mile junk trips**: a trip opened the moment a single gpsd fix reported speed ≥ 1 m/s (~2.2 mph), which parked GPS speed jitter crosses constantly. Distance only accrues after a 50 m breadcrumb leg, so these noise trips sat at 0.0 mi and were committed anyway when they closed.
- **GPX download never worked**: the button was a plain `<a href>`, which carries no `Authorization` header (auth is a bearer JWT in localStorage, not a cookie) → 401 on every click.
- No way to review a trip beyond a static polyline.

## Changes

### Backend
- **Debounced trip start** — movement must persist `start_confirm_seconds` (default 10 s) before a trip row is created; a lone phantom-speed fix never opens a trip.
- **Short-trip discard** — trips that close with less than `min_trip_distance_m` (default 100 m) are deleted instead of stored; the same guard applies to stale dangling trips closed on restart.
- **Startup cleanup** — previously stored short/noise trips are purged once when the service starts (set `COACHIQ_TRIP_LOG__MIN_TRIP_DISTANCE_M=0` to disable all of this).
- **`DELETE /api/location/trips/{id}`** — removes a trip + breadcrumbs; 409 while the trip is still recording.

### Frontend
- **Fixed GPX download** — new `apiGetBlob` client helper (auth header + pre-request token refresh), saved via a blob object URL with the server-provided filename.
- **Trip replay** — play/pause, timeline scrubber, cycling 10×/30×/60×/120× speed, moving marker interpolated between breadcrumbs, live clock + speed readout, traveled-path highlight over the full trail. Time-based ticking so replay speed stays accurate under browser timer throttling.
- **Per-trip delete** with tap-again-to-confirm (hidden for the live trip).
- **Map polish** — memoized trail/position inputs so the map no longer re-fits bounds on every 5 s poll re-render.

## Testing

- `tests/services/test_trip_log_service.py`: 12 passing, incl. new coverage for blip suppression, confirm-window start, short-trip discard on end and on restart, and real trips surviving the guard.
- Verified in-browser against a mock location API: trips list, replay (play/scrub/speed), GPX download (200 + no error toast), and delete (arm → confirm → list refresh).
- `tsc --noEmit`, ESLint (0 findings on changed files), `vite build`, `ruff format/check` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)