### PR TITLE
feat(location): snap-to-road map matching for recorded trips

### DIFF
--- a/backend/api/routers/location.py
+++ b/backend/api/routers/location.py
@@ -111,6 +111,32 @@ async def merge_trip_with_previous(
     return {"merged": merged}
 
 
+@router.post("/trips/{trip_id}/rematch", summary="Re-run snap-to-road map matching for a trip")
+async def rematch_trip(
+    trip_id: int,
+    trip_log_service: Annotated[Any, Depends(get_optional_trip_log_service)],
+    trip_log_repository: Annotated[Any, Depends(get_optional_trip_log_repository)],
+) -> dict[str, Any]:
+    """Force a fresh Valhalla match for a finished trip.
+
+    Returns the trip with its (possibly still NULL) ``matched_geometry``; a
+    failed or low-confidence match leaves the raw breadcrumbs as the fallback.
+    """
+    service = _require(trip_log_service, "Trip log")
+    repository = _require(trip_log_repository, "Trip log")
+    trip = await repository.get_trip(trip_id)
+    if trip is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Trip not found")
+    if trip["ended_at"] is None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Trip is still recording; it can be matched once it ends",
+        )
+    matched = await service.rematch_trip(trip_id)
+    updated = await repository.get_trip(trip_id)
+    return {"trip": updated, "matched": matched}
+
+
 @router.get("/trips/{trip_id}/points", summary="Breadcrumbs for one trip")
 async def get_trip_points(
     trip_id: int,

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -1356,6 +1356,14 @@ class TripLogSettings(BaseSettings):
         default="https://nominatim.openstreetmap.org/reverse",
         description="Reverse-geocoding endpoint (Nominatim-compatible)",
     )
+    matching_enabled: bool = Field(
+        default=True,
+        description="Snap trip breadcrumbs to roads via a self-hosted Valhalla instance",
+    )
+    matching_url: str = Field(
+        default="http://forge.holthome.net:8002/trace_route",
+        description="Valhalla /trace_route map-matching endpoint (empty/unreachable no-ops)",
+    )
 
 
 class TimeSyncSettings(BaseSettings):

--- a/backend/models/trip_log.py
+++ b/backend/models/trip_log.py
@@ -39,6 +39,11 @@ class GpsTrip(Base, TimestampMixin):
     end_place: Mapped[str | None] = mapped_column(
         String, nullable=True, comment="Reverse-geocoded end locality"
     )
+    matched_geometry: Mapped[str | None] = mapped_column(
+        String,
+        nullable=True,
+        comment="Snap-to-road geometry as JSON [[lat, lon], ...]; NULL falls back to raw",
+    )
 
 
 class GpsBreadcrumb(Base, TimestampMixin):

--- a/backend/repositories/trip_log_repository.py
+++ b/backend/repositories/trip_log_repository.py
@@ -43,7 +43,7 @@ class TripLogRepository(MonitoredRepository):
             # the feature first shipped are patched in here (SQLite ALTER).
             result = await session.execute(text("PRAGMA table_info(gps_trips)"))
             existing = {row[1] for row in result}
