### PR TITLE
fix(frontend): map SSE entity payload to REST shape so live values don't blank

### DIFF
--- a/frontend/src/contexts/__tests__/realtime-cache.test.ts
+++ b/frontend/src/contexts/__tests__/realtime-cache.test.ts
@@ -2,6 +2,13 @@
  * Tests for applyEntityUpdate — SSE entity updates must patch the query
  * cache in place instead of invalidating collections, so a chatty CAN bus
  * doesn't fan out into refetch storms that trip the backend rate limit.
+ *
+ * The SSE stream sends the backend's internal ("legacy") entity shape: live
+ * field values under `raw`, `state` as a device-status STRING, and a unix-float
+ * `timestamp`. The UI reads the REST shape (EntitySchemaV2), where those field
+ * values ARE `state` and the time is an ISO `last_updated`. These tests pin the
+ * conversion: without it, a live update overwrote `state` with the status
+ * string, so values rendered on first load then blanked on the first update.
  */
 
 import { QueryClient } from '@tanstack/react-query'
@@ -11,7 +18,8 @@ import type { EntityCollectionSchema, EntitySchema } from '@/api/types/domains'
 import { applyEntityUpdate } from '../realtime-cache'
 import { entitiesQueryKeys } from '@/hooks/useEntities'
 
