### PR TITLE
feat(location): periodically retry trip enrichment so the coach self-heals

### DIFF
--- a/backend/services/trip_log/trip_log_service.py
+++ b/backend/services/trip_log/trip_log_service.py
@@ -50,7 +50,12 @@ _PUBLISH_MIN_MOVE_M = 10.0
 
 # Nominatim usage policy: at most one request per second.
 _GEOCODE_PACING_SECONDS = 1.1
-_GEOCODE_BACKFILL_LIMIT = 20
+_GEOCODE_BACKFILL_LIMIT = 100
+
+# Enrichment (geocode + map match) runs once at startup and then on this
+# interval, so a coach that regains connectivity to Nominatim/Valhalla while
+# driving self-heals its unnamed/unmatched trips without needing a restart.
+_ENRICHMENT_INTERVAL_SECONDS = 3600.0
 
 # Course-change breadcrumbs: gpsd's reported track is unreliable at a crawl,
 # so only trust it above this speed, and require a little real movement and
@@ -64,10 +69,12 @@ _HALF_TURN_DEG = 180.0
 
 # Map matching runs against a self-hosted Valhalla instance (no rate limit), so
 # it only needs a backfill batch size, not per-request pacing.
-_MATCH_BACKFILL_LIMIT = 20
+_MATCH_BACKFILL_LIMIT = 200
 # Unlike geocoding, a match can fail for a single trip permanently (a drive that
 # stays on roads OSM doesn't map), so the backfill skips isolated failures and
-# only gives up after this many in a row — the signature of Valhalla being down.
+# only gives up after this many in a row *before any trip has matched* — the
+# signature of Valhalla being unreachable. Once one trip matches we know we are
+# online, so later failures are just unmappable trips and never stop the drain.
 _MATCH_BACKFILL_MAX_CONSECUTIVE_FAILURES = 3
 
 
@@ -90,9 +97,8 @@ class TripLogService:
         self._running = False
         self._task: asyncio.Task | None = None
         self._prune_task: asyncio.Task | None = None
-        self._geocode_backfill_task: asyncio.Task | None = None
+        self._enrichment_task: asyncio.Task | None = None
         self._geocode_tasks: set[asyncio.Task] = set()
-        self._match_backfill_task: asyncio.Task | None = None
         self._match_tasks: set[asyncio.Task] = set()
         self._connected = False
 
@@ -130,10 +136,8 @@ class TripLogService:
         self._task = asyncio.create_task(self._watch_loop())
         if self._settings.retention_days > 0:
             self._prune_task = asyncio.create_task(self._prune_loop())
-        if self._settings.geocode_enabled:
-            self._geocode_backfill_task = asyncio.create_task(self._geocode_backfill())
-        if self._settings.matching_enabled:
-            self._match_backfill_task = asyncio.create_task(self._match_backfill())
+        if self._settings.geocode_enabled or self._settings.matching_enabled:
+            self._enrichment_task = asyncio.create_task(self._enrichment_loop())
         logger.info("Trip Log Service started")
 
     async def stop(self) -> None:
@@ -141,9 +145,8 @@ class TripLogService:
         if not self._running:
             return
         self._running = False
-        tasks = [self._task, self._prune_task, self._geocode_backfill_task]
+        tasks = [self._task, self._prune_task, self._enrichment_task]
         tasks.extend(self._geocode_tasks)
-        tasks.append(self._match_backfill_task)
         tasks.extend(self._match_tasks)
         for task in tasks:
             if task:
@@ -152,9 +155,8 @@ class TripLogService:
                     await task
         self._task = None
         self._prune_task = None
-        self._geocode_backfill_task = None
+        self._enrichment_task = None
         self._geocode_tasks.clear()
-        self._match_backfill_task = None
         self._match_tasks.clear()
         logger.info("Trip Log Service stopped")
 
@@ -480,12 +482,15 @@ class TripLogService:
         return True
 
     async def _match_backfill(self) -> None:
-        """Snap recent trips that predate matching (or ended while offline).
+        """Snap trips that predate matching (or ended while offline).
 
         A single trip that won't match (e.g. an entirely-off-road campground