-            for column in ("start_place", "end_place"):
+            for column in ("start_place", "end_place", "matched_geometry"):
                 if column not in existing:
                     await session.execute(
                         text(f"ALTER TABLE gps_trips ADD COLUMN {column} VARCHAR")
@@ -270,6 +270,9 @@ class TripLogRepository(MonitoredRepository):
             target.distance_m = target.distance_m + source.distance_m + bridge_distance_m
             target.max_speed_mps = max(target.max_speed_mps, source.max_speed_mps)
             target.point_count = target.point_count + source.point_count
+            # The merged trail differs from either matched geometry; drop it so
+            # the backfill re-snaps rather than showing a stale partial road.
+            target.matched_geometry = None
             await session.delete(source)
             await session.commit()
             await session.refresh(target)
@@ -300,6 +303,30 @@ class TripLogRepository(MonitoredRepository):
                 .where(
                     GpsTrip.ended_at.is_not(None),
                     GpsTrip.start_place.is_(None) | GpsTrip.end_place.is_(None),
+                )
+                .order_by(GpsTrip.started_at.desc())
+                .limit(limit)
+            )
+            return [_trip_to_dict(trip) for trip in result.scalars()]
+
+    @MonitoredRepository._monitored_operation("set_trip_matched_geometry")  # noqa: SLF001 - repo-standard decorator (see analytics_repository)
+    async def set_trip_matched_geometry(self, trip_id: int, geometry: str) -> None:
+        """Store snap-to-road geometry (JSON) on a trip."""
+        async with self._db_manager.get_session() as session:
+            await session.execute(
+                update(GpsTrip).where(GpsTrip.id == trip_id).values(matched_geometry=geometry)
+            )
+            await session.commit()
+
+    @MonitoredRepository._monitored_operation("get_trips_missing_match")  # noqa: SLF001 - repo-standard decorator (see analytics_repository)
+    async def get_trips_missing_match(self, limit: int = 20) -> list[dict[str, Any]]:
+        """Newest closed trips that have not been map-matched yet."""
+        async with self._db_manager.get_session() as session:
+            result = await session.execute(
+                select(GpsTrip)
+                .where(
+                    GpsTrip.ended_at.is_not(None),
+                    GpsTrip.matched_geometry.is_(None),
                 )
                 .order_by(GpsTrip.started_at.desc())
                 .limit(limit)
@@ -340,6 +367,7 @@ def _trip_to_dict(trip: GpsTrip) -> dict[str, Any]:
         "point_count": trip.point_count,
         "start_place": trip.start_place,
         "end_place": trip.end_place,
+        "matched_geometry": trip.matched_geometry,
         "active": trip.ended_at is None,
     }
 

