### PR TITLE
feat(location): denoise GPS fixes and capture corners in the trip trail

### DIFF
--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -1283,13 +1283,38 @@ class TripLogSettings(BaseSettings):
     gpsd_host: str = Field(default="127.0.0.1", description="gpsd host")
     gpsd_port: int = Field(default=2947, description="gpsd JSON port", ge=1, le=65535)
     min_distance_m: float = Field(
-        default=50.0,
+        default=25.0,
         description="Minimum distance between recorded breadcrumbs in meters",
         gt=0,
     )
     min_interval_seconds: float = Field(
-        default=15.0,
+        default=5.0,
         description="Minimum time between recorded breadcrumbs while moving (0 disables)",
+        ge=0,
+    )
+    min_course_change_deg: float = Field(
+        default=12.0,
+        description=(
+            "Record an extra breadcrumb when the heading turns by at least this "
+            "many degrees, so corners are captured instead of cut (0 disables)"
+        ),
+        ge=0,
+        le=180,
+    )
+    max_accuracy_m: float = Field(
+        default=25.0,
+        description=(
+            "Reject fixes whose reported horizontal error (gpsd eph) exceeds this; "
+            "trims multipath scatter near buildings (0 disables, or when eph absent)"
+        ),
+        ge=0,
+    )
+    max_implied_speed_mps: float = Field(
+        default=55.0,
+        description=(
+            "Reject a fix that would imply a jump faster than this from the last "
+            "accepted fix; drops GPS 'teleport' spikes (0 disables). 55 m/s ~ 123 mph"
+        ),
         ge=0,
     )
     stationary_speed_mps: float = Field(

--- a/backend/services/trip_log/trip_log_service.py
+++ b/backend/services/trip_log/trip_log_service.py
@@ -5,8 +5,11 @@ Reads position from the local gpsd (the same daemon that feeds the Cerbo GX
 and the router sidecar) and records a thoughtful trail rather than a 1 Hz
 firehose:
 
-- a breadcrumb is recorded only after moving ``min_distance_m`` from the
-  last recorded point (and at most every ``min_interval_seconds``),
+- imprecise fixes (large reported ``eph``) and multipath "teleport" spikes
+  are dropped before they reach the trail,
+- a breadcrumb is recorded after moving ``min_distance_m`` from the last
+  recorded point (and at most every ``min_interval_seconds``), OR whenever
+  the heading turns by ``min_course_change_deg`` so corners aren't cut,
 - nothing is recorded while parked,
 - a trip starts only after movement persists for ``start_confirm_seconds``
   (single-fix GPS speed jitter while parked never opens a trip),
@@ -48,6 +51,16 @@ _PUBLISH_MIN_MOVE_M = 10.0
 _GEOCODE_PACING_SECONDS = 1.1
 _GEOCODE_BACKFILL_LIMIT = 20
 
+# Course-change breadcrumbs: gpsd's reported track is unreliable at a crawl,
+# so only trust it above this speed, and require a little real movement and
+# spacing so stationary jitter can't spam turn points.
+_COURSE_MIN_SPEED_MPS = 2.0
+_CORNER_MIN_DISTANCE_M = 5.0
+_CORNER_MIN_INTERVAL_SECONDS = 2.0
+
+_FULL_TURN_DEG = 360.0
+_HALF_TURN_DEG = 180.0
+
 
 class TripLogService:
     """Background recorder of GPS breadcrumbs segmented into trips."""
@@ -82,6 +95,7 @@ class TripLogService:
         self._pending_start_at: float | None = None
         self._last_recorded: tuple[float, float] | None = None  # (lat, lon)
         self._last_recorded_at = 0.0
+        self._last_recorded_course: float | None = None
         self._last_movement_at = 0.0
         self._last_fix: GpsdTpv | None = None
         self._last_fix_at = 0.0
@@ -162,6 +176,11 @@ class TripLogService:
             return
 
         now = time.time()
+        if not self._fix_is_trustworthy(tpv, now):
+            # Drop noisy/spurious fixes before they reach the trail or SSE;
+            # leaving _last_fix untouched lets dt grow so a genuine relocation
+            # (e.g. leaving a tunnel) is accepted after a few seconds.
+            return
         self._last_fix = tpv
         self._last_fix_at = now
 
@@ -169,6 +188,30 @@ class TripLogService:
             await self._track_movement(tpv, now)
         finally:
             await self._maybe_publish_position(tpv, now)
+
+    def _fix_is_trustworthy(self, tpv: GpsdTpv, now: float) -> bool:
+        """Reject imprecise or physically-impossible fixes (GPS noise)."""
+        max_accuracy = self._settings.max_accuracy_m
+        if max_accuracy > 0 and tpv.eph is not None and tpv.eph > max_accuracy:
+            return False
+
+        max_implied = self._settings.max_implied_speed_mps
+        if (
+            max_implied > 0
+            and self._last_fix is not None
+            and self._last_fix.lat is not None
+            and self._last_fix.lon is not None
+            and tpv.lat is not None
+            and tpv.lon is not None
+        ):
+            dt = now - self._last_fix_at
+            if dt > 0:
+                jump_m = haversine_distance_m(
+                    self._last_fix.lat, self._last_fix.lon, tpv.lat, tpv.lon
+                )
+                if jump_m / dt > max_implied:
+                    return False
+        return True
 
     async def _track_movement(self, tpv: GpsdTpv, now: float) -> None:
         if tpv.lat is None or tpv.lon is None:  # narrowed by caller; keeps pyright honest
@@ -211,13 +254,28 @@ class TripLogService:
             await self._end_trip()
             return
 
-        # ...or record the next breadcrumb once we've gone far enough.
-        if (
+        # ...or record the next breadcrumb once we've gone far enough, or the
+        # heading has turned enough that a straight line would cut the corner.
+        far_enough = (
             distance_from_last is not None
             and distance_from_last >= self._settings.min_distance_m
             and now - self._last_recorded_at >= self._settings.min_interval_seconds
-        ):
-            await self._record_point(tpv, now, distance_from_last)
+        )
+        if far_enough or self._heading_turned(tpv, distance_from_last, now):
+            await self._record_point(tpv, now, distance_from_last or 0.0)
+
+    def _heading_turned(self, tpv: GpsdTpv, distance_from_last: float | None, now: float) -> bool:
+        """True when the course has changed enough to warrant a corner point."""
+        threshold = self._settings.min_course_change_deg
+        if threshold <= 0 or tpv.track is None or self._last_recorded_course is None:
+            return False
+        if (tpv.speed or 0.0) < _COURSE_MIN_SPEED_MPS:
+            return False  # gpsd track is unreliable at a crawl
+        if distance_from_last is None or distance_from_last < _CORNER_MIN_DISTANCE_M:
+            return False
+        if now - self._last_recorded_at < _CORNER_MIN_INTERVAL_SECONDS:
+            return False
+        return _angular_difference(tpv.track, self._last_recorded_course) >= threshold
 
     async def _start_trip(self, tpv: GpsdTpv, now: float) -> None:
         if tpv.lat is None or tpv.lon is None:  # narrowed by caller; keeps pyright honest
@@ -244,6 +302,7 @@ class TripLogService:
         self._active_trip_distance_m += leg_distance_m
         self._last_recorded = (tpv.lat, tpv.lon)
         self._last_recorded_at = now
+        self._last_recorded_course = tpv.track
 
     async def _end_trip(self) -> None:
         trip_id = self._active_trip_id
@@ -443,3 +502,9 @@ class TripLogService:
             "gpsd_connected": self._connected,
             "active_trip_id": self._active_trip_id,
         }