-        drive) is skipped rather than allowed to block the trips behind it; the
-        loop only bails out once enough trips fail in a row to indicate Valhalla
-        is unreachable, and retries the rest on the next start.
+        drive) is skipped rather than allowed to block the trips behind it. The
+        drain only bails out if enough trips fail in a row *before any has
+        matched* — the signature of Valhalla being unreachable (where each
+        attempt is a slow connect timeout). Once one trip matches, connectivity
+        is proven, so the remaining failures are treated as unmappable and
+        skipped so the whole backlog still drains.
         """
         try:
             trips = await self._repository.get_trips_missing_match(_MATCH_BACKFILL_LIMIT)
@@ -497,7 +502,10 @@ class TripLogService:
                     consecutive_failures = 0
                     continue
                 consecutive_failures += 1
-                if consecutive_failures >= _MATCH_BACKFILL_MAX_CONSECUTIVE_FAILURES:
+                if (
+                    matched == 0
+                    and consecutive_failures >= _MATCH_BACKFILL_MAX_CONSECUTIVE_FAILURES
+                ):
                     break
             if matched:
                 logger.info("Map matched %d trips", matched)
@@ -505,6 +513,24 @@ class TripLogService:
             raise
         except Exception:
             logger.exception("Error in map match backfill")
+
+    async def _enrichment_loop(self) -> None:
+        """Run enrichment at startup, then on an interval.
+
+        Retrying on a timer (not only at startup) means a coach that was out of
+        reach of Nominatim/Valhalla while driving self-heals its unnamed and
+        unmatched trips once it regains connectivity, without needing a restart.
+        """
+        while self._running:
+            await self._run_enrichment_once()
+            await asyncio.sleep(_ENRICHMENT_INTERVAL_SECONDS)
+
+    async def _run_enrichment_once(self) -> None:
+        """One geocode + map-match backfill pass (both gated by their setting)."""
+        if self._settings.geocode_enabled:
+            await self._geocode_backfill()
+        if self._settings.matching_enabled:
+            await self._match_backfill()
 
     async def rematch_trip(self, trip_id: int) -> bool:
         """Force a re-match of one trip (used by the API rematch endpoint)."""

--- a/tests/services/test_trip_log_service.py
+++ b/tests/services/test_trip_log_service.py
@@ -518,6 +518,60 @@ class TestMapMatching:
         assert repository.trips[trip_id]["matched_geometry"] is None
         assert repository.points == points_before
 
+    async def test_backfill_keeps_draining_past_unmappable_run_once_online(self):
+        service, repository = make_service()
+        geometry = "[[35.5784, -75.4655], [35.5884, -75.4655]]"
+        # One match proves connectivity, then a long run of unmappable trips
+        # (more than the consecutive-failure limit) must NOT stop the drain —
+        # the trip after them still matches.
+        service._matcher = FakeMatcher(results=[geometry, None, None, None, None, geometry])
+
+        ids = [
+            await self._finished_trip_with_points(repository, started_offset=offset)
+            for offset in (600, 1200, 1800, 2400, 3000, 3600)
+        ]
+
+        await service._match_backfill()
+        assert repository.trips[ids[0]]["matched_geometry"] == geometry
+        assert repository.trips[ids[5]]["matched_geometry"] == geometry  # reached despite 4 misses
+        assert all(repository.trips[ids[i]]["matched_geometry"] is None for i in (1, 2, 3, 4))
+
+    async def test_enrichment_pass_runs_geocode_and_match(self, monkeypatch):
+        import backend.services.trip_log.trip_log_service as module
+
+        monkeypatch.setattr(module, "_GEOCODE_PACING_SECONDS", 0.0)
+        service, repository = make_service(geocode_enabled=True, matching_enabled=True)
+        geometry = "[[35.5784, -75.4655], [35.5884, -75.4655]]"
+        service._matcher = FakeMatcher(geometry)
+        service._geocoder = FakeGeocoder(
+            ["Nags Head, North Carolina", "Kitty Hawk, North Carolina"]
+        )
+
+        trip_id = await self._finished_trip_with_points(repository)
+
+        await service._run_enrichment_once()
+        assert repository.trips[trip_id]["matched_geometry"] == geometry
+        assert repository.trips[trip_id]["start_place"] == "Nags Head, North Carolina"
+
+    async def test_enrichment_loop_repeats_until_stopped(self, monkeypatch):
+        import backend.services.trip_log.trip_log_service as module
+
+        monkeypatch.setattr(module, "_ENRICHMENT_INTERVAL_SECONDS", 0.0)
+        service, _ = make_service(matching_enabled=True)
+
+        passes = 0
+
+        async def counting_pass() -> None:
+            nonlocal passes
+            passes += 1
+            if passes >= 3:  # let it tick a few times, then stop the loop
+                service._running = False
+
+        service._run_enrichment_once = counting_pass  # type: ignore[method-assign]
+        service._running = True
+        await service._enrichment_loop()
+        assert passes == 3  # ran repeatedly, not just once
+
 
 class TestReadSide:
     async def test_current_position_reflects_last_fix(self):


### PR DESCRIPTION
Follow-up to the map-matching work (#235). Makes geocoding and map matching **self-heal on a timer** instead of only retrying at app startup.

## Problem
Both enrichments (reverse-geocoded names, snap-to-road geometry) ran their backfill exactly once, in `start()`. For an RV that's the wrong trigger: forge/Valhalla and public Nominatim live at home, the coach travels out of reach, finishes several trips offline, then comes back — and those trips would stay unnamed/unmatched until the **next app restart** (deploy or reboot), which could be days. There was no periodic retry and no connectivity-detection while running.

## Changes
- **Periodic `_enrichment_loop`** replaces the two one-shot startup tasks: runs geocode + match backfill immediately at startup, then **every hour**, so trips self-heal within an hour of the coach regaining connectivity — no restart. Loop body is `_run_enrichment_once` (testable); the task is cancelled cleanly in `stop()`.
- **Bigger drain**: batch sizes raised (geocode 20→100, match 20→200) so a backlog from a long offline stretch actually clears instead of only the newest 20 per pass. (Geocode stays paced at 1 req/s per Nominatim policy; Valhalla is self-hosted/unmetered.)
- **Roadblock fix in match backfill**: it now only treats a failure streak as "Valhalla unreachable" (and bails) *before any trip has matched*. Once one match succeeds, connectivity is proven, so subsequent failures are unmappable trips that get skipped rather than allowed to stall everything behind them. This closes the case where a cluster of off-road (campground/boondocking) trips could block the drain on every pass.

## Behavior after this
- **forge down / coach offline**: matching fails fast, trips keep their raw trail (`matched_geometry` NULL), nothing blocks. Next hourly tick retries.
- **coach regains connectivity**: within ≤1 hour the loop drains the whole unmatched/unnamed backlog automatically.
- **new trips**: still matched/geocoded immediately at trip-end (unchanged); the loop is purely the retry path.
- Manual `POST /trips/{id}/rematch` still available for on-demand.

## Testing
28 backend tests pass (25 + 3 new): the enrichment pass runs both backfills, the loop repeats until stopped, and match backfill drains past a run of unmappable trips once online. `ruff format`/`check` clean; pyright 0 errors on the changed service file.

Background-loop logic with no browser surface, so tests are the verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)