--- a/backend/services/trip_log/map_matching.py
+++ b/backend/services/trip_log/map_matching.py
@@ -1,0 +1,153 @@
+"""
+Map matching (snap-to-road) for recorded trips.
+
+Sends a trip's raw GPS breadcrumbs to a self-hosted Valhalla ``/trace_route``
+endpoint (Meili map matching) and returns the snapped road geometry as a JSON
+``[[lat, lon], ...]`` string. Failures are soft — the RV is frequently offline
+or parked somewhere OSM doesn't map (campgrounds, boondocking sites), so callers
+treat ``None`` as "keep the raw breadcrumbs and try again later".
+
+The raw breadcrumbs are never modified; matched geometry is a separate, derived
+field the UI can toggle off, so a low-confidence snap must return ``None`` rather
+than a plausible-looking wrong road.
+"""
+
+import json
+from itertools import pairwise
+from typing import Any
+
+import httpx
+
+from backend.core.structured_logging import get_logger
+from backend.integrations.router_sidecar.location import haversine_distance_m
+
+logger = get_logger(__name__, "RouteMatcher")
+
+_TIMEOUT_SECONDS = 30.0
+_USER_AGENT = "CoachIQ/1.0 (https://github.com/carpenike/coachiq)"
+
+# A path needs at least two points.
+_MIN_POINTS = 2
+# Valhalla accepts large shapes, but keep each request bounded and stitch the
+# chunks so a cross-country trip can't build one pathological request.
+_MAX_POINTS_PER_REQUEST = 1000
+# Reject a match whose total length differs from the raw trail by more than this
+# fraction — the matcher snapped to the wrong road (common near unmapped
+# campgrounds) and the raw trail is the more trustworthy record.
+_LENGTH_TOLERANCE = 0.5
+
+# Google/Valhalla encoded-polyline codec. Valhalla emits precision 6 (1e6).
+_POLYLINE_PRECISION = 1_000_000.0
+_POLYLINE_CHUNK_BITS = 5
+_POLYLINE_CONTINUATION_BIT = 0x20
+_POLYLINE_CHUNK_MASK = 0x1F
+_POLYLINE_ASCII_OFFSET = 63
+# Round stored coordinates to Valhalla's precision-6 resolution (~0.1 m).
+_STORED_COORD_DECIMALS = 6
+
+
+def _decode_polyline6(encoded: str) -> list[tuple[float, float]]:
+    """Decode a Valhalla precision-6 encoded polyline into (lat, lon) pairs."""
+    coordinates: list[tuple[float, float]] = []
+    index = 0
+    lat = 0
+    lon = 0
+    length = len(encoded)
+    while index < length:
+        deltas = [0, 0]
+        for axis in (0, 1):  # 0 = latitude, 1 = longitude
+            shift = 0
+            result = 0
+            while True:
+                byte = ord(encoded[index]) - _POLYLINE_ASCII_OFFSET
+                index += 1
+                result |= (byte & _POLYLINE_CHUNK_MASK) << shift
+                shift += _POLYLINE_CHUNK_BITS
+                if byte < _POLYLINE_CONTINUATION_BIT:
+                    break
+            deltas[axis] = ~(result >> 1) if result & 1 else (result >> 1)
+        lat += deltas[0]
+        lon += deltas[1]
+        coordinates.append((lat / _POLYLINE_PRECISION, lon / _POLYLINE_PRECISION))
+    return coordinates
+
+
+def _extract_geometry(payload: dict[str, Any]) -> list[tuple[float, float]]:
+    """Concatenate the decoded shape of every leg in a Valhalla trace_route."""
+    trip = payload.get("trip") or {}
+    coordinates: list[tuple[float, float]] = []
+    for leg in trip.get("legs") or []:
+        shape = leg.get("shape")
+        if isinstance(shape, str) and shape:
+            coordinates.extend(_decode_polyline6(shape))
+    return coordinates
+
+
+class RouteMatcher:
+    """Thin async client for Valhalla ``/trace_route``."""
+
+    def __init__(self, url: str) -> None:
+        self._url = url
+
+    async def match(self, points: list[dict[str, Any]], raw_distance_m: float) -> str | None:
+        """Snap breadcrumbs to roads.
+
+        Returns a JSON ``[[lat, lon], ...]`` string, or ``None`` on any failure
+        (offline, empty result, or an implausible match). Never raises.
+        """
+        if len(points) < _MIN_POINTS:
+            return None
+        try:
+            matched: list[tuple[float, float]] = []
+            for start in range(0, len(points), _MAX_POINTS_PER_REQUEST):
+                chunk = points[start : start + _MAX_POINTS_PER_REQUEST]
+                if len(chunk) < _MIN_POINTS:
+                    break
+                geometry = await self._match_chunk(chunk)
+                if not geometry:
+                    return None
+                matched.extend(geometry)
+        except Exception as exc:  # offline or unmapped: normal on the road
+            logger.debug("Map match failed (%s); will retry later", exc)
+            return None
+        if len(matched) < _MIN_POINTS or not self._is_plausible(matched, raw_distance_m):
+            logger.debug("Map match implausible for %.0fm trip; keeping raw", raw_distance_m)
+            return None
+        return json.dumps(
+            [
+                [round(lat, _STORED_COORD_DECIMALS), round(lon, _STORED_COORD_DECIMALS)]
+                for lat, lon in matched
+            ]
+        )
+
+    async def _match_chunk(self, chunk: list[dict[str, Any]]) -> list[tuple[float, float]]:
+        payload = {
+            "shape": [{"lat": point["latitude"], "lon": point["longitude"]} for point in chunk],
+            "costing": "auto",
+            "shape_match": "map_snap",
+        }
+        async with httpx.AsyncClient(timeout=_TIMEOUT_SECONDS) as client:
+            # The httpx stub pyright resolves models AsyncClient.post without any
+            # request-body parameter, so it wrongly rejects ``json=`` (and
+            # ``content=``). httpx 0.28.1 has it at runtime; suppress the stale-
+            # stub false positive rather than hand-encode the body.
+            response = await client.post(
+                self._url,
+                json=payload,  # pyright: ignore[reportCallIssue]
+                headers={"User-Agent": _USER_AGENT},
+            )
+            response.raise_for_status()
+            return _extract_geometry(response.json())
+
+    @staticmethod
+    def _is_plausible(matched: list[tuple[float, float]], raw_distance_m: float) -> bool:
+        """A match is plausible when its length is within tolerance of the raw trail."""
+        if raw_distance_m <= 0:
+            return True
+        matched_distance_m = sum(
+            haversine_distance_m(previous[0], previous[1], current[0], current[1])
+            for previous, current in pairwise(matched)
+        )
+        low = raw_distance_m * (1.0 - _LENGTH_TOLERANCE)
+        high = raw_distance_m * (1.0 + _LENGTH_TOLERANCE)
+        return low <= matched_distance_m <= high

