### PR TITLE
feat(location): trip names, live trail, SSE position, odometer, merge

### DIFF
--- a/backend/api/routers/location.py
+++ b/backend/api/routers/location.py
@@ -60,6 +60,57 @@ async def list_trips(
     return {"trips": trips, "count": len(trips)}
 
 
+@router.get("/trips/summary", summary="Aggregate trip statistics")
+async def get_trip_summary(
+    trip_log_repository: Annotated[Any, Depends(get_optional_trip_log_repository)],
+) -> dict[str, Any]:
+    """Odometer-style totals over all recorded trips plus the current year."""
+    repository = _require(trip_log_repository, "Trip log")
+    year_start = datetime(datetime.now(tz=UTC).year, 1, 1, tzinfo=UTC).timestamp()
+    return {
+        "all_time": await repository.get_trip_summary(),
+        "year": await repository.get_trip_summary(since=year_start),
+    }
+
+
+@router.post("/trips/{trip_id}/merge-previous", summary="Merge a trip into the one before it")
+async def merge_trip_with_previous(
+    trip_id: int,
+    trip_log_repository: Annotated[Any, Depends(get_optional_trip_log_repository)],
+) -> dict[str, Any]:
+    """Fold a trip into its predecessor (e.g. one drive split by a lunch stop)."""
+    from backend.integrations.router_sidecar.location import haversine_distance_m
+
+    repository = _require(trip_log_repository, "Trip log")
+    trip = await repository.get_trip(trip_id)
+    if trip is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Trip not found")
+    if trip["ended_at"] is None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Trip is still recording; it can be merged once it ends",
+        )
+    previous = await repository.get_previous_trip(trip_id)
+    if previous is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="No earlier trip to merge into"
+        )
+    bridge_m = 0.0
+    if previous["end_latitude"] is not None:
+        bridge_m = haversine_distance_m(
+            previous["end_latitude"],
+            previous["end_longitude"],
+            trip["start_latitude"],
+            trip["start_longitude"],
+        )
+    merged = await repository.merge_trips(
+        source_id=trip_id, target_id=previous["id"], bridge_distance_m=bridge_m
+    )
+    if merged is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Trip not found")
+    return {"merged": merged}
+
+
 @router.get("/trips/{trip_id}/points", summary="Breadcrumbs for one trip")
 async def get_trip_points(
     trip_id: int,

--- a/backend/core/composition_root.py
+++ b/backend/core/composition_root.py
@@ -1038,6 +1038,7 @@ class CompositionRoot:
             trip_log_service = TripLogService(
                 settings=trip_log_settings,
                 trip_log_repository=self.require_service("trip_log_repository"),
+                event_broker=self.get_optional_service("event_broker"),
             )
             await trip_log_service.start()
             self._set_root_constructed_service("trip_log_service", trip_log_service)

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -1319,9 +1319,17 @@ class TripLogSettings(BaseSettings):
         gt=0,
     )
     retention_days: int = Field(
-        default=0,
+        default=365,
         description="Days of breadcrumbs to keep; 0 keeps everything",
         ge=0,
+    )
+    geocode_enabled: bool = Field(
+        default=True,
+        description="Reverse-geocode trip start/end into place names via Nominatim",
+    )
+    geocode_url: str = Field(
+        default="https://nominatim.openstreetmap.org/reverse",
+        description="Reverse-geocoding endpoint (Nominatim-compatible)",
     )
 
 