-function makeEntity(id: string, overrides: Partial<EntitySchema> = {}): EntitySchema {
+/** A REST-shaped entity (EntitySchemaV2) as it lands from GET /api/v1/entities. */
+function makeRestEntity(id: string, overrides: Partial<EntitySchema> = {}): EntitySchema {
   return {
     entity_id: id,
     name: id,
@@ -23,6 +31,32 @@ function makeEntity(id: string, overrides: Partial<EntitySchema> = {}): EntitySc
     available: true,
     ...overrides,
   } as EntitySchema
+}
+
+/**
+ * An SSE `entity_update` payload's `entity_data`, in the backend's actual
+ * on-the-wire (legacy) shape: field values live under `raw`/`value`, `state` is
+ * a device-status string, and `timestamp` is unix-float seconds.
+ */
+function makeSsePayload(
+  id: string,
+  raw: Record<string, unknown>,
+  overrides: Record<string, unknown> = {}
+): Record<string, unknown> {
+  return {
+    entity_id: id,
+    friendly_name: `Friendly ${id}`,
+    device_type: 'climate',
+    protocol: 'rvc',
+    suggested_area: 'main',
+    state: 'external_control',
+    raw,
+    value: raw,
+    timestamp: 1783536790,
+    capabilities: [],
+    groups: ['climate'],
+    ...overrides,
+  }
 }
 
 function makeCollection(entities: EntitySchema[]): EntityCollectionSchema {
@@ -42,39 +76,51 @@ describe('applyEntityUpdate', () => {
     client = new QueryClient()
   })
 
-  it('writes the entity into its individual-entity cache entry', () => {
-    const updated = makeEntity('thermostat_1', { state: { temp: 72 } })
-    applyEntityUpdate(client, { entity_id: 'thermostat_1', entity_data: updated })
+  it('exposes SSE raw field values as `state` (the shape the UI reads)', () => {
+    applyEntityUpdate(client, {
+      entity_id: 'thermostat_1',
+      entity_data: makeSsePayload('thermostat_1', { temp: 72 }),
+    })
 
-    expect(client.getQueryData(entitiesQueryKeys.entity('thermostat_1'))).toEqual(updated)
+    const cached = client.getQueryData<EntitySchema>(entitiesQueryKeys.entity('thermostat_1'))
+    // The regression: state must be the field dict, NOT the "external_control" string.
+    expect(cached?.state).toEqual({ temp: 72 })
+    expect(cached?.last_updated).toBe(new Date(1783536790 * 1000).toISOString())
+    expect(cached?.available).toBe(true)
   })
 
-  it('patches the entity into every cached collection containing it', () => {
-    const stale = makeEntity('thermostat_1', { state: { temp: 68 } })
-    const other = makeEntity('thermostat_2')
+  it('patches raw values into cached collections while preserving REST fields', () => {
+    const stale = makeRestEntity('thermostat_1', { name: 'Bedroom', state: { temp: 68 } })
+    const other = makeRestEntity('thermostat_2')
     const keyA = entitiesQueryKeys.collection({ device_type: 'climate' })
     const keyB = entitiesQueryKeys.collection({ device_type: 'climate', page_size: 100 })
     client.setQueryData(keyA, makeCollection([stale, other]))
     client.setQueryData(keyB, makeCollection([stale]))
 
-    const updated = makeEntity('thermostat_1', { state: { temp: 72 } })
-    applyEntityUpdate(client, { entity_id: 'thermostat_1', entity_data: updated })
+    applyEntityUpdate(client, {
+      entity_id: 'thermostat_1',
+      entity_data: makeSsePayload('thermostat_1', { temp: 72 }),
+    })
 
     const collectionA = client.getQueryData<EntityCollectionSchema>(keyA)
-    expect(collectionA?.entities).toEqual([updated, other])
+    const patchedA = collectionA?.entities.find((e) => e.entity_id === 'thermostat_1')
+    expect(patchedA?.state).toEqual({ temp: 72 }) // live value shows, not blanked
+    expect(patchedA?.name).toBe('Bedroom') // REST-provided field survives the merge
+    expect(collectionA?.entities.find((e) => e.entity_id === 'thermostat_2')).toBe(other)
+
     const collectionB = client.getQueryData<EntityCollectionSchema>(keyB)
-    expect(collectionB?.entities).toEqual([updated])
+    expect(collectionB?.entities[0]?.state).toEqual({ temp: 72 })
   })
 
   it('leaves collections that do not contain the entity untouched', () => {
-    const tanks = makeCollection([makeEntity('fresh_tank', { device_type: 'tank' })])
+    const tanks = makeCollection([makeRestEntity('fresh_tank', { device_type: 'tank' })])
     const key = entitiesQueryKeys.collection({ device_type: 'tank' })
     client.setQueryData(key, tanks)
     const before = client.getQueryState(key)?.dataUpdatedAt
 
     applyEntityUpdate(client, {
       entity_id: 'thermostat_1',
-      entity_data: makeEntity('thermostat_1'),
+      entity_data: makeSsePayload('thermostat_1', { temp: 72 }),
     })
 
     expect(client.getQueryData(key)).toBe(tanks)
@@ -83,11 +129,11 @@ describe('applyEntityUpdate', () => {
 
   it('does not mark any collection query as invalidated', () => {
     const key = entitiesQueryKeys.collection({ device_type: 'climate' })
-    client.setQueryData(key, makeCollection([makeEntity('thermostat_1')]))
+    client.setQueryData(key, makeCollection([makeRestEntity('thermostat_1')]))
 
     applyEntityUpdate(client, {
       entity_id: 'thermostat_1',
-      entity_data: makeEntity('thermostat_1', { state: { temp: 75 } }),
+      entity_data: makeSsePayload('thermostat_1', { temp: 75 }),
     })
 
     expect(client.getQueryState(key)?.isInvalidated).toBe(false)

--- a/frontend/src/contexts/realtime-cache.ts
+++ b/frontend/src/contexts/realtime-cache.ts
@@ -7,12 +7,61 @@
 
 import type { QueryClient } from '@tanstack/react-query'
 
-import type { EntityCollectionSchema, EntitySchema } from '@/api/types/domains'
+import type { EntityCollectionSchema, EntitySchema, LegacyEntity } from '@/api/types/domains'
 import { entitiesQueryKeys } from '@/hooks/useEntities'
 
 export interface IEntityUpdatePayload {
   entity_id: string
   entity_data: Record<string, unknown>
+}
+
+/**
+ * Convert an SSE entity payload into the REST collection shape the UI reads.
+ *
+ * The SSE stream sends entities in the backend's internal ("legacy") shape:
+ * the live field values live under `raw`, `state` is a device-status STRING
+ * (e.g. "external_control"), and the timestamp is a unix float under
+ * `timestamp`. The REST collection (EntitySchemaV2) instead exposes those field
+ * values AS the `state` object and the time as an ISO `last_updated` — and every
+ * page reads `entity.state.<field>`. Casting the raw SSE payload straight to
+ * EntitySchema (the previous behaviour) made `state` the status string, so
+ * `state.<field>` was undefined: values rendered on first load from REST, then
+ * blanked on the first live update. Merge onto the previous entity so
+ * REST-provided fields (name, protocol, available, area) survive when the SSE
+ * payload omits them.
+ */
+type SseEntity = Partial<LegacyEntity> & { protocol?: string; last_updated?: string }
+
+/** Build an EntitySchema from an SSE payload alone (no prior REST entity). */
+function bootstrapEntity(legacy: SseEntity): EntitySchema {
+  const id = String(legacy.entity_id ?? '')
+  return {
+    entity_id: id,
+    name: legacy.friendly_name ?? id,
+    device_type: legacy.device_type ?? 'unknown',
+    protocol: legacy.protocol ?? 'unknown',
+    area: legacy.suggested_area ?? null,
+    state: {},
+    last_updated: '',
+    available: true,
+  }
+}
+
+function toEntitySchema(data: Record<string, unknown>, prev?: EntitySchema): EntitySchema {
+  const legacy = data as SseEntity
+  const base = prev ?? bootstrapEntity(legacy)
+  const lastUpdated =
+    typeof legacy.timestamp === 'number'
+      ? new Date(legacy.timestamp * 1000).toISOString()
+      : (legacy.last_updated ?? base.last_updated)
+
+  // Map the SSE `raw` field values onto `state` — the shape every page reads.
+  return {
+    ...base,
+    state: legacy.raw ?? legacy.value ?? base.state ?? {},
+    last_updated: lastUpdated,
+    available: true,
+  }
 }
 
 /**
@@ -27,15 +76,18 @@ export interface IEntityUpdatePayload {
  * on entity_created, which still invalidates.
  */
 export function applyEntityUpdate(client: QueryClient, payload: IEntityUpdatePayload): void {
-  const entity = payload.entity_data as EntitySchema
-  client.setQueryData(entitiesQueryKeys.entity(payload.entity_id), entity)
+  client.setQueryData<EntitySchema>(entitiesQueryKeys.entity(payload.entity_id), (prev) =>
+    toEntitySchema(payload.entity_data, prev)
+  )
   client.setQueriesData<EntityCollectionSchema>(
     { queryKey: entitiesQueryKeys.collections() },
     (collection) => {
       if (!collection?.entities.some((e) => e.entity_id === payload.entity_id)) return undefined
       return {
         ...collection,
-        entities: collection.entities.map((e) => (e.entity_id === payload.entity_id ? entity : e)),
+        entities: collection.entities.map((e) =>
+          e.entity_id === payload.entity_id ? toEntitySchema(payload.entity_data, e) : e
+        ),
       }
     }
   )


### PR DESCRIPTION
## Problem

On entity views, values render correctly on first load and then **blank out whatever updates live** — Power's AC/inverter/solar cards, and Climate zones, drop to a dash with "Updated unknown" on the first realtime event. Diagnosed live on iq.holtel.io: the data path is healthy (all 200s, Cerbo connected), the backend has fresh complete data, but the cards go blank the moment an SSE update arrives.

## Root cause

`applyEntityUpdate` cast the SSE `entity_update` payload straight to `EntitySchema` and wrote it into the query cache. But the two shapes differ:

- **SSE (`entity_data`)** is the backend's internal *legacy* shape: live field values under `raw`, `state` is a device-status **string** (`"external_control"`), timestamp is a unix float.
- **REST (`EntitySchemaV2`)**, which every page renders, exposes those field values **as** `state` (an object) with an ISO `last_updated`.

So the first live update overwrote `state` — the object every card reads via `state.<field>` — with the string `"external_control"`, and `state.<field>` became `undefined`. Introduced by the SSE-patch change (fd3a1b2), which assumed `entity_data` was already REST-shaped.

## Fix

Convert the SSE payload to the REST shape before caching: map `raw` → `state`, `timestamp` → `last_updated`, merging onto the previously cached entity so REST-provided fields (`name`, `protocol`, `available`, `area`) survive when the SSE payload omits them. ([realtime-cache.ts](frontend/src/contexts/realtime-cache.ts))

## Verification

Ran the fixed converter against the **exact live production payload**:

| | before | after |
|---|---|---|
| `state` | `"external_control"` (string) | `{…}` (object) |
| `state.pv_power` | `undefined` → dash | `0.56` |
| `state.yield_today_kwh` | — | `0.88` |
| `name` / `last_updated` | lost | `"Solar Charger"` / live ISO |

The existing test fed `applyEntityUpdate` an already-REST-shaped payload, so it never exercised the real on-the-wire shape — which is why the bug passed CI. The test now uses the actual SSE (legacy) shape and asserts `state` survives as the field dict. Typecheck + eslint clean.

## Notes

- This is the real cause of the entity-blanking on **both** Power and the original Climate report — it supersedes the 401-timing theory from #229. #229's identity fix stands on its own (correct + needed); its 401 refresh-retry is a fine robustness improvement but was not the blanking cause.
- Frontend-only; takes effect on the Pi once a coachiq bump is deployed to nixpi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)