### PR TITLE
chore(pre-commit): use python3 instead of hard-pinning python3.12

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,8 +4,14 @@
 
 # See https://pre-commit.com for full documentation
 
+# Use whatever python3 the developer has rather than hard-requiring python3.12.
+# The interpreter only bootstraps the hook envs; ruff/pyright/bandit lint for
+# 3.12 semantics via their own config (ruff target-version = "py312"), so results
+# are identical regardless of the running interpreter. Pinning an exact 3.12
+# meant commits outside `nix develop` (where 3.12 isn't on PATH) silently failed
+# to run hooks and forced --no-verify.
 default_language_version:
-  python: python3.12
+  python: python3
 
 repos:
   # ===== ALWAYS BLOCKING (Fast, Critical) =====


### PR DESCRIPTION
## Problem

`default_language_version` pinned `python: python3.12`, but `python3.12` only exists inside `nix develop`. Committing from a normal shell (system `python3` is 3.11, the local `.venv` is 3.13, and `python3.12` is nowhere on PATH) made pre-commit fail to bootstrap its hook environments:

```
RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.12'
```

Every commit/push then silently required `--no-verify`, which is exactly how a couple of ruff issues slipped past local hooks and only failed in CI on #229.

## Fix

Pin to `python3` instead of an exact `python3.12`. The interpreter only bootstraps the hook virtualenvs — it does **not** change what the hooks enforce: ruff/pyright/bandit lint for 3.12 semantics via their own config (`ruff target-version = "py312"`, pyright's `pythonVersion`). CI/Nix still resolves `python3` to 3.12, so nothing changes there.

## Verification

With the change applied, the previously-broken hooks bootstrap and run under the local `python3` (3.11):

```
ruff format..............................................................Passed
bandit...................................................................Passed
```

This commit itself was made **without** `--no-verify` — the pre-commit and pre-push hooks ran successfully, which is the end-to-end proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)