+
+
+def _angular_difference(a: float, b: float) -> float:
+    """Smallest absolute difference between two compass headings, in degrees."""
+    diff = abs(a - b) % _FULL_TURN_DEG
+    return _FULL_TURN_DEG - diff if diff > _HALF_TURN_DEG else diff

--- a/tests/services/test_trip_log_service.py
+++ b/tests/services/test_trip_log_service.py
@@ -111,6 +111,12 @@ def make_service(**overrides: Any) -> tuple[TripLogService, FakeTripLogRepositor
         "min_trip_distance_m": 0.0,
         # Geocoding is exercised explicitly with a fake geocoder.
         "geocode_enabled": False,
+        # Fix-quality gates and course sampling are disabled by default so the
+        # synthetic fixes below (large jumps, no timing) aren't rejected; the
+        # trace-quality tests enable them explicitly.
+        "max_accuracy_m": 0.0,
+        "max_implied_speed_mps": 0.0,
+        "min_course_change_deg": 0.0,
     }
     kwargs.update(overrides)
     settings = TripLogSettings(**kwargs)
@@ -118,8 +124,16 @@ def make_service(**overrides: Any) -> tuple[TripLogService, FakeTripLogRepositor
     return TripLogService(settings, repository), repository
 
 
-def fix(lat: float, lon: float, speed: float = 0.0) -> GpsdTpv:
-    return GpsdTpv(lat=lat, lon=lon, timestamp=None, mode=3, speed=speed, track=90.0, alt=3.0)
+def fix(
+    lat: float,
+    lon: float,
+    speed: float = 0.0,
+    track: float = 90.0,
+    eph: float | None = None,
+) -> GpsdTpv:
+    return GpsdTpv(
+        lat=lat, lon=lon, timestamp=None, mode=3, speed=speed, track=track, alt=3.0, eph=eph
+    )
 
 
 # ~0.001 deg latitude ≈ 111 m; ~0.0001 ≈ 11 m.
@@ -265,6 +279,68 @@ class FakeBroker:
 
     async def publish(self, event: str, data: dict[str, Any]) -> None:
         self.events.append((event, data))
+
+
+class TestTraceQuality:
+    """Fix-quality gates and corner-capturing course sampling."""
+
+    async def test_rejects_imprecise_fix_by_eph(self):
+        service, repository = make_service(max_accuracy_m=25.0)
+        await service._handle_fix(fix(LAT, LON, speed=5.0, eph=10.0))  # good fix
+        good_points = len(repository.points)
+        assert good_points == 1
+
+        # A wildly imprecise fix (eph 80 m) is dropped: no point, and it does
+        # not even become the current position.
+        await service._handle_fix(fix(LAT + 0.001, LON, speed=5.0, eph=80.0))
+        assert len(repository.points) == good_points
+        assert service._last_fix is not None
+        assert service._last_fix.eph == 10.0
+
+    async def test_rejects_teleport_spike_by_implied_speed(self):
+        service, _ = make_service(max_implied_speed_mps=55.0)
+        await service._handle_fix(fix(LAT, LON, speed=5.0))
+        anchor = service._last_fix
+
+        # ~1 km jump one moment later implies ~1000 m/s — multipath, dropped.
+        service._last_fix_at = time.time() - 1.0
+        await service._handle_fix(fix(LAT + 0.009, LON, speed=5.0))
+        assert service._last_fix is anchor  # unchanged; spike ignored
+
+    async def test_relocation_accepted_after_gap(self):
+        # The same jump is legitimate once enough time passes (left a tunnel).
+        service, _ = make_service(max_implied_speed_mps=55.0)
+        await service._handle_fix(fix(LAT, LON, speed=5.0))
+        service._last_fix_at = time.time() - 60.0  # a minute of dead reckoning
+        await service._handle_fix(fix(LAT + 0.009, LON, speed=5.0))
+        assert service._last_fix is not None
+        assert service._last_fix.lat == LAT + 0.009
+
+    async def test_course_change_records_corner_point(self):
+        service, repository = make_service(
+            min_distance_m=200.0,  # far enough that distance alone won't fire
+            min_course_change_deg=12.0,
+        )
+        # Drive east, recording the trip's first point (heading 90).
+        await service._handle_fix(fix(LAT, LON, speed=10.0, track=90.0))
+        assert len(repository.points) == 1
+
+        # ~11 m further but now heading north: a sharp turn under the distance
+        # threshold still earns a breadcrumb so the corner isn't cut.
+        service._last_recorded_at = time.time() - 3.0
+        await service._handle_fix(fix(LAT, LON + 0.0001, speed=10.0, track=0.0))
+        assert len(repository.points) == 2
+
+    async def test_gentle_curve_below_threshold_adds_no_point(self):
+        service, repository = make_service(
+            min_distance_m=200.0,
+            min_course_change_deg=12.0,
+        )
+        await service._handle_fix(fix(LAT, LON, speed=10.0, track=90.0))
+        service._last_recorded_at = time.time() - 3.0
+        # Only a 5-degree drift and under the distance threshold: no point.
+        await service._handle_fix(fix(LAT, LON + 0.0001, speed=10.0, track=95.0))
+        assert len(repository.points) == 1
 
 
 class TestPositionPublishing:


### PR DESCRIPTION
Tier-1 trace-quality improvements (Pi-only, no external services) so recorded trails follow the roads instead of the jagged, corner-cutting lines seen in the current UI. This is the cheap-and-robust half of the map-cleanup work; true snap-to-road map matching (Valhalla on forge) is tracked separately.

## What was wrong

Two independent problems produced the zigzag:
1. **Corner-cutting** — breadcrumbs were sampled every 50 m, so a straight line between them cut across turns.
2. **GPS noise** — multipath near buildings scattered points, and occasional fixes "teleported" hundreds of metres.

## Changes (`TripLogService`)

- **Accuracy gate** — drop fixes whose reported horizontal error (gpsd `eph`, already parsed but previously ignored) exceeds `max_accuracy_m` (default 25 m). No-op when the receiver doesn't report `eph`.
- **Spike gate** — drop a fix that would imply a jump faster than `max_implied_speed_mps` (default 55 m/s ≈ 123 mph) from the last accepted fix. Rejections leave `_last_fix` untouched so `dt` grows and a genuine relocation (leaving a tunnel) is accepted within a few seconds — self-healing, no permanent lock-out.
- **Course-change sampling** — record an extra breadcrumb when the heading turns by `min_course_change_deg` (default 12°), gated on speed (gpsd track is unreliable at a crawl), a 5 m floor, and a 2 s floor so stationary jitter can't spam turn points. This is what puts a vertex at each corner.
- **Denser defaults** — `min_distance_m` 50 → 25, `min_interval_seconds` 15 → 5 for smoother straights and richer raw data (also better input for future map matching).

All gates are configurable via `COACHIQ_TRIP_LOG__*` and disable at 0.

## Testing

- New `TestTraceQuality`: eph rejection, teleport-spike rejection, post-gap relocation acceptance, corner capture, and a gentle sub-threshold curve that correctly adds no point. Existing lifecycle/noise/publish/geocode tests unchanged (new gates default-off in the harness). **21 passing.**
- Drove a synthetic noisy track (10-fix east leg with an injected 1 km spike and a 90 m-eph fix, a slow 90° turn, then a north leg) through the **real** service: both noise fixes are dropped and the recorded trail is a clean L with a breadcrumb sitting on the corner vertex — no corner-cut, no scatter.
- `ruff format`/`check` clean on changed lines; pyright adds no new errors; targeted tests green.

## Note on smoothing

I deliberately did **not** add positional smoothing (EMA/median): the accuracy + spike gates remove the outliers that smoothing would target, and smoothing fights the course-change sampling by rounding the very corners this captures. If jitter persists on real drives it can be added later as an opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)