### PR TITLE
fix(auth): keep user identity across token refresh; retry entity fetches on 401

### DIFF
--- a/backend/services/auth/sessions.py
+++ b/backend/services/auth/sessions.py
@@ -19,6 +19,31 @@ from backend.services.auth.tokens import TokenService
 
 logger = logging.getLogger(__name__)
 
+# Identity claims that must survive into every access token minted here. The
+# initial login mints a token carrying these directly and also stashes them in
+# the session's device_info; refreshes and password-login session creation mint
+# fresh tokens in this service, so they must re-attach the same claims.
+# Everything else in device_info (fingerprint, user_agent, ip_subnet) is session
+# bookkeeping and must NOT leak into the JWT.
+_IDENTITY_CLAIM_KEYS = ("username", "email", "role", "mode", "provider")
+
+
+def _identity_claims(device_info: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Extract the user-identity claims stored alongside a session.
+
+    Returns ``None`` when nothing relevant is present so ``generate_access_token``
+    falls back to its bare defaults. Without this, a refreshed access token has
+    only ``sub``: ``/api/auth/me`` reports an empty username/email and defaults
+    ``role`` to ``"user"``, so the UI shows the bare user_id (a UUID) and silently
+    downgrades admins.
+    """
+    if not device_info:
+        return None
+    claims = {
+        key: device_info[key] for key in _IDENTITY_CLAIM_KEYS if device_info.get(key) is not None
+    }
+    return claims or None
+
 
 class SessionService:
     """Service for session and refresh token management."""
@@ -84,8 +109,11 @@ class SessionService:
                 oldest = min(sessions, key=lambda s: s["created_at"])
                 await self._session_repo.revoke_user_session(oldest["refresh_token"])
 
-        # Generate tokens
-        access_token = self._token_service.generate_access_token(user_id)
+        # Generate tokens. Carry the caller's identity claims into the access
+        # token so /api/auth/me can report username/email/role (not a bare UUID).
+        access_token = self._token_service.generate_access_token(
+            user_id, additional_claims=_identity_claims(device_info)
+        )
         refresh_token = self._token_service.generate_refresh_token()
 
         # Enhance device_info with fingerprint if request is provided
@@ -133,9 +161,13 @@ class SessionService:
             logger.warning("Refresh token not found or expired")
             return None
 
-        # Generate new access token
+        # Generate new access token. Re-attach the identity claims captured when
+        # the session was created; otherwise the refreshed token carries only
+        # `sub` and the user degrades to a bare UUID with role "user".
         user_id = session["user_id"]
-        access_token = self._token_service.generate_access_token(user_id)
+        access_token = self._token_service.generate_access_token(
+            user_id, additional_claims=_identity_claims(session.get("device_info"))
+        )
 
         logger.debug(f"Refreshed access token for user {user_id}")
         return access_token

--- a/frontend/src/api/__tests__/client-auth-retry.test.ts
+++ b/frontend/src/api/__tests__/client-auth-retry.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Regression tests for the request-time 401 refresh-and-retry in `apiRequest`.
+ *
+ * A request can leave with an access token that is already dead server-side —
+ * the proactive refresh only fires inside the pre-expiry buffer, and a
+ * backgrounded tablet wakes with an expired token whose refresh timer was
+ * throttled. Without a response-side retry the request 401s, the query errors,
+ * and entity collections blank out (only entities still receiving live SSE
+ * updates keep any data). These tests pin the fix: one 401 triggers a single
+ * token refresh + retry; auth endpoints are excluded to avoid recursing into
+ * the refresh they are part of.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { RefreshTokenResponse } from '@/api/types'
+
+const refreshTokenAPI = vi.fn<(token: string) => Promise<RefreshTokenResponse>>()
+
+vi.mock('@/api/endpoints', () => ({
+  refreshToken: (token: string) => refreshTokenAPI(token),
+  revokeRefreshToken: vi.fn().mockResolvedValue(undefined),
+  getAuthStatus: vi.fn().mockResolvedValue({ enabled: true, mode: 'multi' }),
+}))
+
+// Import AFTER the mock so the modules under test bind to the mocked endpoints.
+const { apiGet } = await import('@/api/client')
+const { tokenStorage } = await import('@/lib/token-storage')
+
+/** A live (not near-expiry) access token so the proactive refresh stays a no-op. */
+function seedLiveTokens(accessToken = 'access-original') {
+  const now = Date.now()
+  localStorage.setItem('auth_token', accessToken)
+  localStorage.setItem('refresh_token', 'refresh-original')
+  localStorage.setItem('token_expiry', String(now + 600_000))
+  localStorage.setItem('refresh_token_expiry', String(now + 7 * 24 * 3_600_000))
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  } as unknown as Response
+}
+
+function refreshResponse(suffix: string): RefreshTokenResponse {
+  return {
+    access_token: `access-${suffix}`,
+    refresh_token: `refresh-${suffix}`,
+    token_type: 'bearer',
+    expires_in: 900,
+    refresh_expires_in: 30 * 24 * 3600,
+  } as RefreshTokenResponse
+}
+
+function authHeaderOf(call: Parameters<typeof fetch> | undefined): string | undefined {
+  const init = call?.[1]
+  const headers = init?.headers as Record<string, string> | undefined
+  return headers?.Authorization
+}
+
+const fetchMock = vi.fn<typeof fetch>()
+
+describe('apiRequest 401 refresh-and-retry', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    refreshTokenAPI.mockReset()
+    fetchMock.mockReset()
+    vi.stubGlobal('fetch', fetchMock)
+    tokenStorage.setRefreshCallbacks({})
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+    tokenStorage.cleanup()
+    vi.unstubAllGlobals()
+  })
+
+  it('refreshes once and retries with the new token after a 401', async () => {
+    seedLiveTokens()
+    refreshTokenAPI.mockResolvedValue(refreshResponse('fresh'))
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(401, { detail: 'expired' }))
+      .mockResolvedValueOnce(jsonResponse(200, { ok: true }))
+
+    const result = await apiGet<{ ok: boolean }>('/api/v1/entities')
+
+    expect(result).toEqual({ ok: true })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(refreshTokenAPI).toHaveBeenCalledTimes(1)
+    // The first attempt carried the dead token; the retry carries the fresh one.
+    expect(authHeaderOf(fetchMock.mock.calls[0])).toBe('Bearer access-original')
+    expect(authHeaderOf(fetchMock.mock.calls[1])).toBe('Bearer access-fresh')
+  })
+
+  it('surfaces the 401 when the retry still fails', async () => {
+    seedLiveTokens()
+    refreshTokenAPI.mockResolvedValue(refreshResponse('fresh'))
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(401, { detail: 'expired' }))
+      .mockResolvedValueOnce(jsonResponse(401, { detail: 'still dead' }))
+
+    await expect(apiGet('/api/v1/entities')).rejects.toMatchObject({ status: 401 })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(refreshTokenAPI).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not refresh-and-retry auth endpoints (avoids recursing into the refresh)', async () => {
+    seedLiveTokens()
+    refreshTokenAPI.mockResolvedValue(refreshResponse('fresh'))
+    fetchMock.mockResolvedValueOnce(jsonResponse(401, { detail: 'bad refresh token' }))
+
+    await expect(apiGet('/api/auth/refresh')).rejects.toMatchObject({ status: 401 })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(refreshTokenAPI).not.toHaveBeenCalled()
+  })
+
+  it('does not retry when no valid refresh token is available', async () => {
+    // Live access token but an expired refresh token: nothing to refresh with.
+    const now = Date.now()
+    localStorage.setItem('auth_token', 'access-original')
+    localStorage.setItem('refresh_token', 'refresh-original')
+    localStorage.setItem('token_expiry', String(now + 600_000))
+    localStorage.setItem('refresh_token_expiry', String(now - 1_000))
+    fetchMock.mockResolvedValueOnce(jsonResponse(401, { detail: 'expired' }))
+
+    await expect(apiGet('/api/v1/entities')).rejects.toMatchObject({ status: 401 })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(refreshTokenAPI).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -175,9 +175,9 @@ export async function apiRequest<T>(
 ): Promise<T> {
   const fullUrl = url.startsWith('/') ? url : `${API_BASE}/${url}`;
 
-  await ensureFreshAccessToken();
-
-  const response = await fetch(fullUrl, {
+  // Build the request each time so a retry picks up the freshly-refreshed token
+  // via getAuthHeader() rather than reusing the dead one.
+  const buildInit = (): RequestInit => ({
     ...defaultOptions,
     ...options,
     headers: {
@@ -187,7 +187,41 @@ export async function apiRequest<T>(
     },
   });
 
+  await ensureFreshAccessToken();
+
+  const response = await fetch(fullUrl, buildInit());
+
+  // A 401 means the access token was already dead when the request left: the
+  // proactive refresh above only fires inside the pre-expiry buffer, and a
+  // backgrounded tablet/phone can wake with an expired token (its refresh timer
+  // was throttled while asleep). Refresh once and retry before surfacing the
+  // failure, so a transient expiry doesn't blank the query and strand the UI on
+  // stale/empty data. Mirrors the SSE client's 401 handling.
+  //
+  // Auth endpoints are excluded: /api/auth/refresh is how we refresh, so
+  // retrying it here would re-enter attemptTokenRefresh and deadlock on its own
+  // coalesced in-flight promise.
+  if (
+    response.status === 401 &&
+    !isAuthEndpoint(url) &&
+    tokenStorage.isRefreshTokenValid()
+  ) {
+    const refreshed = await tokenStorage.attemptTokenRefresh().catch(() => false);
+    if (refreshed) {
+      return handleApiResponse<T>(await fetch(fullUrl, buildInit()));
+    }
+  }
+
   return handleApiResponse<T>(response);
+}
+
+/**
+ * Token-management endpoints must not trigger the request-time 401 refresh:
+ * they either manage the token lifecycle themselves or would recurse into the
+ * in-flight refresh they are part of.
+ */
+function isAuthEndpoint(url: string): boolean {
+  return url.includes('/api/auth/');
 }
 
 /**

--- a/tests/services/test_session_service_identity_claims.py
+++ b/tests/services/test_session_service_identity_claims.py
@@ -1,0 +1,152 @@
+"""Regression tests: access tokens minted by ``SessionService`` keep identity.
+
+The service-mode token lifecycle mints access tokens in :class:`SessionService`
+(on session creation and on refresh). Historically both paths called
+``TokenService.generate_access_token(user_id)`` with no claims, so a refreshed
+token carried only ``sub``: ``/api/auth/me`` then reported an empty
+username/email and defaulted ``role`` to ``"user"``. The UI rendered the bare
+user_id (a UUID) in the sidebar and silently downgraded admins. These tests pin
+the fix — identity claims stashed in the session's ``device_info`` are
+re-attached to every minted access token.
+"""
+
+from datetime import UTC, datetime
+from typing import Any
+
+import jwt
+import pytest
+
+from backend.services.auth.sessions import SessionService
+from backend.services.auth.tokens import TokenService
+
+JWT_SECRET = "test-secret"  # noqa: S105
+JWT_ALGORITHM = "HS256"
+
+
+class _PassthroughMonitor:
+    """Performance monitor stub: returns the method unwrapped."""
+
+    def monitor_service_method(self, _service: str, _method: str, **_kwargs: Any):
+        return lambda func: func
+
+
+class _InMemorySessionRepo:
+    """Minimal SessionRepository surface used by SessionService."""
+
+    def __init__(self) -> None:
+        self._sessions: dict[str, dict[str, Any]] = {}
+
+    async def get_active_session_count(self, _user_id: str) -> int:
+        return 0
+
+    async def get_user_sessions(self, user_id: str) -> list[dict[str, Any]]:
+        return [s for s in self._sessions.values() if s["user_id"] == user_id]
+
+    async def revoke_user_session(self, refresh_token: str) -> bool:
+        return self._sessions.pop(refresh_token, None) is not None
+
+    async def create_user_session(
+        self,
+        user_id: str,
+        refresh_token: str,
+        device_info: dict[str, Any],
+        expires_at: datetime,
+    ) -> bool:
+        self._sessions[refresh_token] = {
+            "user_id": user_id,
+            "refresh_token": refresh_token,
+            "device_info": device_info,
+            "expires_at": expires_at,
+            "created_at": datetime.now(UTC),
+        }
+        return True
+
+    async def get_user_session(self, refresh_token: str) -> dict[str, Any] | None:
+        return self._sessions.get(refresh_token)
+
+
+def _decode(token: str) -> dict[str, Any]:
+    return jwt.decode(token, JWT_SECRET, algorithms=[JWT_ALGORITHM])
+
+
+@pytest.fixture
+def service() -> SessionService:
+    token_service = TokenService(
+        jwt_secret=JWT_SECRET,
+        jwt_algorithm=JWT_ALGORITHM,
+        access_token_expire_minutes=15,
+        magic_link_expire_minutes=15,
+    )
+    return SessionService(
+        token_service=token_service,
+        session_repository=_InMemorySessionRepo(),
+        performance_monitor=_PassthroughMonitor(),
+    )
+
+
+DEVICE_INFO = {
+    "username": "ryan",
+    "email": "ryan@example.com",
+    "role": "admin",
+    "mode": "oidc",
+    "provider": "pocketid",
+    # Session bookkeeping that must NOT leak into the JWT.
+    "fingerprint": "abc123",
+    "user_agent": "pytest",
+    "ip_subnet": "10.0.0",
+}
+
+
+@pytest.mark.asyncio
+async def test_create_session_access_token_carries_identity(service: SessionService) -> None:
+    access_token, _refresh = await service.create_session("user-uuid", dict(DEVICE_INFO))
+
+    claims = _decode(access_token)
+    assert claims["sub"] == "user-uuid"
+    assert claims["username"] == "ryan"
+    assert claims["email"] == "ryan@example.com"
+    assert claims["role"] == "admin"
+    assert claims["mode"] == "oidc"
+
+
+@pytest.mark.asyncio
+async def test_refreshed_access_token_preserves_identity(service: SessionService) -> None:
+    _access, refresh_token = await service.create_session("user-uuid", dict(DEVICE_INFO))
+
+    refreshed = await service.refresh_access_token(refresh_token)
+
+    assert refreshed is not None
+    claims = _decode(refreshed)
+    # The whole point of the fix: a refresh must not degrade the identity.
+    assert claims["sub"] == "user-uuid"
+    assert claims["username"] == "ryan"
+    assert claims["email"] == "ryan@example.com"
+    assert claims["role"] == "admin"
+    assert claims["mode"] == "oidc"
+
+
+@pytest.mark.asyncio
+async def test_minted_tokens_omit_session_bookkeeping(service: SessionService) -> None:
+    access_token, refresh_token = await service.create_session("user-uuid", dict(DEVICE_INFO))
+    refreshed = await service.refresh_access_token(refresh_token)
+
+    for token in (access_token, refreshed):
+        assert token is not None
+        claims = _decode(token)
+        assert "fingerprint" not in claims
+        assert "user_agent" not in claims
+        assert "ip_subnet" not in claims
+
+
+@pytest.mark.asyncio
+async def test_refresh_without_stored_identity_still_works(service: SessionService) -> None:
+    # A session created without identity claims (e.g. a legacy row) must still
+    # refresh; the token just falls back to bare defaults rather than crashing.
+    _access, refresh_token = await service.create_session("user-uuid", {})
+
+    refreshed = await service.refresh_access_token(refresh_token)
+
+    assert refreshed is not None
+    claims = _decode(refreshed)
+    assert claims["sub"] == "user-uuid"
+    assert "username" not in claims


### PR DESCRIPTION
## Problem

Two symptoms reported from the Climate page, both rooted in the **access-token refresh cycle**:

1. **User ID degrades to a UUID.** The sidebar showed a bare `user_id` (a UUID) with a `user` role badge instead of the real username/role — appearing only *after some time*, not right after login.
2. **Entity cards blank out** (`Updated unknown` / `no sensor data`), alongside `401`s on `GET /api/v1/entities/health` in the console. Tell-tale detail: one card (Bay Heat) kept live data while the rest went blank.

## Root cause

Login mints a *rich* access token (username, email, role, mode), but it's short-lived and the frontend silently refreshes it. Two things went wrong at refresh time:

- **Backend (identity):** In service mode, `SessionService` minted access tokens with **only `sub`** on both session creation and refresh, dropping the identity claims. So on the first background refresh, `/api/auth/me` began returning an empty username/email and a default role of `user` — the sidebar fell back to the UUID and admins were silently downgraded.
- **Frontend (blanked entries):** `apiRequest` refreshed only *proactively* (inside the pre-expiry buffer) and **never retried on a `401`**. A request that left with a just-expired token errored the query and blanked the entity collections; only entities that then received a live SSE `entity_update` (e.g. Bay Heat) kept any data.

## Changes

- **`backend/services/auth/sessions.py`** — re-attach the identity claims that login already stashes in the session's `device_info` (persisted to the `user_sessions` table, so it survives a backend restart) to every access token minted on create/refresh. Session bookkeeping (fingerprint, user_agent, ip_subnet) is filtered out so it never leaks into the JWT.
- **`frontend/src/api/client.ts`** — on a `401`, do one coalesced token refresh + single retry with the fresh token before surfacing the failure (mirrors the SSE client's 401 handling). Auth endpoints are excluded so retrying `/api/auth/refresh` can't recurse into its own in-flight refresh and deadlock.

## Tests

- `tests/services/test_session_service_identity_claims.py` — 4 new tests: create/refresh preserve identity, bookkeeping omitted, empty-device_info still refreshes. Related auth suites still green (25 tests).
- `frontend/src/api/__tests__/client-auth-retry.test.ts` — 4 new tests: refresh+retry on 401, surfaces persistent 401, no retry for auth endpoints, no retry without a valid refresh token. `tsc` clean, eslint 0 errors.

Not exercised via browser preview — neither change is observable without a live OIDC backend and a real token-expiry cycle, so the unit tests are the verification.

## Note

Already-degraded tokens in an open browser session will still show the UUID until their next refresh (or a fresh login) picks up the corrected token — the fix is on the mint path; nothing to migrate server-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)