### PR TITLE
fix(frontend): stop Vite dev server from serving source modules with 1-year cache

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -49,10 +49,10 @@ export default defineConfig({
     hmr: false,
     // Limit the number of concurrent requests to prevent browser resource exhaustion
     middlewareMode: false,
-    // Enable caching for better performance
-    headers: {
-      'Cache-Control': 'max-age=31536000',
-    },
+    // No custom Cache-Control here: source modules (/src/*) are unhashed, so a
+    // long max-age makes browsers serve stale code across dev-server restarts.
+    // Vite's defaults already cache correctly (etag for sources, immutable for
+    // hashed /node_modules/.vite/deps); production headers come from the proxy.
     // Proxy API requests to the backend server (WebSockets connect directly)
     proxy: {
       // Proxy REST API requests


### PR DESCRIPTION
## Summary
- `server.headers` in `frontend/vite.config.ts` set `Cache-Control: max-age=31536000` on **every** dev-server response, including unhashed `/src/*` module URLs
- Browsers cached source modules for a year and kept serving them across dev-server restarts, causing missing-export SyntaxErrors and duplicate-React `Cannot read properties of null (reading 'useState')` crashes until the cache was manually busted
- Removed the header block; Vite's defaults are correct per URL class: `no-cache` + ETag for source modules, hash-versioned `?v=` URLs for pre-bundled deps. Production caching is handled by the reverse proxy, not the dev server.

## Verification
- Ran the dev server and confirmed `/src/api/location.ts` now returns `Cache-Control: no-cache` with an ETag (previously `max-age=31536000`)
- App loads and renders with no module-loading errors

Note for anyone previously bitten: existing browser caches created under the old header need one manual bust (hard reload with cache cleared, or a different port); after that, restarts always serve fresh code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)