--- a/backend/services/trip_log/trip_log_service.py
+++ b/backend/services/trip_log/trip_log_service.py
@@ -32,6 +32,7 @@ from backend.core.structured_logging import get_logger
 from backend.integrations.router_sidecar.gpsd import GpsdClient, GpsdTpv
 from backend.integrations.router_sidecar.location import haversine_distance_m
 from backend.services.trip_log.geocoding import ReverseGeocoder
+from backend.services.trip_log.map_matching import RouteMatcher
 
 logger = get_logger(__name__, "TripLogService")
 
@@ -61,6 +62,14 @@ _CORNER_MIN_INTERVAL_SECONDS = 2.0
 _FULL_TURN_DEG = 360.0
 _HALF_TURN_DEG = 180.0
 
+# Map matching runs against a self-hosted Valhalla instance (no rate limit), so
+# it only needs a backfill batch size, not per-request pacing.
+_MATCH_BACKFILL_LIMIT = 20
+# Unlike geocoding, a match can fail for a single trip permanently (a drive that
+# stays on roads OSM doesn't map), so the backfill skips isolated failures and
+# only gives up after this many in a row — the signature of Valhalla being down.
+_MATCH_BACKFILL_MAX_CONSECUTIVE_FAILURES = 3
+
 
 class TripLogService:
     """Background recorder of GPS breadcrumbs segmented into trips."""
@@ -76,12 +85,15 @@ class TripLogService:
         self._event_broker = event_broker
         self._client = GpsdClient(settings.gpsd_host, settings.gpsd_port)
         self._geocoder = ReverseGeocoder(settings.geocode_url)
+        self._matcher = RouteMatcher(settings.matching_url)
 
         self._running = False
         self._task: asyncio.Task | None = None
         self._prune_task: asyncio.Task | None = None
         self._geocode_backfill_task: asyncio.Task | None = None
         self._geocode_tasks: set[asyncio.Task] = set()
+        self._match_backfill_task: asyncio.Task | None = None
+        self._match_tasks: set[asyncio.Task] = set()
         self._connected = False
 
         # SSE publish throttle state
@@ -120,6 +132,8 @@ class TripLogService:
             self._prune_task = asyncio.create_task(self._prune_loop())
         if self._settings.geocode_enabled:
             self._geocode_backfill_task = asyncio.create_task(self._geocode_backfill())
+        if self._settings.matching_enabled:
+            self._match_backfill_task = asyncio.create_task(self._match_backfill())
         logger.info("Trip Log Service started")
 
     async def stop(self) -> None:
@@ -129,6 +143,8 @@ class TripLogService:
         self._running = False
         tasks = [self._task, self._prune_task, self._geocode_backfill_task]
         tasks.extend(self._geocode_tasks)
+        tasks.append(self._match_backfill_task)
+        tasks.extend(self._match_tasks)
         for task in tasks:
             if task:
                 task.cancel()
@@ -138,6 +154,8 @@ class TripLogService:
         self._prune_task = None
         self._geocode_backfill_task = None
         self._geocode_tasks.clear()
+        self._match_backfill_task = None
+        self._match_tasks.clear()
         logger.info("Trip Log Service stopped")
 
     # ------------------------------------------------------------------
@@ -327,6 +345,8 @@ class TripLogService:
             logger.info("Trip ended", trip_id=trip_id)
             if self._settings.geocode_enabled:
                 self._spawn_geocode(trip_id)
+            if self._settings.matching_enabled:
+                self._spawn_match(trip_id)
         self._active_trip_id = None
         self._active_trip_distance_m = 0.0
 
@@ -422,6 +442,73 @@ class TripLogService:
             raise
         except Exception:
             logger.exception("Error in geocode backfill")
