### PR TITLE
fix(trip-log): chunk map-match requests by distance, not just point count

### DIFF
--- a/backend/services/trip_log/map_matching.py
+++ b/backend/services/trip_log/map_matching.py
@@ -31,6 +31,11 @@ _MIN_POINTS = 2
 # Valhalla accepts large shapes, but keep each request bounded and stitch the
 # chunks so a cross-country trip can't build one pathological request.
 _MAX_POINTS_PER_REQUEST = 1000
+# Valhalla's /trace_route rejects any single request whose matched path exceeds
+# ~200 km (error_code 154). Bound each chunk's driven distance well under that
+# and stitch the pieces so a long highway trip still matches. The breadcrumb leg
+# distances already track the road, so this ~ the snapped distance per request.
+_MAX_CHUNK_DISTANCE_M = 150_000.0
 # Reject a match whose total length differs from the raw trail by more than this
 # fraction — the matcher snapped to the wrong road (common near unmapped
 # campgrounds) and the raw trail is the more trustworthy record.
@@ -83,6 +88,44 @@ def _extract_geometry(payload: dict[str, Any]) -> list[tuple[float, float]]:
     return coordinates
 
 
+def _chunk_points(points: list[dict[str, Any]]) -> list[list[dict[str, Any]]]:
+    """Split breadcrumbs into segments bounded by point count and driven distance.
+
+    Valhalla's trace_route caps a single request at ~200 km, so a long trip must
+    be matched in pieces. Consecutive chunks share their boundary point so the
+    snapped segments join without a gap when stitched.
+    """
+    chunks: list[list[dict[str, Any]]] = []
+    current: list[dict[str, Any]] = []
+    current_distance = 0.0
+    for point in points:
+        if not current:
+            current = [point]
+            current_distance = 0.0
+            continue
+        step = haversine_distance_m(
+            current[-1]["latitude"], current[-1]["longitude"], point["latitude"], point["longitude"]
+        )
+        if (
+            len(current) >= _MAX_POINTS_PER_REQUEST
+            or current_distance + step > _MAX_CHUNK_DISTANCE_M
+        ):
+            chunks.append(current)
+            current = [current[-1]]  # overlap one point so the segments stitch
+            current_distance = 0.0
+            step = haversine_distance_m(
+                current[-1]["latitude"],
+                current[-1]["longitude"],
+                point["latitude"],
+                point["longitude"],
+            )
+        current.append(point)
+        current_distance += step
+    if len(current) >= _MIN_POINTS:
+        chunks.append(current)
+    return chunks
+
+
 class RouteMatcher:
     """Thin async client for Valhalla ``/trace_route``."""
 
@@ -99,10 +142,9 @@ class RouteMatcher:
             return None
         try:
             matched: list[tuple[float, float]] = []
-            for start in range(0, len(points), _MAX_POINTS_PER_REQUEST):
-                chunk = points[start : start + _MAX_POINTS_PER_REQUEST]
+            for chunk in _chunk_points(points):
                 if len(chunk) < _MIN_POINTS:
-                    break
+                    continue
                 geometry = await self._match_chunk(chunk)
                 if not geometry:
                     return None

--- a/tests/services/test_map_matching.py
+++ b/tests/services/test_map_matching.py
@@ -1,0 +1,78 @@
+"""Tests for the Valhalla map-matching client's distance-aware chunking."""
+
+from itertools import pairwise
+from typing import Any
+
+from backend.integrations.router_sidecar.location import haversine_distance_m
+from backend.services.trip_log.map_matching import (
+    _MAX_CHUNK_DISTANCE_M,
+    _MAX_POINTS_PER_REQUEST,
+    RouteMatcher,
+    _chunk_points,
+)
+
+# ~0.009 deg latitude ≈ 1 km; a straight run north from Harrisburg, PA.
+_BASE_LAT = 40.2732
+_BASE_LON = -76.8867
+
+
+def _line(count: int, step_deg: float = 0.009) -> list[dict[str, Any]]:
+    return [{"latitude": _BASE_LAT + i * step_deg, "longitude": _BASE_LON} for i in range(count)]
+
+
+def _path_distance_m(points: list[dict[str, Any]]) -> float:
+    return sum(
+        haversine_distance_m(a["latitude"], a["longitude"], b["latitude"], b["longitude"])
+        for a, b in pairwise(points)
+    )
+
+
+class TestChunkPoints:
+    def test_short_trip_is_one_chunk(self):
+        points = _line(10)  # ~9 km
+        chunks = _chunk_points(points)
+        assert len(chunks) == 1
+        assert chunks[0] == points
+
+    def test_long_trip_splits_under_the_distance_limit(self):
+        # ~400 km of breadcrumbs — well past Valhalla's 200 km single-request cap.
+        points = _line(400)
+        chunks = _chunk_points(points)
+        assert len(chunks) > 1
+        for chunk in chunks:
+            assert _path_distance_m(chunk) <= _MAX_CHUNK_DISTANCE_M
+
+    def test_consecutive_chunks_overlap_for_stitching(self):
+        points = _line(400)
+        chunks = _chunk_points(points)
+        for previous, following in pairwise(chunks):
+            # The last point of one chunk is the first of the next so the snapped
+            # segments join without a gap.
+            assert previous[-1] == following[0]
+
+    def test_splits_on_point_count_even_when_short(self):
+        # Dense, tiny steps: distance stays small but the count bound must split.
+        points = _line(_MAX_POINTS_PER_REQUEST + 50, step_deg=0.00001)
+        chunks = _chunk_points(points)
+        assert len(chunks) > 1
+        assert all(len(chunk) <= _MAX_POINTS_PER_REQUEST for chunk in chunks)
+
+
+class TestMatchStitching:
+    async def test_match_splits_long_trip_and_stitches(self, monkeypatch):
+        matcher = RouteMatcher("http://valhalla.invalid/trace_route")
+        seen: list[int] = []
+
+        async def fake_match_chunk(chunk: list[dict[str, Any]]) -> list[tuple[float, float]]:
+            seen.append(len(chunk))
+            return [
+                (chunk[0]["latitude"], chunk[0]["longitude"]),
+                (chunk[-1]["latitude"], chunk[-1]["longitude"]),
+            ]
+
+        monkeypatch.setattr(matcher, "_match_chunk", fake_match_chunk)
+
+        # raw_distance_m=0 disables the plausibility gate so we test only stitching.
+        result = await matcher.match(_line(400), raw_distance_m=0.0)
+        assert result is not None
+        assert len(seen) > 1  # the long trip was sent as multiple requests


### PR DESCRIPTION
Valhalla's `/trace_route` rejects any single request whose matched path exceeds ~200 km (`error_code 154`). The matcher chunked only by point count (1000 pts), so a long highway trip's chunk blew past 200 km and the whole trip failed to match — observed on a real 548 km recorded trip (a 100-point subset matched fine).

## Fix
- `_chunk_points` now bounds each request by **driven distance (<150 km)** as well as point count, and consecutive chunks share their boundary point so the snapped segments stitch without a gap.
- Breadcrumb leg distances already track the road, so this approximates the snapped distance per request.

## Tests
- New `tests/services/test_map_matching.py`: distance + point-count bounds, chunk overlap, and `match()` splitting a long trip into multiple stitched requests.
- Full suite green locally (33 passed), ruff clean.

🤖 Generated with Claude Code