--- a/backend/models/trip_log.py
+++ b/backend/models/trip_log.py
@@ -6,7 +6,7 @@ stretch of movement bounded by stationary gaps). Tables are created by the
 startup ``Base.metadata.create_all`` pass like the analytics tables.
 """
 
-from sqlalchemy import Float, Index, Integer
+from sqlalchemy import Float, Index, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from backend.models.database import Base, TimestampMixin
@@ -33,6 +33,12 @@ class GpsTrip(Base, TimestampMixin):
     )
     max_speed_mps: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
     point_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    start_place: Mapped[str | None] = mapped_column(
+        String, nullable=True, comment="Reverse-geocoded start locality"
+    )
+    end_place: Mapped[str | None] = mapped_column(
+        String, nullable=True, comment="Reverse-geocoded end locality"
+    )
 
 
 class GpsBreadcrumb(Base, TimestampMixin):

--- a/backend/repositories/trip_log_repository.py
+++ b/backend/repositories/trip_log_repository.py
@@ -3,7 +3,7 @@
 import logging
 from typing import Any
 
-from sqlalchemy import delete, func, select, update
+from sqlalchemy import delete, func, select, text, update
 
 from backend.core.performance import PerformanceMonitor
 from backend.models.trip_log import GpsBreadcrumb, GpsTrip
@@ -39,6 +39,15 @@ class TripLogRepository(MonitoredRepository):
                     tables=[GpsTrip.__table__, GpsBreadcrumb.__table__],
                 )
             )
+            # create_all never alters existing tables, so columns added after
+            # the feature first shipped are patched in here (SQLite ALTER).
+            result = await session.execute(text("PRAGMA table_info(gps_trips)"))
+            existing = {row[1] for row in result}
+            for column in ("start_place", "end_place"):
+                if column not in existing:
+                    await session.execute(
+                        text(f"ALTER TABLE gps_trips ADD COLUMN {column} VARCHAR")
+                    )
             await session.commit()
 
     @MonitoredRepository._monitored_operation("start_trip")  # noqa: SLF001 - repo-standard decorator (see analytics_repository)
@@ -191,6 +200,112 @@ class TripLogRepository(MonitoredRepository):
             await session.commit()
             return len(trip_ids)
 
+    @MonitoredRepository._monitored_operation("get_trip_summary")  # noqa: SLF001 - repo-standard decorator (see analytics_repository)
+    async def get_trip_summary(self, since: float | None = None) -> dict[str, Any]:
+        """Aggregate stats over closed trips, optionally started after ``since``."""
+        conditions = [GpsTrip.ended_at.is_not(None)]
+        if since is not None:
+            conditions.append(GpsTrip.started_at >= since)
+        async with self._db_manager.get_session() as session:
+            result = await session.execute(
+                select(
+                    func.count(GpsTrip.id),
+                    func.coalesce(func.sum(GpsTrip.distance_m), 0.0),
+                    func.coalesce(func.sum(GpsTrip.ended_at - GpsTrip.started_at), 0.0),
+                    func.coalesce(func.max(GpsTrip.max_speed_mps), 0.0),
+                ).where(*conditions)
+            )
+            count, distance_m, duration_s, max_speed = result.one()
+            return {
+                "trip_count": int(count),
+                "distance_m": float(distance_m),
+                "duration_s": float(duration_s),
+                "max_speed_mps": float(max_speed),
+            }
+
+    @MonitoredRepository._monitored_operation("get_previous_trip")  # noqa: SLF001 - repo-standard decorator (see analytics_repository)
+    async def get_previous_trip(self, trip_id: int) -> dict[str, Any] | None:
+        """Return the closed trip that immediately precedes the given one."""
+        async with self._db_manager.get_session() as session:
+            anchor = await session.get(GpsTrip, trip_id)
+            if anchor is None:
+                return None
+            result = await session.execute(
+                select(GpsTrip)
+                .where(
+                    GpsTrip.ended_at.is_not(None),
+                    GpsTrip.started_at < anchor.started_at,
+                    GpsTrip.id != trip_id,
+                )
+                .order_by(GpsTrip.started_at.desc())
+                .limit(1)
+            )
+            trip = result.scalar_one_or_none()
+            return _trip_to_dict(trip) if trip else None
+
+    @MonitoredRepository._monitored_operation("merge_trips")  # noqa: SLF001 - repo-standard decorator (see analytics_repository)
+    async def merge_trips(
+        self, source_id: int, target_id: int, bridge_distance_m: float = 0.0
+    ) -> dict[str, Any] | None:
+        """Fold ``source`` (the newer trip) into ``target`` (the older one).
+
+        Breadcrumbs move to the target; distance sums (plus the gap bridge),
+        the end position/place comes from the source, and the source row is
+        deleted. Returns the merged trip.
+        """
+        async with self._db_manager.get_session() as session:
+            source = await session.get(GpsTrip, source_id)
+            target = await session.get(GpsTrip, target_id)
+            if source is None or target is None:
+                return None
+            await session.execute(
+                update(GpsBreadcrumb)
+                .where(GpsBreadcrumb.trip_id == source_id)
+                .values(trip_id=target_id)
+            )
+            target.ended_at = source.ended_at
+            target.end_latitude = source.end_latitude
+            target.end_longitude = source.end_longitude
+            target.end_place = source.end_place
+            target.distance_m = target.distance_m + source.distance_m + bridge_distance_m
+            target.max_speed_mps = max(target.max_speed_mps, source.max_speed_mps)
+            target.point_count = target.point_count + source.point_count
+            await session.delete(source)
+            await session.commit()
+            await session.refresh(target)
+            return _trip_to_dict(target)
+
+    @MonitoredRepository._monitored_operation("set_trip_places")  # noqa: SLF001 - repo-standard decorator (see analytics_repository)
+    async def set_trip_places(
+        self, trip_id: int, start_place: str | None, end_place: str | None
+    ) -> None:
+        """Store reverse-geocoded place names on a trip (None values are kept as-is)."""
+        values: dict[str, str] = {}
+        if start_place is not None:
+            values["start_place"] = start_place
+        if end_place is not None:
+            values["end_place"] = end_place
+        if not values:
+            return
+        async with self._db_manager.get_session() as session:
+            await session.execute(update(GpsTrip).where(GpsTrip.id == trip_id).values(**values))
+            await session.commit()
+
+    @MonitoredRepository._monitored_operation("get_trips_missing_places")  # noqa: SLF001 - repo-standard decorator (see analytics_repository)
+    async def get_trips_missing_places(self, limit: int = 20) -> list[dict[str, Any]]:
+        """Newest closed trips that have no geocoded place names yet."""
+        async with self._db_manager.get_session() as session:
+            result = await session.execute(
+                select(GpsTrip)
+                .where(
+                    GpsTrip.ended_at.is_not(None),
+                    GpsTrip.start_place.is_(None) | GpsTrip.end_place.is_(None),
+                )
+                .order_by(GpsTrip.started_at.desc())
+                .limit(limit)
+            )
+            return [_trip_to_dict(trip) for trip in result.scalars()]
+
     @MonitoredRepository._monitored_operation("prune_older_than")  # noqa: SLF001 - repo-standard decorator (see analytics_repository)
     async def prune_older_than(self, cutoff_timestamp: float) -> int:
         """Delete breadcrumbs (and fully-pruned trips) older than the cutoff."""
@@ -223,6 +338,8 @@ def _trip_to_dict(trip: GpsTrip) -> dict[str, Any]:
         "distance_m": trip.distance_m,
         "max_speed_mps": trip.max_speed_mps,
         "point_count": trip.point_count,
+        "start_place": trip.start_place,
+        "end_place": trip.end_place,
         "active": trip.ended_at is None,
     }
 

--- a/backend/services/trip_log/geocoding.py
+++ b/backend/services/trip_log/geocoding.py
@@ -1,0 +1,72 @@
+"""
+Reverse geocoding for trip start/end place names.
+
+Uses a Nominatim-compatible endpoint (default: the public OSM instance) to
+turn coordinates into a short "Locality, Region" label. Failures are soft —
+the RV is frequently offline, so callers treat ``None`` as "try again later".
+
+The public Nominatim usage policy requires a descriptive User-Agent and at
+most one request per second; callers are responsible for the pacing.
+"""
+
+from typing import Any
+
+import httpx
+
+from backend.core.structured_logging import get_logger
+
+logger = get_logger(__name__, "ReverseGeocoder")
+
+_TIMEOUT_SECONDS = 10.0
+_USER_AGENT = "CoachIQ/1.0 (https://github.com/carpenike/coachiq)"
+# Nominatim zoom 10 resolves to city/town granularity.
+_ZOOM = 10
+
+# Most-specific-first keys Nominatim uses for the locality.
+_LOCALITY_KEYS = ("city", "town", "village", "hamlet", "municipality", "locality", "county")
+
+
+def _short_place(payload: dict[str, Any]) -> str | None:
+    """Reduce a Nominatim response to "Locality, Region"."""
+    address = payload.get("address") or {}
+    locality = next(
+        (address[key] for key in _LOCALITY_KEYS if address.get(key)),
+        None,
+    )
+    region = address.get("state") or address.get("region")
+    if locality and region:
+        return f"{locality}, {region}"
+    if locality:
+        return str(locality)
+    display = payload.get("display_name")
+    if isinstance(display, str) and display:
+        return ", ".join(part.strip() for part in display.split(",")[:2])
+    return None
+
+
+class ReverseGeocoder:
+    """Thin async client for Nominatim ``/reverse``."""
+
+    def __init__(self, url: str) -> None:
+        self._url = url
+
+    async def reverse(self, latitude: float, longitude: float) -> str | None:
+        """Return a short place label for the coordinates, or None on any failure."""
+        params = {
+            "format": "jsonv2",
+            "lat": f"{latitude:.6f}",
+            "lon": f"{longitude:.6f}",
+            "zoom": str(_ZOOM),
+            "addressdetails": "1",
+        }
+        try:
+            async with httpx.AsyncClient(timeout=_TIMEOUT_SECONDS) as client:
+                response = await client.get(
+                    self._url, params=params, headers={"User-Agent": _USER_AGENT}
+                )
+                response.raise_for_status()
+                return _short_place(response.json())
+        except (httpx.HTTPError, ValueError) as exc:
+            # Offline or rate-limited: normal on the road, not an error.
+            logger.debug("Reverse geocode failed (%s); will retry later", exc)
+            return None

--- a/backend/services/trip_log/geocoding.py
+++ b/backend/services/trip_log/geocoding.py
@@ -66,7 +66,6 @@ class ReverseGeocoder:
                 )
                 response.raise_for_status()
                 return _short_place(response.json())
-        except (httpx.HTTPError, ValueError) as exc:
-            # Offline or rate-limited: normal on the road, not an error.
+        except Exception as exc:  # offline or rate-limited: normal on the road
             logger.debug("Reverse geocode failed (%s); will retry later", exc)
             return None

--- a/backend/services/trip_log/trip_log_service.py
+++ b/backend/services/trip_log/trip_log_service.py
@@ -28,6 +28,7 @@ from backend.core.config import TripLogSettings
 from backend.core.structured_logging import get_logger
 from backend.integrations.router_sidecar.gpsd import GpsdClient, GpsdTpv
 from backend.integrations.router_sidecar.location import haversine_distance_m
+from backend.services.trip_log.geocoding import ReverseGeocoder
 
 logger = get_logger(__name__, "TripLogService")
 
@@ -37,19 +38,43 @@ _RECONNECT_DELAY_SECONDS = 5.0
 _MAX_RECONNECT_DELAY_SECONDS = 60.0
 _PRUNE_INTERVAL_SECONDS = 24 * 3600.0
 
+# SSE position publishing: heartbeat while parked, movement-gated while
+# driving so the broker isn't fed a 1 Hz firehose.
+_PUBLISH_HEARTBEAT_SECONDS = 30.0
+_PUBLISH_MIN_INTERVAL_SECONDS = 2.0
+_PUBLISH_MIN_MOVE_M = 10.0
+
+# Nominatim usage policy: at most one request per second.
+_GEOCODE_PACING_SECONDS = 1.1
+_GEOCODE_BACKFILL_LIMIT = 20
+
 
 class TripLogService:
     """Background recorder of GPS breadcrumbs segmented into trips."""
 
-    def __init__(self, settings: TripLogSettings, trip_log_repository: Any) -> None:
+    def __init__(
+        self,
+        settings: TripLogSettings,
+        trip_log_repository: Any,
+        event_broker: Any = None,
+    ) -> None:
         self._settings = settings
         self._repository = trip_log_repository
+        self._event_broker = event_broker
         self._client = GpsdClient(settings.gpsd_host, settings.gpsd_port)
+        self._geocoder = ReverseGeocoder(settings.geocode_url)
 
         self._running = False
         self._task: asyncio.Task | None = None
         self._prune_task: asyncio.Task | None = None
+        self._geocode_backfill_task: asyncio.Task | None = None
+        self._geocode_tasks: set[asyncio.Task] = set()
         self._connected = False
+
+        # SSE publish throttle state
+        self._last_published_at = 0.0
+        self._last_published_pos: tuple[float, float] | None = None
+        self._last_published_trip_id: int | None = None
 
         # Sampling state
         self._active_trip_id: int | None = None
@@ -79,6 +104,8 @@ class TripLogService:
         self._task = asyncio.create_task(self._watch_loop())
         if self._settings.retention_days > 0:
             self._prune_task = asyncio.create_task(self._prune_loop())
+        if self._settings.geocode_enabled:
+            self._geocode_backfill_task = asyncio.create_task(self._geocode_backfill())
         logger.info("Trip Log Service started")
 
     async def stop(self) -> None:
@@ -86,13 +113,17 @@ class TripLogService:
         if not self._running:
             return
         self._running = False
-        for task in (self._task, self._prune_task):
+        tasks = [self._task, self._prune_task, self._geocode_backfill_task]
+        tasks.extend(self._geocode_tasks)
+        for task in tasks:
             if task:
                 task.cancel()
                 with contextlib.suppress(asyncio.CancelledError):
                     await task
         self._task = None
         self._prune_task = None
+        self._geocode_backfill_task = None
+        self._geocode_tasks.clear()
         logger.info("Trip Log Service stopped")
 
     # ------------------------------------------------------------------
@@ -134,6 +165,14 @@ class TripLogService:
         self._last_fix = tpv
         self._last_fix_at = now
 
+        try:
+            await self._track_movement(tpv, now)
+        finally:
+            await self._maybe_publish_position(tpv, now)
+
+    async def _track_movement(self, tpv: GpsdTpv, now: float) -> None:
+        if tpv.lat is None or tpv.lon is None:  # narrowed by caller; keeps pyright honest
+            return
         speed = tpv.speed or 0.0
         moving_by_speed = speed >= self._settings.stationary_speed_mps
         distance_from_last = (
@@ -227,8 +266,103 @@ class TripLogService:
                 longitude=self._last_recorded[1],
             )
             logger.info("Trip ended", trip_id=trip_id)
+            if self._settings.geocode_enabled:
+                self._spawn_geocode(trip_id)
         self._active_trip_id = None
         self._active_trip_distance_m = 0.0
+
+    # ------------------------------------------------------------------
+    # SSE position publishing
+    # ------------------------------------------------------------------
+
+    async def _maybe_publish_position(self, tpv: GpsdTpv, now: float) -> None:
+        """Push the current position to SSE subscribers, throttled.
+
+        Publishes immediately on trip start/end, on a slow heartbeat while
+        parked, and per ~10 m of movement (min 2 s apart) while driving.
+        """
+        if self._event_broker is None:
+            return
+        trip_changed = self._active_trip_id != self._last_published_trip_id
+        elapsed = now - self._last_published_at
+        moved = (
+            haversine_distance_m(
+                self._last_published_pos[0], self._last_published_pos[1], tpv.lat, tpv.lon
+            )
+            if self._last_published_pos is not None and tpv.lat is not None
+            else None
+        )
+        due = (
+            trip_changed
+            or elapsed >= _PUBLISH_HEARTBEAT_SECONDS
+            or (
+                elapsed >= _PUBLISH_MIN_INTERVAL_SECONDS
+                and (moved is None or moved >= _PUBLISH_MIN_MOVE_M)
+            )
+        )
+        if not due:
+            return
+        try:
+            await self._event_broker.publish("location_update", self.get_current_position())
+        except Exception:
+            logger.exception("Error publishing location update")
+            return
+        self._last_published_at = now
+        self._last_published_trip_id = self._active_trip_id
+        if tpv.lat is not None and tpv.lon is not None:
+            self._last_published_pos = (tpv.lat, tpv.lon)
+
+    # ------------------------------------------------------------------
+    # Reverse geocoding
+    # ------------------------------------------------------------------
+
+    def _spawn_geocode(self, trip_id: int) -> None:
+        """Geocode a finished trip in the background (offline-tolerant)."""
+        task = asyncio.create_task(self._geocode_trip_by_id(trip_id))
+        self._geocode_tasks.add(task)
+        task.add_done_callback(self._geocode_tasks.discard)
+
+    async def _geocode_trip_by_id(self, trip_id: int) -> None:
+        try:
+            trip = await self._repository.get_trip(trip_id)
+            if trip is not None:
+                await self._geocode_trip(trip)
+        except Exception:
+            logger.exception("Error geocoding trip %s", trip_id)
+
+    async def _geocode_trip(self, trip: dict[str, Any]) -> bool:
+        """Fill missing place names for one trip; True if anything resolved."""
+        start_place = None
+        end_place = None
+        if trip.get("start_place") is None:
+            start_place = await self._geocoder.reverse(
+                trip["start_latitude"], trip["start_longitude"]
+            )
+            await asyncio.sleep(_GEOCODE_PACING_SECONDS)
+        if trip.get("end_place") is None and trip.get("end_latitude") is not None:
+            end_place = await self._geocoder.reverse(trip["end_latitude"], trip["end_longitude"])
+            await asyncio.sleep(_GEOCODE_PACING_SECONDS)
+        if start_place is None and end_place is None:
+            return False
+        await self._repository.set_trip_places(trip["id"], start_place, end_place)
+        return True
+
+    async def _geocode_backfill(self) -> None:
+        """Name recent trips that predate geocoding (or ended while offline)."""
+        try:
+            trips = await self._repository.get_trips_missing_places(_GEOCODE_BACKFILL_LIMIT)
+            named = 0
+            for trip in trips:
+                if not await self._geocode_trip(trip):
+                    # Offline (or the geocoder is refusing) — try again next start.
+                    break
+                named += 1
+            if named:
+                logger.info("Geocoded %d trips", named)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("Error in geocode backfill")
 
     async def _resume_or_close_dangling_trip(self) -> None:
         """After a restart, resume a recent active trip or close a stale one."""

--- a/frontend/src/api/location.ts
+++ b/frontend/src/api/location.ts
@@ -2,7 +2,7 @@
  * Location API client (/api/location) — current GPS position and trip log.
  */
 
-import { apiDelete, apiGet, apiGetBlob } from './client';
+import { apiDelete, apiGet, apiGetBlob, apiPost } from './client';
 
 export interface ICurrentLocation {
   connected: boolean;
@@ -27,7 +27,21 @@ export interface ITrip {
   distance_m: number;
   max_speed_mps: number;
   point_count: number;
+  start_place: string | null;
+  end_place: string | null;
   active: boolean;
+}
+
+export interface ITripSummaryBucket {
+  trip_count: number;
+  distance_m: number;
+  duration_s: number;
+  max_speed_mps: number;
+}
+
+export interface ITripSummary {
+  all_time: ITripSummaryBucket;
+  year: ITripSummaryBucket;
 }
 
 export interface ITripPoint {
@@ -68,4 +82,16 @@ export async function downloadTripGpx(tripId: number): Promise<void> {
 
 export async function deleteTrip(tripId: number): Promise<void> {
   await apiDelete(`/api/location/trips/${tripId}`);
+}
+
+export async function fetchTripSummary(): Promise<ITripSummary> {
+  return apiGet<ITripSummary>('/api/location/trips/summary');
+}
+
+/** Fold a trip into the one before it (a drive split by a long stop). */
+export async function mergeTripWithPrevious(tripId: number): Promise<ITrip> {
+  const result = await apiPost<{ merged: ITrip }>(
+    `/api/location/trips/${tripId}/merge-previous`
+  );
+  return result.merged;
 }

--- a/frontend/src/contexts/realtime-provider.tsx
+++ b/frontend/src/contexts/realtime-provider.tsx
@@ -55,6 +55,10 @@ export function RealtimeProvider({ children }: { readonly children: React.ReactN
         applyEntityUpdate(client, data as IEntityUpdatePayload)
       } else if (event === 'entity_created' || event === 'halt_command_emission') {
         void client.invalidateQueries({ queryKey: entitiesQueryKeys.collections() })
+      } else if (event === 'location_update') {
+        // Payload matches GET /api/location, so it drops straight into the
+        // query the location page already reads.
+        client.setQueryData(['location', 'current'], data)
       }
     },
     onStateChange: (state) => {

--- a/frontend/src/pages/location.tsx
+++ b/frontend/src/pages/location.tsx
@@ -10,6 +10,8 @@
 import "leaflet/dist/leaflet.css"
 
 import {
+  IconArrowMerge,
+  IconCurrentLocation,
   IconDownload,
   IconPlayerPause,
   IconPlayerPlay,
@@ -18,7 +20,14 @@ import {
   IconTrash,
 } from "@tabler/icons-react"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
-import { useEffect, useMemo, useState } from "react"
+import {
+  useEffect,
+  useMemo,
+  useState,
+  type Dispatch,
+  type ReactNode,
+  type SetStateAction,
+} from "react"
 import { CircleMarker, MapContainer, Polyline, TileLayer, useMap } from "react-leaflet"
 import { toast } from "sonner"
 
@@ -28,6 +37,8 @@ import {
   fetchCurrentLocation,
   fetchTripPoints,
   fetchTrips,
+  fetchTripSummary,
+  mergeTripWithPrevious,
   type ITrip,
   type ITripPoint,
 } from "@/api/location"
@@ -72,6 +83,24 @@ function fmtClock(seconds: number): string {
   })
 }
 
+function fmtMilesLong(meters: number): string {
+  return `${Math.round(meters / METERS_PER_MILE).toLocaleString()} mi`
+}
+
+/** "Nags Head, North Carolina" -> "Nags Head" (for compact A -> B titles). */
+function localityOnly(place: string): string {
+  return place.split(",")[0]?.trim() ?? place
+}
+
+function tripTitle(trip: ITrip): string {
+  if (trip.start_place && trip.end_place) {
+    return trip.start_place === trip.end_place
+      ? trip.start_place
+      : `${localityOnly(trip.start_place)} → ${localityOnly(trip.end_place)}`
+  }
+  return fmtTripDate(trip.started_at)
+}
+
 /**
  * Keep Leaflet's internal size in sync with the container. Leaflet measures
  * once at init; if the tab/panel is laid out later (background tab, sidebar
@@ -105,6 +134,16 @@ function FitBounds({ positions }: Readonly<{ positions: [number, number][] }>) {
 function gpsStatusLabel(fix: boolean, connected: boolean): string {
   if (fix) return "GPS fix"
   return connected ? "Waiting for fix" : "gpsd unreachable"
+}
+
+/** Keep the map centered on the coach while follow mode is on. */
+function FollowHere({ here }: Readonly<{ here: [number, number] | null }>) {
+  const map = useMap()
+  useEffect(() => {
+    if (!here) return
+    map.setView(here, Math.max(map.getZoom(), 13), { animate: true })
+  }, [map, here])
+  return null
 }
 
 // ---------------------------------------------------------------------------
@@ -161,7 +200,7 @@ interface ITripReplay {
 }
 
 /** Replay cursor over a trip's breadcrumbs, advanced on a wall-clock interval. */
-function useTripReplay(points: ITripPoint[]): ITripReplay {
+function useTripReplay(points: ITripPoint[], tripKey: number | null): ITripReplay {
   const [playing, setPlaying] = useState(false)
   const [speedIndex, setSpeedIndex] = useState(1) // 30x
   const [elapsed, setElapsed] = useState(0)
@@ -172,11 +211,12 @@ function useTripReplay(points: ITripPoint[]): ITripReplay {
   const multiplier = REPLAY_SPEEDS.at(speedIndex) ?? 30
   const active = duration > 0
 
-  // A different trip was selected: rewind.
+  // A different trip was selected: rewind. Keyed on the trip id, not the
+  // points array identity, so background refetches don't reset the cursor.
   useEffect(() => {
     setElapsed(0)
     setPlaying(false)
-  }, [points])
+  }, [tripKey])
 
   useEffect(() => {
     if (!playing || duration <= 0) return
@@ -284,10 +324,12 @@ function TrailMap({
   trail,
   here,
   replay,
+  follow,
 }: Readonly<{
   trail: [number, number][]
   here: [number, number] | null
   replay: ITripReplay
+  follow: boolean
 }>) {
   let fitTargets: [number, number][] = trail
   if (fitTargets.length === 0 && here) fitTargets = [here]
@@ -306,7 +348,7 @@ function TrailMap({
         url="https://tile.openstreetmap.org/{z}/{x}/{y}.png"
       />
       <InvalidateOnResize />
-      <FitBounds positions={fitTargets} />
+      {follow ? <FollowHere here={here} /> : <FitBounds positions={fitTargets} />}
       {trail.length > 1 && (
         <Polyline
           positions={trail}
@@ -383,20 +425,65 @@ function CurrentPositionCard() {
 interface ITripRowProps {
   trip: ITrip
   selected: boolean
+  canMerge: boolean
   onSelect: () => void
   onDelete: () => void
+  onMerge: () => void
 }
 
-function TripRow({ trip, selected, onSelect, onDelete }: Readonly<ITripRowProps>) {
-  const [confirmingDelete, setConfirmingDelete] = useState(false)
+/** Icon button whose action needs a second tap to confirm. */
+function ConfirmingIconButton({
+  icon,
+  label,
+  confirmLabel,
+  onConfirm,
+}: Readonly<{
+  icon: ReactNode
+  label: string
+  confirmLabel: string
+  onConfirm: () => void
+}>) {
+  const [confirming, setConfirming] = useState(false)
 
-  // Un-arm the delete confirmation if it isn't followed through.
+  // Un-arm if the second tap doesn't come.
   useEffect(() => {
-    if (!confirmingDelete) return
-    const id = setTimeout(() => setConfirmingDelete(false), 3_000)
+    if (!confirming) return
+    const id = setTimeout(() => setConfirming(false), 3_000)
     return () => clearTimeout(id)
-  }, [confirmingDelete])
+  }, [confirming])
 
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      className={cn(
+        "size-7 text-muted-foreground",
+        confirming && "bg-destructive/10 text-destructive"
+      )}
+      aria-label={confirming ? confirmLabel : label}
+      title={confirming ? confirmLabel : label}
+      onClick={() => {
+        if (confirming) {
+          setConfirming(false)
+          onConfirm()
+        } else {
+          setConfirming(true)
+        }
+      }}
+    >
+      {icon}
+    </Button>
+  )
+}
+
+function TripRow({
+  trip,
+  selected,
+  canMerge,
+  onSelect,
+  onDelete,
+  onMerge,
+}: Readonly<ITripRowProps>) {
   const handleDownload = async () => {
     try {
       await downloadTripGpx(trip.id)
@@ -407,6 +494,7 @@ function TripRow({ trip, selected, onSelect, onDelete }: Readonly<ITripRowProps>
     }
   }
 
+  const named = Boolean(trip.start_place && trip.end_place)
   return (
     <div
       className={cn(
@@ -416,14 +504,15 @@ function TripRow({ trip, selected, onSelect, onDelete }: Readonly<ITripRowProps>
     >
       <button type="button" onClick={onSelect} className="min-w-0 flex-1 text-left">
         <p className="truncate font-medium">
-          {fmtTripDate(trip.started_at)}
+          {tripTitle(trip)}
           {trip.active && (
             <Badge variant="default" className="ml-2 text-xs">
               live
             </Badge>
           )}
         </p>
-        <p className="text-xs text-muted-foreground">
+        <p className="truncate text-xs text-muted-foreground">
+          {named && `${fmtTripDate(trip.started_at)} · `}
           {fmtDuration(trip.started_at, trip.ended_at)} · max {fmtMph(trip.max_speed_mps)}
         </p>
       </button>
@@ -438,27 +527,21 @@ function TripRow({ trip, selected, onSelect, onDelete }: Readonly<ITripRowProps>
         >
           <IconDownload className="size-4" />
         </Button>
+        {!trip.active && canMerge && (
+          <ConfirmingIconButton
+            icon={<IconArrowMerge className="size-4" />}
+            label="Merge into previous trip"
+            confirmLabel="Tap again to merge into previous trip"
+            onConfirm={onMerge}
+          />
+        )}
         {!trip.active && (
-          <Button
-            variant="ghost"
-            size="icon"
-            className={cn(
-              "size-7 text-muted-foreground",
-              confirmingDelete && "bg-destructive/10 text-destructive"
-            )}
-            aria-label={confirmingDelete ? "Tap again to delete trip" : "Delete trip"}
-            title={confirmingDelete ? "Tap again to delete" : "Delete trip"}
-            onClick={() => {
-              if (confirmingDelete) {
-                setConfirmingDelete(false)
-                onDelete()
-              } else {
-                setConfirmingDelete(true)
-              }
-            }}
-          >
-            <IconTrash className="size-4" />
-          </Button>
+          <ConfirmingIconButton
+            icon={<IconTrash className="size-4" />}
+            label="Delete trip"
+            confirmLabel="Tap again to delete trip"
+            onConfirm={onDelete}
+          />
         )}
       </div>
     </div>
@@ -469,33 +552,116 @@ function TripRow({ trip, selected, onSelect, onDelete }: Readonly<ITripRowProps>
 // Page
 // ---------------------------------------------------------------------------
 
-export default function LocationPage() {
-  const [selectedTripId, setSelectedTripId] = useState<number | null>(null)
-  const queryClient = useQueryClient()
+const EMPTY_POINTS: ITripPoint[] = []
 
-  const { data: current } = useQuery({
-    queryKey: ["location", "current"],
-    queryFn: fetchCurrentLocation,
-    refetchInterval: 5_000,
+/** Map card with the follow-the-coach toggle and (for finished trips) replay. */
+function MapCard({
+  trail,
+  here,
+  replay,
+  follow,
+  onToggleFollow,
+}: Readonly<{
+  trail: [number, number][]
+  here: [number, number] | null
+  replay: ITripReplay
+  follow: boolean
+  onToggleFollow: () => void
+}>) {
+  return (
+    <Card className="overflow-hidden lg:col-span-2">
+      <div className="relative">
+        <TrailMap trail={trail} here={here} replay={replay} follow={follow} />
+        {here && (
+          <Button
+            variant={follow ? "default" : "secondary"}
+            size="icon"
+            className="absolute right-2 top-2 z-[1000] size-8 shadow"
+            aria-label={follow ? "Stop following position" : "Follow position"}
+            title={follow ? "Stop following" : "Follow the coach"}
+            onClick={onToggleFollow}
+          >
+            <IconCurrentLocation className="size-4" />
+          </Button>
+        )}
+      </div>
+      {replay.active && <ReplayBar replay={replay} />}
+    </Card>
+  )
+}
+
+/** Trips card: odometer summary line plus the trip list. */
+function TripsCard({
+  trips,
+  shownTripId,
+  onSelect,
+  onDelete,
+  onMerge,
+}: Readonly<{
+  trips: ITrip[]
+  shownTripId: number | null
+  onSelect: (tripId: number) => void
+  onDelete: (tripId: number) => void
+  onMerge: (tripId: number) => void
+}>) {
+  const { data: summary } = useQuery({
+    queryKey: ["location", "trip-summary"],
+    queryFn: fetchTripSummary,
+    refetchInterval: 300_000,
     retry: false,
   })
-  const { data: tripData } = useQuery({
-    queryKey: ["location", "trips"],
-    queryFn: () => fetchTrips(50),
-    refetchInterval: 60_000,
-    retry: false,
-  })
-  const { data: pointData } = useQuery({
-    queryKey: ["location", "trip-points", selectedTripId],
-    queryFn: () => fetchTripPoints(selectedTripId as number),
-    enabled: selectedTripId !== null,
-  })
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="flex items-center gap-2 text-base">
+          <IconRoute className="size-4 text-muted-foreground" aria-hidden />
+          Trips
+        </CardTitle>
+        {summary && summary.all_time.trip_count > 0 && (
+          <p className="text-xs text-muted-foreground">
+            {fmtMilesLong(summary.all_time.distance_m)} over {summary.all_time.trip_count}{" "}
+            trips
+            {summary.year.trip_count > 0 &&
+              ` · ${fmtMilesLong(summary.year.distance_m)} this year`}
+          </p>
+        )}
+      </CardHeader>
+      <CardContent className="max-h-[50vh] space-y-1 overflow-y-auto">
+        {trips.length === 0 && (
+          <p className="text-sm text-muted-foreground">
+            No trips recorded yet — breadcrumbs start the next time the coach moves.
+          </p>
+        )}
+        {trips.map((trip, index) => (
+          <TripRow
+            key={trip.id}
+            trip={trip}
+            selected={shownTripId === trip.id}
+            canMerge={index < trips.length - 1}
+            onSelect={() => onSelect(trip.id)}
+            onDelete={() => onDelete(trip.id)}
+            onMerge={() => onMerge(trip.id)}
+          />
+        ))}
+      </CardContent>
+    </Card>
+  )
+}
+
+/** Delete/merge mutations with cache invalidation and selection fix-up. */
+function useTripActions(setSelectedTripId: Dispatch<SetStateAction<number | null>>) {
+  const queryClient = useQueryClient()
+  const invalidateTrips = () => {
+    void queryClient.invalidateQueries({ queryKey: ["location", "trips"] })
+    void queryClient.invalidateQueries({ queryKey: ["location", "trip-summary"] })
+  }
 
   const deleteMutation = useMutation({
     mutationFn: deleteTrip,
     onSuccess: (_data, tripId) => {
       setSelectedTripId((prev) => (prev === tripId ? null : prev))
-      void queryClient.invalidateQueries({ queryKey: ["location", "trips"] })
+      invalidateTrips()
     },
     onError: (error) => {
       toast.error(
@@ -504,10 +670,62 @@ export default function LocationPage() {
     },
   })
 
-  const trips = tripData?.trips ?? []
+  const mergeMutation = useMutation({
+    mutationFn: mergeTripWithPrevious,
+    onSuccess: (merged, tripId) => {
+      // The merged-from trip is gone; keep the combined trip on screen.
+      setSelectedTripId((prev) => (prev === tripId ? merged.id : prev))
+      invalidateTrips()
+      void queryClient.invalidateQueries({ queryKey: ["location", "trip-points"] })
+      toast.success("Merged into the previous trip")
+    },
+    onError: (error) => {
+      toast.error(
+        `Failed to merge trip: ${error instanceof Error ? error.message : String(error)}`
+      )
+    },
+  })
+
+  return { deleteMutation, mergeMutation }
+}
+
+export default function LocationPage() {
+  const [selectedTripId, setSelectedTripId] = useState<number | null>(null)
+  const [follow, setFollow] = useState(false)
+
+  // SSE pushes location_update events straight into this cache entry;
+  // the interval is only a fallback for when the stream is down.
+  const { data: current } = useQuery({
+    queryKey: ["location", "current"],
+    queryFn: fetchCurrentLocation,
+    refetchInterval: 15_000,
+    retry: false,
+  })
+  const { data: tripData } = useQuery({
+    queryKey: ["location", "trips"],
+    queryFn: () => fetchTrips(50),
+    refetchInterval: 60_000,
+    retry: false,
+  })
+
+  // With nothing selected, show the trip being recorded right now (if any)
+  // as a live, growing trail.
+  const activeTripId = current?.active_trip_id ?? null
+  const shownTripId = selectedTripId ?? activeTripId
+  const isLiveTrail = shownTripId !== null && shownTripId === activeTripId
+
+  const { data: pointData } = useQuery({
+    queryKey: ["location", "trip-points", shownTripId],
+    queryFn: () => fetchTripPoints(shownTripId as number),
+    enabled: shownTripId !== null,
+    refetchInterval: isLiveTrail ? 15_000 : false,
+  })
+
+  const { deleteMutation, mergeMutation } = useTripActions(setSelectedTripId)
+
   const points = useMemo(
-    () => (selectedTripId !== null ? (pointData?.points ?? []) : []),
-    [selectedTripId, pointData]
+    () => (shownTripId !== null ? (pointData?.points ?? EMPTY_POINTS) : EMPTY_POINTS),
+    [shownTripId, pointData]
   )
   // Memoized so FitBounds doesn't re-fit on every poll/replay render.
   const trail = useMemo<[number, number][]>(
@@ -522,44 +740,30 @@ export default function LocationPage() {
     [current?.fix, current?.latitude, current?.longitude]
   )
 
-  const replay = useTripReplay(points)
+  // Replay applies to finished trips; a live trail has no fixed timeline yet.
+  const replay = useTripReplay(isLiveTrail ? EMPTY_POINTS : points, shownTripId)
 
   return (
     <div className="flex-1 space-y-4 p-4 pt-6 lg:px-6">
       <CurrentPositionCard />
 
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
-        <Card className="overflow-hidden lg:col-span-2">
-          <TrailMap trail={trail} here={here} replay={replay} />
-          {replay.active && <ReplayBar replay={replay} />}
-        </Card>
-
-        <Card>
-          <CardHeader className="pb-2">
-            <CardTitle className="flex items-center gap-2 text-base">
-              <IconRoute className="size-4 text-muted-foreground" aria-hidden />
-              Trips
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="max-h-[50vh] space-y-1 overflow-y-auto">
-            {trips.length === 0 && (
-              <p className="text-sm text-muted-foreground">
-                No trips recorded yet — breadcrumbs start the next time the coach moves.
-              </p>
-            )}
-            {trips.map((trip) => (
-              <TripRow
-                key={trip.id}
-                trip={trip}
-                selected={selectedTripId === trip.id}
-                onSelect={() =>
-                  setSelectedTripId(selectedTripId === trip.id ? null : trip.id)
-                }
-                onDelete={() => deleteMutation.mutate(trip.id)}
-              />
-            ))}
-          </CardContent>
-        </Card>
+        <MapCard
+          trail={trail}
+          here={here}
+          replay={replay}
+          follow={follow}
+          onToggleFollow={() => setFollow((prev) => !prev)}
+        />
+        <TripsCard
+          trips={tripData?.trips ?? []}
+          shownTripId={shownTripId}
+          onSelect={(tripId) =>
+            setSelectedTripId(selectedTripId === tripId ? null : tripId)
+          }
+          onDelete={(tripId) => deleteMutation.mutate(tripId)}
+          onMerge={(tripId) => mergeMutation.mutate(tripId)}
+        />
       </div>
     </div>
   )

--- a/tests/services/test_trip_log_service.py
+++ b/tests/services/test_trip_log_service.py
@@ -23,14 +23,43 @@ class FakeTripLogRepository:
             "ended_at": None,
             "start_latitude": latitude,
             "start_longitude": longitude,
+            "end_latitude": None,
+            "end_longitude": None,
             "distance_m": 0.0,
+            "start_place": None,
+            "end_place": None,
         }
         return trip_id
 
     async def end_trip(
         self, trip_id: int, ended_at: float, latitude: float, longitude: float
     ) -> None:
-        self.trips[trip_id]["ended_at"] = ended_at
+        trip = self.trips[trip_id]
+        trip["ended_at"] = ended_at
+        trip["end_latitude"] = latitude
+        trip["end_longitude"] = longitude
+
+    async def get_trip(self, trip_id: int) -> dict[str, Any] | None:
+        return self.trips.get(trip_id)
+
+    async def set_trip_places(
+        self, trip_id: int, start_place: str | None, end_place: str | None
+    ) -> None:
+        trip = self.trips[trip_id]
+        if start_place is not None:
+            trip["start_place"] = start_place
+        if end_place is not None:
+            trip["end_place"] = end_place
+
+    async def get_trips_missing_places(self, limit: int = 20) -> list[dict[str, Any]]:
+        unnamed = [
+            trip
+            for trip in self.trips.values()
+            if trip["ended_at"] is not None
+            and (trip["start_place"] is None or trip["end_place"] is None)
+        ]
+        unnamed.sort(key=lambda trip: -trip["started_at"])
+        return unnamed[:limit]
 
     async def add_point(self, **kwargs: Any) -> None:
         self.points.append(kwargs)
@@ -80,6 +109,8 @@ def make_service(**overrides: Any) -> tuple[TripLogService, FakeTripLogRepositor
         # drive trips with single fixes; the guard tests override these.
         "start_confirm_seconds": 0.0,
         "min_trip_distance_m": 0.0,
+        # Geocoding is exercised explicitly with a fake geocoder.
+        "geocode_enabled": False,
     }
     kwargs.update(overrides)
     settings = TripLogSettings(**kwargs)
@@ -226,6 +257,81 @@ class TestNoiseGuards:
         await service._resume_or_close_dangling_trip()
         assert service._active_trip_id is None
         assert trip_id not in repository.trips
+
+
+class FakeBroker:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict[str, Any]]] = []
+
+    async def publish(self, event: str, data: dict[str, Any]) -> None:
+        self.events.append((event, data))
+
+
+class TestPositionPublishing:
+    async def test_publishes_heartbeat_then_throttles(self):
+        service, _ = make_service()
+        broker = FakeBroker()
+        service._event_broker = broker
+
+        await service._handle_fix(fix(LAT, LON, speed=0.0))
+        assert len(broker.events) == 1
+        assert broker.events[0][0] == "location_update"
+
+        # Same spot moments later: inside min interval, no second event.
+        await service._handle_fix(fix(LAT, LON, speed=0.0))
+        assert len(broker.events) == 1
+
+    async def test_publishes_immediately_on_trip_transition(self):
+        service, _ = make_service()
+        broker = FakeBroker()
+        service._event_broker = broker
+
+        await service._handle_fix(fix(LAT, LON, speed=0.0))  # heartbeat, parked
+        await service._handle_fix(fix(LAT, LON, speed=5.0))  # trip starts
+        assert len(broker.events) == 2
+        assert broker.events[-1][1]["active_trip_id"] is not None
+
+
+class FakeGeocoder:
+    def __init__(self, results: list[str | None]) -> None:
+        self._results = results
+        self.calls: list[tuple[float, float]] = []
+
+    async def reverse(self, latitude: float, longitude: float) -> str | None:
+        self.calls.append((latitude, longitude))
+        return self._results.pop(0) if self._results else None
+
+
+class TestGeocoding:
+    async def test_geocode_trip_fills_missing_places(self, monkeypatch):
+        import backend.services.trip_log.trip_log_service as module
+
+        monkeypatch.setattr(module, "_GEOCODE_PACING_SECONDS", 0.0)
+        service, repository = make_service()
+        service._geocoder = FakeGeocoder(["Nags Head, North Carolina", "Richmond, Virginia"])
+
+        trip_id = await repository.start_trip(time.time() - 3600, LAT, LON)
+        await repository.end_trip(trip_id, time.time(), LAT + 0.5, LON)
+        assert await service._geocode_trip(repository.trips[trip_id]) is True
+        assert repository.trips[trip_id]["start_place"] == "Nags Head, North Carolina"
+        assert repository.trips[trip_id]["end_place"] == "Richmond, Virginia"
+
+    async def test_backfill_stops_when_offline(self, monkeypatch):
+        import backend.services.trip_log.trip_log_service as module
+
+        monkeypatch.setattr(module, "_GEOCODE_PACING_SECONDS", 0.0)
+        service, repository = make_service()
+        geocoder = FakeGeocoder([])  # every lookup fails (offline)
+        service._geocoder = geocoder
+
+        for offset in (7200, 3600):
+            trip_id = await repository.start_trip(time.time() - offset, LAT, LON)
+            await repository.end_trip(trip_id, time.time() - offset + 600, LAT + 0.1, LON)
+
+        await service._geocode_backfill()
+        # First trip failed both lookups; the loop must not hammer the rest.
+        assert len(geocoder.calls) == 2
+        assert all(trip["start_place"] is None for trip in repository.trips.values())
 
 
 class TestReadSide:


### PR DESCRIPTION
Follow-ups to #228, implementing the rest of the location-tracking improvement list.

## Backend

- **Reverse-geocoded trip names** — trips get `start_place`/`end_place` ("Nags Head, North Carolina") via Nominatim: geocoded when a trip ends, with a startup backfill (up to 20 newest unnamed trips) for trips recorded offline or before this feature. Policy-compliant User-Agent + 1 req/s pacing; failures are soft (RV offline is normal) and retried next start. Columns are `ALTER TABLE`-ed into existing databases. Toggle: `COACHIQ_TRIP_LOG__GEOCODE_ENABLED`.
- **SSE position stream** — `TripLogService` now publishes `location_update` events through the event broker (same pattern as Victron/entity updates): immediately on trip start/end, per ~10 m while driving (min 2 s apart), 30 s heartbeat while parked.
- **`GET /api/location/trips/summary`** — all-time and year-to-date totals (count, distance, duration, top speed).
- **`POST /api/location/trips/{id}/merge-previous`** — folds a trip into its predecessor: breadcrumbs re-parented, distances summed including the haversine bridge across the gap, source row deleted. 409 while recording.
- **`retention_days` default 0 → 365** — breadcrumb pruning is now on by default instead of grow-forever (0 still means keep everything).

## Frontend

- Trip rows titled by place ("Nags Head → Kitty Hawk"); date moves to the detail line.
- Odometer line under the Trips header: "1,234 mi over 87 trips · 456 mi this year".
- **Live trail**: with no trip selected, the currently recording trip renders as a growing polyline (15 s point refresh). Replay remains for finished trips, and its cursor is now keyed on trip id so background refetches don't rewind it.
- **Follow-the-coach** map toggle (crosshair button) that keeps the map centered on the live position.
- `location_update` SSE events patch the `["location","current"]` query cache directly (per the PR-#227 pattern); position polling drops from 5 s to a 15 s fallback.
- Merge-into-previous row action with the same tap-again-to-confirm affordance as delete.

## Testing

- Service tests: SSE publish throttling (heartbeat + trip-transition), geocoder naming, backfill halting when offline — 16 passing overall.
- Verified in-browser against a mock API+SSE server: named trips, odometer line, live badge/trail, follow mode panning with SSE movement (position updates every ~2 s, faster than any poll), replay shown for ended trips and hidden for the live one, merge (toast + list + summary refresh), delete, GPX download.
- `tsc --noEmit`, ESLint (0 findings on changed files, incl. resolving max-lines/complexity by extracting `MapCard`/`TripsCard`/`useTripActions`), `vite build`, `ruff format/check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)