+
+    # ------------------------------------------------------------------
+    # Map matching (snap-to-road)
+    # ------------------------------------------------------------------
+
+    def _spawn_match(self, trip_id: int) -> None:
+        """Map-match a finished trip in the background (offline-tolerant)."""
+        task = asyncio.create_task(self._match_trip_by_id(trip_id))
+        self._match_tasks.add(task)
+        task.add_done_callback(self._match_tasks.discard)
+
+    async def _match_trip_by_id(self, trip_id: int, *, force: bool = False) -> bool:
+        try:
+            trip = await self._repository.get_trip(trip_id)
+            if trip is None:
+                return False
+            return await self._match_trip(trip, force=force)
+        except Exception:
+            logger.exception("Error map matching trip %s", trip_id)
+            return False
+
+    async def _match_trip(self, trip: dict[str, Any], *, force: bool = False) -> bool:
+        """Snap one trip's breadcrumbs to roads; True if geometry was stored.
+
+        Raw breadcrumbs are read but never modified. A failed or low-confidence
+        match leaves ``matched_geometry`` NULL so the UI falls back to the raw
+        trail and the backfill retries later.
+        """
+        if not force and trip.get("matched_geometry") is not None:
+            return True
+        points = await self._repository.get_trip_points(trip["id"])
+        geometry = await self._matcher.match(points, trip.get("distance_m") or 0.0)
+        if geometry is None:
+            return False
+        await self._repository.set_trip_matched_geometry(trip["id"], geometry)
+        return True
+
+    async def _match_backfill(self) -> None:
+        """Snap recent trips that predate matching (or ended while offline).
+
+        A single trip that won't match (e.g. an entirely-off-road campground
+        drive) is skipped rather than allowed to block the trips behind it; the
+        loop only bails out once enough trips fail in a row to indicate Valhalla
+        is unreachable, and retries the rest on the next start.
+        """
+        try:
+            trips = await self._repository.get_trips_missing_match(_MATCH_BACKFILL_LIMIT)
+            matched = 0
+            consecutive_failures = 0
+            for trip in trips:
+                if await self._match_trip(trip):
+                    matched += 1
+                    consecutive_failures = 0
+                    continue
+                consecutive_failures += 1
+                if consecutive_failures >= _MATCH_BACKFILL_MAX_CONSECUTIVE_FAILURES:
+                    break
+            if matched:
+                logger.info("Map matched %d trips", matched)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("Error in map match backfill")
+
+    async def rematch_trip(self, trip_id: int) -> bool:
+        """Force a re-match of one trip (used by the API rematch endpoint)."""
+        return await self._match_trip_by_id(trip_id, force=True)
 
     async def _resume_or_close_dangling_trip(self) -> None:
         """After a restart, resume a recent active trip or close a stale one."""

--- a/frontend/src/api/location.ts
+++ b/frontend/src/api/location.ts
@@ -29,6 +29,8 @@ export interface ITrip {
   point_count: number;
   start_place: string | null;
   end_place: string | null;
+  /** Snap-to-road geometry as JSON "[[lat, lon], ...]"; null falls back to raw breadcrumbs. */
+  matched_geometry: string | null;
   active: boolean;
 }
 
@@ -94,4 +96,12 @@ export async function mergeTripWithPrevious(tripId: number): Promise<ITrip> {
     `/api/location/trips/${tripId}/merge-previous`
   );
   return result.merged;
+}
+
+/** Force a fresh snap-to-road match; returns the trip (matched_geometry may still be null). */
+export async function rematchTrip(tripId: number): Promise<ITrip> {
+  const result = await apiPost<{ trip: ITrip; matched: boolean }>(
+    `/api/location/trips/${tripId}/rematch`
+  );
+  return result.trip;
 }

--- a/frontend/src/pages/location.tsx
+++ b/frontend/src/pages/location.tsx
@@ -554,6 +554,25 @@ function TripRow({
 
 const EMPTY_POINTS: ITripPoint[] = []
 
+/** Parse a trip's stored snap-to-road geometry ("[[lat, lon], ...]") into Leaflet points. */
+function parseMatchedGeometry(raw: string | null | undefined): [number, number][] | null {
+  if (!raw) return null
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return null
+    const coords = parsed.filter(
+      (point): point is [number, number] =>
+        Array.isArray(point) &&
+        point.length === 2 &&
+        typeof point[0] === "number" &&
+        typeof point[1] === "number"
+    )
+    return coords.length > 1 ? coords : null
+  } catch {
+    return null
+  }
+}
+
 /** Map card with the follow-the-coach toggle and (for finished trips) replay. */
 function MapCard({
   trail,
@@ -561,17 +580,36 @@ function MapCard({
   replay,
   follow,
   onToggleFollow,
+  hasSnapped,
+  showRaw,
+  onToggleRaw,
 }: Readonly<{
   trail: [number, number][]
   here: [number, number] | null
   replay: ITripReplay
   follow: boolean
   onToggleFollow: () => void
+  hasSnapped: boolean
+  showRaw: boolean
+  onToggleRaw: () => void
 }>) {
   return (
     <Card className="overflow-hidden lg:col-span-2">
       <div className="relative">
         <TrailMap trail={trail} here={here} replay={replay} follow={follow} />
+        {hasSnapped && (
+          <Button
+            variant={showRaw ? "secondary" : "default"}
+            size="sm"
+            className="absolute left-2 top-2 z-[1000] h-8 gap-1 px-2 shadow"
+            aria-label={showRaw ? "Show snapped-to-road track" : "Show raw GPS track"}
+            title={showRaw ? "Showing raw GPS — tap for snapped" : "Showing snapped — tap for raw"}
+            onClick={onToggleRaw}
+          >
+            <IconRoute className="size-4" />
+            {showRaw ? "Raw" : "Snapped"}
+          </Button>
+        )}
         {here && (
           <Button
             variant={follow ? "default" : "secondary"}
@@ -689,6 +727,29 @@ function useTripActions(setSelectedTripId: Dispatch<SetStateAction<number | null
   return { deleteMutation, mergeMutation }
 }
 
+/** Derived snapped/raw trail state for the shown trip (snapped preferred when available). */
+function useSnappedTrail(
+  rawTrail: [number, number][],
+  matchedGeometry: string | null | undefined,
+  tripKey: number | null,
+  isLiveTrail: boolean
+): {
+  displayTrail: [number, number][]
+  hasSnapped: boolean
+  showRaw: boolean
+  onToggleRaw: () => void
+} {
+  const [showRaw, setShowRaw] = useState(false)
+  // Reset to the preferred snapped view whenever the shown trip changes.
+  useEffect(() => setShowRaw(false), [tripKey])
+  const snappedTrail = useMemo(() => parseMatchedGeometry(matchedGeometry), [matchedGeometry])
+  // A live trail is still growing, so it is never shown snapped.
+  const hasSnapped = snappedTrail !== null && !isLiveTrail
+  const displayTrail =
+    snappedTrail !== null && !isLiveTrail && !showRaw ? snappedTrail : rawTrail
+  return { displayTrail, hasSnapped, showRaw, onToggleRaw: () => setShowRaw((prev) => !prev) }
+}
+
 export default function LocationPage() {
   const [selectedTripId, setSelectedTripId] = useState<number | null>(null)
   const [follow, setFollow] = useState(false)
@@ -732,6 +793,12 @@ export default function LocationPage() {
     () => points.map((point) => [point.latitude, point.longitude]),
     [points]
   )
+  const { displayTrail, hasSnapped, showRaw, onToggleRaw } = useSnappedTrail(
+    trail,
+    pointData?.trip.matched_geometry,
+    shownTripId,
+    isLiveTrail
+  )
   const here = useMemo<[number, number] | null>(
     () =>
       current?.fix && current.latitude !== null && current.longitude !== null
@@ -749,11 +816,14 @@ export default function LocationPage() {
 
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
         <MapCard
-          trail={trail}
+          trail={displayTrail}
           here={here}
           replay={replay}
           follow={follow}
           onToggleFollow={() => setFollow((prev) => !prev)}
+          hasSnapped={hasSnapped}
+          showRaw={showRaw}
+          onToggleRaw={onToggleRaw}
         />
         <TripsCard
           trips={tripData?.trips ?? []}

--- a/tests/services/test_trip_log_service.py
+++ b/tests/services/test_trip_log_service.py
@@ -28,6 +28,7 @@ class FakeTripLogRepository:
             "distance_m": 0.0,
             "start_place": None,
             "end_place": None,
+            "matched_geometry": None,
         }
         return trip_id
 
@@ -60,6 +61,23 @@ class FakeTripLogRepository:
         ]
         unnamed.sort(key=lambda trip: -trip["started_at"])
         return unnamed[:limit]
+
+    async def set_trip_matched_geometry(self, trip_id: int, geometry: str) -> None:
+        self.trips[trip_id]["matched_geometry"] = geometry
+
+    async def get_trips_missing_match(self, limit: int = 20) -> list[dict[str, Any]]:
+        unmatched = [
+            trip
+            for trip in self.trips.values()
+            if trip["ended_at"] is not None and trip["matched_geometry"] is None
+        ]
+        unmatched.sort(key=lambda trip: -trip["started_at"])
+        return unmatched[:limit]
+
+    async def get_trip_points(self, trip_id: int) -> list[dict[str, Any]]:
+        points = [point for point in self.points if point["trip_id"] == trip_id]
+        points.sort(key=lambda point: point["timestamp"])
+        return points
 
     async def add_point(self, **kwargs: Any) -> None:
         self.points.append(kwargs)
@@ -111,6 +129,8 @@ def make_service(**overrides: Any) -> tuple[TripLogService, FakeTripLogRepositor
         "min_trip_distance_m": 0.0,
         # Geocoding is exercised explicitly with a fake geocoder.
         "geocode_enabled": False,
+        # Map matching is exercised explicitly with a fake matcher.
+        "matching_enabled": False,
         # Fix-quality gates and course sampling are disabled by default so the
         # synthetic fixes below (large jumps, no timing) aren't rejected; the
         # trace-quality tests enable them explicitly.
@@ -408,6 +428,95 @@ class TestGeocoding:
         # First trip failed both lookups; the loop must not hammer the rest.
         assert len(geocoder.calls) == 2
         assert all(trip["start_place"] is None for trip in repository.trips.values())
+
+
+class FakeMatcher:
+    def __init__(
+        self, geometry: str | None = None, *, results: list[str | None] | None = None
+    ) -> None:
+        # `geometry` is returned for every call; `results` is consumed one per
+        # call (then None) to script per-trip success/failure.
+        self._geometry = geometry
+        self._results = list(results) if results is not None else None
+        self.calls: list[tuple[int, float]] = []
+
+    async def match(self, points: list[dict[str, Any]], raw_distance_m: float) -> str | None:
+        self.calls.append((len(points), raw_distance_m))
+        if self._results is not None:
+            return self._results.pop(0) if self._results else None
+        return self._geometry
+
+
+class TestMapMatching:
+    async def _finished_trip_with_points(
+        self, repository: FakeTripLogRepository, started_offset: float = 3600
+    ) -> int:
+        trip_id = await repository.start_trip(time.time() - started_offset, LAT, LON)
+        await repository.add_point(
+            trip_id=trip_id, timestamp=time.time() - started_offset, latitude=LAT, longitude=LON
+        )
+        await repository.add_point(
+            trip_id=trip_id,
+            timestamp=time.time() - started_offset + 60,
+            latitude=LAT + 0.01,
+            longitude=LON,
+        )
+        await repository.end_trip(trip_id, time.time(), LAT + 0.01, LON)
+        return trip_id
+
+    async def test_match_at_end_stores_geometry(self):
+        service, repository = make_service()
+        geometry = "[[35.5784, -75.4655], [35.5884, -75.4655]]"
+        service._matcher = FakeMatcher(geometry)
+
+        trip_id = await self._finished_trip_with_points(repository)
+        points_before = [dict(point) for point in repository.points]
+
+        assert await service._match_trip(repository.trips[trip_id]) is True
+        assert repository.trips[trip_id]["matched_geometry"] == geometry
+        # Raw breadcrumbs must be left completely untouched.
+        assert repository.points == points_before
+
+    async def test_backfill_stops_when_matcher_unreachable(self):
+        service, repository = make_service()
+        matcher = FakeMatcher(None)  # every match fails (Valhalla down)
+        service._matcher = matcher
+
+        for offset in (10800, 7200, 3600, 1800, 900):  # five unmatched trips
+            await self._finished_trip_with_points(repository, started_offset=offset)
+
+        await service._match_backfill()
+        # Bails out after N consecutive failures instead of hammering all five.
+        assert len(matcher.calls) == 3
+        assert all(trip["matched_geometry"] is None for trip in repository.trips.values())
+
+    async def test_backfill_skips_unmappable_trip_and_continues(self):
+        service, repository = make_service()
+        geometry = "[[35.5784, -75.4655], [35.5884, -75.4655]]"
+        # Newest trip is unmappable (None); the two older ones match. Backfill
+        # must not let the one failure block the trips behind it.
+        service._matcher = FakeMatcher(results=[None, geometry, geometry])
+
+        newest = await self._finished_trip_with_points(repository, started_offset=1800)
+        older = await self._finished_trip_with_points(repository, started_offset=3600)
+        oldest = await self._finished_trip_with_points(repository, started_offset=7200)
+
+        await service._match_backfill()
+        assert repository.trips[newest]["matched_geometry"] is None
+        assert repository.trips[older]["matched_geometry"] == geometry
+        assert repository.trips[oldest]["matched_geometry"] == geometry
+
+    async def test_low_confidence_leaves_field_null_and_raw_untouched(self):
+        service, repository = make_service()
+        # A rejected (low-confidence) match returns None from the matcher.
+        service._matcher = FakeMatcher(None)
+
+        trip_id = await self._finished_trip_with_points(repository)
+        points_before = [dict(point) for point in repository.points]
+
+        assert await service._match_trip(repository.trips[trip_id]) is False
+        assert repository.trips[trip_id]["matched_geometry"] is None
+        assert repository.points == points_before
 
 
 class TestReadSide:


### PR DESCRIPTION
Tier-2 of the location work: lazy, offline-tolerant **map matching** that snaps a trip's raw GPS breadcrumbs to the OSM road network via a self-hosted Valhalla instance, so trails render on the actual streets instead of the jagged raw trace. Pairs with the Valhalla-on-forge infra change in nix-config (separate PR); `matching_enabled` no-ops until Valhalla answers, so this can merge independently.

Originally drafted by a build agent from the tier-2 spec; I rebased it onto tier-1 (#234), resolved the conflicts as a union, reviewed the implementation, and fixed a backfill roadblock (below).

## Core principle
Raw breadcrumbs are **never modified**. Matched geometry is a separate, optional derived field; the UI can toggle it off, and matching falls back to raw whenever it fails or the result is implausible (common near unmapped RV parks / boondocking sites).

## Backend
- **`map_matching.py`** — httpx client for Valhalla `/trace_route` (`map_snap`, `costing=auto`). Correct precision-6 polyline decoder, chunks/stitches long trips, rejects matches whose length differs from the raw trail by >50%, soft-fails (`except Exception`, debug log) on any error.
- **`GpsTrip.matched_geometry`** nullable TEXT (JSON `[[lat,lon],…]`), ALTERed in idempotently; `set_trip_matched_geometry` / `get_trips_missing_match`; merge clears stale geometry.
- **`TripLogService`** — matches at trip-end and backfills recent unmatched trips on start, mirroring the geocoding lifecycle (tasks tracked + cancelled in `stop()`). `matching_enabled` + `matching_url` settings.
- **Router** — exposes `matched_geometry` and adds `POST /trips/{id}/rematch` (404/409 like siblings).

### Backfill roadblock fix (my change on top of the agent's draft)
The agent's backfill copied geocoding's *break-on-first-failure*. That's wrong for matching: unlike geocoding (where a failure means offline), a match can fail **permanently** for one trip — a drive that stays on roads OSM doesn't map. Since `get_trips_missing_match` is newest-first, a single recent unmappable trip would permanently block backfill of everything older. Changed to skip isolated failures and bail only after several consecutive failures (the signature of Valhalla being unreachable). Added a test for the isolated-unmappable-trip case.

## Frontend
`ITrip.matched_geometry` + `rematchTrip()`; the map prefers the snapped trail when present with a **Raw/Snapped** toggle (resets to snapped per trip), while **replay stays on raw** breadcrumbs.

## Testing
- 25 backend tests pass (tier-1's 21 + 4 matching: store-at-end, backfill bails when unreachable, isolated unmappable trip skipped so older trips still match, low-confidence leaves field null with raw asserted untouched).
- `ruff format`/`check` clean; frontend `tsc` + ESLint clean; `vite build` succeeds.
- pyright: `map_matching.py`'s only local finding is a false `json=` error — this env resolves httpx from stubs only (no source), which cascades; runtime confirms `json` is a real `post()` param, so CI's installed env accepts it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)