### PR TITLE
feat(frontend): fluid-interface polish and interruptible controls

### DIFF
--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -232,12 +232,34 @@ function AppShellSidebar(props: React.ComponentProps<typeof Sidebar>) {
 // ===== Header =====
 //
 
+/** True once the page is scrolled at all, i.e. content sits under the sticky header. */
+function useScrolledUnderHeader(): boolean {
+  const [scrolled, setScrolled] = React.useState(false)
+  React.useEffect(() => {
+    const onScroll = () => setScrolled(window.scrollY > 0)
+    onScroll()
+    window.addEventListener("scroll", onScroll, { passive: true })
+    return () => window.removeEventListener("scroll", onScroll)
+  }, [])
+  return scrolled
+}
+
 function AppShellHeader() {
   const location = useLocation()
   const title = titleForPath(location.pathname) ?? "CoachIQ"
+  // Scroll edge effect: the divider exists only while content is actually
+  // under the header, so at rest the chrome blends into the page.
+  const scrolled = useScrolledUnderHeader()
 
   return (
-    <header className="app-material sticky top-0 z-40 flex h-(--header-height) shrink-0 items-center gap-2 border-b transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-(--header-height)">
+    <header
+      className={cn(
+        "app-material sticky top-0 z-40 flex h-(--header-height) shrink-0 items-center gap-2 border-b transition-[width,height,border-color,box-shadow] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-(--header-height)",
+        scrolled
+          ? "border-border shadow-[0_1px_8px_-4px_oklch(0_0_0/0.25)]"
+          : "border-transparent"
+      )}
+    >
       <div className="flex w-full items-center gap-1 px-4 lg:gap-2 lg:px-6">
         <SidebarTrigger className="-ml-1" />
         <Separator orientation="vertical" className="mx-2 data-[orientation=vertical]:h-4" />

--- a/frontend/src/components/bulk-operations/BulkOperationResultsV2.tsx
+++ b/frontend/src/components/bulk-operations/BulkOperationResultsV2.tsx
@@ -165,19 +165,19 @@ export function BulkOperationResultsV2({
             {/* Statistics */}
             <div className="grid grid-cols-4 gap-4 text-center">
               <div className="space-y-1">
-                <p className="text-2xl font-bold text-green-600">{success_count}</p>
+                <p className="text-2xl font-bold tracking-tight text-green-600">{success_count}</p>
                 <p className="text-xs text-muted-foreground">Succeeded</p>
               </div>
               <div className="space-y-1">
-                <p className="text-2xl font-bold text-red-600">{failed_count}</p>
+                <p className="text-2xl font-bold tracking-tight text-red-600">{failed_count}</p>
                 <p className="text-xs text-muted-foreground">Failed</p>
               </div>
               <div className="space-y-1">
-                <p className="text-2xl font-bold">{total_count}</p>
+                <p className="text-2xl font-bold tracking-tight">{total_count}</p>
                 <p className="text-xs text-muted-foreground">Total</p>
               </div>
               <div className="space-y-1">
-                <p className="text-2xl font-bold text-blue-600">
+                <p className="text-2xl font-bold tracking-tight text-blue-600">
                   {(total_execution_time_ms / 1000).toFixed(1)}s
                 </p>
                 <p className="text-xs text-muted-foreground">Duration</p>

--- a/frontend/src/components/mfa/MFAManagement.tsx
+++ b/frontend/src/components/mfa/MFAManagement.tsx
@@ -172,15 +172,15 @@ const MFAManagement: React.FC = () => {
           {/* Summary Stats */}
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
             <div className="p-4 border rounded-lg">
-              <div className="text-2xl font-bold text-green-600">{enabledCount}</div>
+              <div className="text-2xl font-bold tracking-tight text-green-600">{enabledCount}</div>
               <div className="text-sm text-muted-foreground">Users with MFA Enabled</div>
             </div>
             <div className="p-4 border rounded-lg">
-              <div className="text-2xl font-bold text-blue-600">{totalUsers - enabledCount}</div>
+              <div className="text-2xl font-bold tracking-tight text-blue-600">{totalUsers - enabledCount}</div>
               <div className="text-sm text-muted-foreground">Users without MFA</div>
             </div>
             <div className="p-4 border rounded-lg">
-              <div className="text-2xl font-bold text-purple-600">
+              <div className="text-2xl font-bold tracking-tight text-purple-600">
                 {totalUsers > 0 ? Math.round((enabledCount / totalUsers) * 100) : 0}%
               </div>
               <div className="text-sm text-muted-foreground">MFA Adoption Rate</div>

--- a/frontend/src/components/network/DeviceDiscoveryTable.tsx
+++ b/frontend/src/components/network/DeviceDiscoveryTable.tsx
@@ -354,25 +354,25 @@ export function DeviceDiscoveryTable({
         {availability && (
           <div className="grid grid-cols-4 gap-4 p-4 bg-muted/50 rounded-lg">
             <div className="text-center">
-              <div className="text-2xl font-bold text-emerald-600">
+              <div className="text-2xl font-bold tracking-tight text-emerald-600">
                 {availability.online_devices || 0}
               </div>
               <div className="text-sm text-muted-foreground">Online</div>
             </div>
             <div className="text-center">
-              <div className="text-2xl font-bold text-gray-500">
+              <div className="text-2xl font-bold tracking-tight text-gray-500">
                 {availability.offline_devices || 0}
               </div>
               <div className="text-sm text-muted-foreground">Offline</div>
             </div>
             <div className="text-center">
-              <div className="text-2xl font-bold text-blue-600">
+              <div className="text-2xl font-bold tracking-tight text-blue-600">
                 {availability.total_devices || 0}
               </div>
               <div className="text-sm text-muted-foreground">Total</div>
             </div>
             <div className="text-center">
-              <div className="text-2xl font-bold text-purple-600">
+              <div className="text-2xl font-bold tracking-tight text-purple-600">
                 {availableProtocols.length}
               </div>
               <div className="text-sm text-muted-foreground">Protocols</div>

--- a/frontend/src/components/power-section.tsx
+++ b/frontend/src/components/power-section.tsx
@@ -146,7 +146,7 @@ function BatteryCard({ entity }: Readonly<{ entity: EntitySchema }>) {
   return (
     <PowerCard entity={entity} icon={IconBattery}>
       <div className="mb-2 space-y-1.5">
-        <p className="text-2xl font-semibold tabular-nums">
+        <p className="text-2xl font-semibold tracking-tight tabular-nums">
           {soc === null ? "—" : `${Math.round(soc)}%`}
         </p>
         <Progress value={soc ?? 0} aria-label="Battery state of charge" />
@@ -163,7 +163,7 @@ function SolarCard({ entity }: Readonly<{ entity: EntitySchema }>) {
   return (
     <PowerCard entity={entity} icon={IconSun}>
       <div className="mb-2">
-        <p className="text-2xl font-semibold tabular-nums">
+        <p className="text-2xl font-semibold tracking-tight tabular-nums">
           {fmtWatts(num(state.pv_power))}
         </p>
       </div>
@@ -197,7 +197,7 @@ function DcLoadsCard({ entity }: Readonly<{ entity: EntitySchema }>) {
   return (
     <PowerCard entity={entity} icon={IconTopologyStar3}>
       <div className="mb-2">
-        <p className="text-2xl font-semibold tabular-nums">{fmtWatts(num(state.power))}</p>
+        <p className="text-2xl font-semibold tracking-tight tabular-nums">{fmtWatts(num(state.power))}</p>
       </div>
       <StatRow label="Voltage" value={fmtNumber(num(state.voltage), "V")} />
       <StatRow label="Current" value={fmtNumber(num(state.current), "A")} />

--- a/frontend/src/components/ui/switch.tsx
+++ b/frontend/src/components/ui/switch.tsx
@@ -9,7 +9,7 @@ const Switch = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SwitchPrimitives.Root
     className={cn(
-      "peer relative inline-flex h-11 w-11 shrink-0 cursor-pointer items-center rounded-full before:absolute before:inset-x-0 before:top-2.5 before:h-6 before:rounded-full before:border-2 before:border-transparent before:transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background active:scale-[0.97] motion-reduce:transform-none disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:before:bg-primary data-[state=unchecked]:before:bg-input",
+      "peer group relative inline-flex h-11 w-11 shrink-0 cursor-pointer items-center rounded-full before:absolute before:inset-x-0 before:top-2.5 before:h-6 before:rounded-full before:border-2 before:border-transparent before:transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background active:scale-[0.97] motion-reduce:transform-none disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:before:bg-primary data-[state=unchecked]:before:bg-input",
       className
     )}
     {...props}
@@ -17,7 +17,10 @@ const Switch = React.forwardRef<
   >
     <SwitchPrimitives.Thumb
       className={cn(
-        "pointer-events-none absolute left-0 top-3 block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0"
+        // The thumb stretches toward the pressed direction (like iOS): it widens on
+        // press, and when checked the extra width grows leftward so the trailing
+        // edge stays anchored.
+        "pointer-events-none absolute left-0 top-3 block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-[translate,width] data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0 group-active:w-6 group-active:data-[state=checked]:translate-x-4"
       )}
     />
   </SwitchPrimitives.Root>

--- a/frontend/src/hooks/__tests__/useOptimisticValue.test.ts
+++ b/frontend/src/hooks/__tests__/useOptimisticValue.test.ts
@@ -1,0 +1,87 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useOptimisticValue } from "@/hooks/useOptimisticValue";
+
+describe("useOptimisticValue", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("shows the server value until a pending echo is set", () => {
+    const { result, rerender } = renderHook(({ server }) => useOptimisticValue(server), {
+      initialProps: { server: 30 },
+    });
+
+    expect(result.current.shown).toBe(30);
+
+    act(() => result.current.setPending(50));
+    expect(result.current.shown).toBe(50);
+
+    // Server still reports the old value — the echo wins.
+    rerender({ server: 30 });
+    expect(result.current.shown).toBe(50);
+  });
+
+  it("drops the echo once the server value catches up", () => {
+    const { result, rerender } = renderHook(({ server }) => useOptimisticValue(server), {
+      initialProps: { server: 30 },
+    });
+
+    act(() => result.current.setPending(50));
+    rerender({ server: 50 });
+    expect(result.current.shown).toBe(50);
+
+    // Echo is gone: a later server change shows through immediately.
+    rerender({ server: 15 });
+    expect(result.current.shown).toBe(15);
+  });
+
+  it("clears the echo on demand (command failure)", () => {
+    const { result } = renderHook(({ server }) => useOptimisticValue(server), {
+      initialProps: { server: "auto" },
+    });
+
+    act(() => result.current.setPending("high"));
+    expect(result.current.shown).toBe("high");
+
+    act(() => result.current.clearPending());
+    expect(result.current.shown).toBe("auto");
+  });
+
+  it("reverts to the server value after the settle timeout", () => {
+    const { result } = renderHook(({ server }) => useOptimisticValue(server, 5_000), {
+      initialProps: { server: 30 },
+    });
+
+    act(() => result.current.setPending(50));
+    expect(result.current.shown).toBe(50);
+
+    act(() => {
+      vi.advanceTimersByTime(5_000)
+    });
+    expect(result.current.shown).toBe(30);
+  });
+
+  it("restarts the settle timeout on each new echo", () => {
+    const { result } = renderHook(({ server }) => useOptimisticValue(server, 5_000), {
+      initialProps: { server: 30 },
+    });
+
+    act(() => result.current.setPending(50));
+    act(() => {
+      vi.advanceTimersByTime(4_000)
+    });
+    act(() => result.current.setPending(20));
+    act(() => {
+      vi.advanceTimersByTime(4_000)
+    });
+
+    // 8s after the first echo, but only 4s after the latest — still echoing.
+    expect(result.current.shown).toBe(20);
+  });
+});

--- a/frontend/src/hooks/useOptimisticValue.ts
+++ b/frontend/src/hooks/useOptimisticValue.ts
@@ -1,0 +1,67 @@
+/**
+ * Optimistic local echo for a control bound to server state.
+ *
+ * Entity commands get this for free from the command lifecycle's cache
+ * patching (entity-command-lifecycle.ts); this hook is for controls that
+ * talk to endpoints outside that system (e.g. the Victron power controls).
+ *
+ * The control stays live while a command is in flight — the UI shows the
+ * user's intent immediately and reconciles when the server state catches
+ * up, when the caller reports failure, or after a settle timeout (so a
+ * command that "succeeds" without ever changing state can't wedge the UI
+ * on a wrong value).
+ */
+
+import { useEffect, useRef, useState } from "react";
+
+const DEFAULT_SETTLE_MS = 10_000;
+
+interface IOptimisticValue<T> {
+  /** Value to render: the pending echo if one is live, else the server value. */
+  shown: T;
+  /** Echo a value the user just chose; starts the settle timeout. */
+  setPending: (value: T) => void;
+  /** Drop the echo (call on command error or non-success result). */
+  clearPending: () => void;
+}
+
+export function useOptimisticValue<T>(
+  serverValue: T,
+  settleMs = DEFAULT_SETTLE_MS
+): IOptimisticValue<T> {
+  const [pending, setPendingBox] = useState<{ value: T } | null>(null);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearTimer = () => {
+    if (timer.current) {
+      clearTimeout(timer.current);
+      timer.current = null;
+    }
+  };
+
+  // Server state caught up with the echo — the echo has served its purpose.
+  useEffect(() => {
+    if (pending !== null && Object.is(serverValue, pending.value)) {
+      setPendingBox(null);
+      clearTimer();
+    }
+  }, [pending, serverValue]);
+
+  useEffect(() => clearTimer, []);
+
+  const setPending = (value: T) => {
+    setPendingBox({ value });
+    clearTimer();
+    timer.current = setTimeout(() => {
+      setPendingBox(null);
+      timer.current = null;
+    }, settleMs);
+  };
+
+  const clearPending = () => {
+    setPendingBox(null);
+    clearTimer();
+  };
+
+  return { shown: pending === null ? serverValue : pending.value, setPending, clearPending };
+}

--- a/frontend/src/pages/can-sniffer.tsx
+++ b/frontend/src/pages/can-sniffer.tsx
@@ -119,7 +119,7 @@ function CANStatistics({ messages }: { messages: CANMessage[] }) {
           <IconActivity className="h-4 w-4 text-muted-foreground" />
         </CardHeader>
         <CardContent>
-          <div className="text-2xl font-bold">{stats.total}</div>
+          <div className="text-2xl font-bold tracking-tight">{stats.total}</div>
           <p className="text-xs text-muted-foreground">
             {stats.lastMinute} in last minute
           </p>
@@ -132,7 +132,7 @@ function CANStatistics({ messages }: { messages: CANMessage[] }) {
           <IconFilter className="h-4 w-4 text-muted-foreground" />
         </CardHeader>
         <CardContent>
-          <div className="text-2xl font-bold">{stats.uniquePGNs}</div>
+          <div className="text-2xl font-bold tracking-tight">{stats.uniquePGNs}</div>
           <p className="text-xs text-muted-foreground">
             Different message types
           </p>
@@ -145,7 +145,7 @@ function CANStatistics({ messages }: { messages: CANMessage[] }) {
           <IconAlertTriangle className="h-4 w-4 text-muted-foreground" />
         </CardHeader>
         <CardContent>
-          <div className="text-2xl font-bold">{stats.errorMessages}</div>
+          <div className="text-2xl font-bold tracking-tight">{stats.errorMessages}</div>
           <p className="text-xs text-muted-foreground">
             {stats.total > 0 ? Math.round((stats.errorMessages / stats.total) * 100) : 0}% error rate
           </p>
@@ -158,7 +158,7 @@ function CANStatistics({ messages }: { messages: CANMessage[] }) {
           <IconActivity className="h-4 w-4 text-muted-foreground" />
         </CardHeader>
         <CardContent>
-          <div className="text-2xl font-bold">{stats.lastMinute}</div>
+          <div className="text-2xl font-bold tracking-tight">{stats.lastMinute}</div>
           <p className="text-xs text-muted-foreground">
             messages/minute
           </p>

--- a/frontend/src/pages/climate.tsx
+++ b/frontend/src/pages/climate.tsx
@@ -178,7 +178,7 @@ function useSetParameters(entity: EntitySchema) {
       }
     )
   }
-  return { send, isPending: control.isPending }
+  return { send }
 }
 
 //
@@ -291,7 +291,9 @@ export function SetpointStepper({
     }, SETPOINT_COMMIT_MS)
   }
 
-  const stepperDisabled = disabled || shown === null || commandState === "sending"
+  // Stay tappable while a command is in flight: a new tap re-enters the
+  // debounce from the shown value and simply re-targets the setpoint.
+  const stepperDisabled = disabled || shown === null
   const statusText = (() => {
     if (commandState === "pending") return `Setpoint ${shown} degrees pending`
     if (commandState === "sending") return `Sending setpoint ${shown} degrees`
@@ -435,7 +437,7 @@ function ZoneCardHeader({
         <p className="text-xs text-muted-foreground">Last changed {relativeTime(stateChangedAt(entity))}</p>
       </div>
       <div className="flex flex-col items-end">
-        <p className="text-3xl font-semibold tabular-nums">{formatTempF(currentF)}</p>
+        <p className="text-3xl font-semibold tracking-tight tabular-nums">{formatTempF(currentF)}</p>
         {isShed(entity) ? (
           <ShedBadge />
         ) : (
@@ -505,7 +507,7 @@ function AquaHotToggleRow({
         </span>
         <Switch
           checked={on}
-          disabled={disabled || control.isPending || mode === "unknown"}
+          disabled={disabled || mode === "unknown"}
           onCheckedChange={setOn}
           aria-label={`Toggle ${entity.name}`}
         />
@@ -536,12 +538,11 @@ function ThermostatZoneCard({
   controlsDisabled,
   disabledReason,
 }: Readonly<IThermostatZoneCardProps>) {
-  const { send: sendParameters, isPending } = useSetParameters(entity)
+  const { send: sendParameters } = useSetParameters(entity)
   const isAvailable = entity.available !== false
   const cardDisabled = controlsDisabled || !isAvailable
   const cardReason = !isAvailable ? "Zone is not responding on the CAN bus" : disabledReason
   const mode = zoneMode(entity)
-  const rowDisabled = cardDisabled || isPending
 
   return (
     <Card className={cn(!isAvailable && "opacity-60")}>
@@ -551,15 +552,15 @@ function ThermostatZoneCard({
           <div className="space-y-3">
             <div className="flex items-center justify-between gap-2">
               <span className="text-xs text-muted-foreground">Setpoint</span>
-              <SetpointStepper entity={entity} heatOnly={false} disabled={rowDisabled} />
+              <SetpointStepper entity={entity} heatOnly={false} disabled={cardDisabled} />
             </div>
-            <ZoneModeRow entity={entity} disabled={rowDisabled} onCommand={sendParameters} />
-            <ZoneFanRow entity={entity} disabled={rowDisabled} onCommand={sendParameters} />
+            <ZoneModeRow entity={entity} disabled={cardDisabled} onCommand={sendParameters} />
+            <ZoneFanRow entity={entity} disabled={cardDisabled} onCommand={sendParameters} />
             {aquaHot && (
               <AquaHotToggleRow
                 entity={aquaHot}
                 sourceOn={aquaHotSourceOn}
-                disabled={rowDisabled}
+                disabled={cardDisabled}
               />
             )}
           </div>
@@ -608,13 +609,13 @@ function HeatZoneCard({ entity, controlsDisabled, disabledReason }: Readonly<IZo
             <div className="flex items-center gap-2">
               <Switch
                 checked={heatOn}
-                disabled={cardDisabled || control.isPending || mode === "unknown"}
+                disabled={cardDisabled || mode === "unknown"}
                 onCheckedChange={setHeat}
                 aria-label={`Toggle ${entity.name}`}
               />
               <span className="text-xs text-muted-foreground">{heatStatus}</span>
             </div>
-            <SetpointStepper entity={entity} heatOnly disabled={cardDisabled || control.isPending} />
+            <SetpointStepper entity={entity} heatOnly disabled={cardDisabled} />
           </div>
         </DisabledTooltip>
       </CardContent>
@@ -707,7 +708,7 @@ function AcLoadSwitch({
   const requestedOn = acLoadRequestedOn(entity)
   const shed = isShed(entity)
   const isAvailable = entity.available !== false
-  const rowDisabled = disabled || !isAvailable || control.isPending
+  const rowDisabled = disabled || !isAvailable
   const rowReason = !isAvailable ? `${entity.name} is not responding` : disabledReason
 
   const send = (targetOn: boolean) => {

--- a/frontend/src/pages/control-semantics.test.tsx
+++ b/frontend/src/pages/control-semantics.test.tsx
@@ -7,11 +7,19 @@ import { DevicePowerControl } from "@/pages/devices"
 import { ToggleDeviceRow } from "@/pages/home"
 import { LightRow } from "@/pages/lights"
 
-const { mutateMock } = vi.hoisted(() => ({ mutateMock: vi.fn() }))
+const { mutateMock, controlState } = vi.hoisted(() => ({
+  mutateMock: vi.fn(),
+  controlState: { isPending: false },
+}))
 
 vi.mock("@/hooks/useEntities", () => ({
   useBulkControlEntities: vi.fn(),
-  useControlEntity: () => ({ mutate: mutateMock, isPending: false }),
+  useControlEntity: () => ({
+    mutate: mutateMock,
+    get isPending() {
+      return controlState.isPending
+    },
+  }),
   useEntities: vi.fn(),
 }))
 
@@ -95,6 +103,33 @@ describe("binary control semantics", () => {
       },
       expect.any(Object)
     )
+  })
+})
+
+describe("interruptibility", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    controlState.isPending = false
+  })
+
+  it("keeps the light switch interactive while a command is in flight", async () => {
+    controlState.isPending = true
+    const user = userEvent.setup()
+    render(
+      <LightRow
+        entity={lightEntity()}
+        controlsDisabled={false}
+        disabledReason=""
+        showTimestamp={false}
+      />
+    )
+
+    const lightSwitch = screen.getByRole("switch", { name: "Galley light" })
+    expect(lightSwitch).toBeEnabled()
+
+    // A second command can redirect the first — never lock out input.
+    await user.click(lightSwitch)
+    expect(mutateMock).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/frontend/src/pages/device-mapping.tsx
+++ b/frontend/src/pages/device-mapping.tsx
@@ -73,7 +73,7 @@ function DeviceMappingStats({ entities }: Readonly<{ entities: EntityData[] }>) 
           <IconDeviceDesktop className="h-4 w-4 text-muted-foreground" />
         </CardHeader>
         <CardContent>
-          <div className="text-2xl font-bold">{stats.total}</div>
+          <div className="text-2xl font-bold tracking-tight">{stats.total}</div>
           <p className="text-xs text-muted-foreground">
             Across {Object.keys(stats.byDeviceType).length} device types
           </p>
@@ -86,7 +86,7 @@ function DeviceMappingStats({ entities }: Readonly<{ entities: EntityData[] }>) 
           <IconMapPin className="h-4 w-4 text-muted-foreground" />
         </CardHeader>
         <CardContent>
-          <div className="text-2xl font-bold">{stats.withRealArea}</div>
+          <div className="text-2xl font-bold tracking-tight">{stats.withRealArea}</div>
           <p className="text-xs text-muted-foreground">
             {stats.total > 0 ? `${Math.round((stats.withRealArea / stats.total) * 100)}% mapped` : "No devices"}
           </p>
@@ -99,7 +99,7 @@ function DeviceMappingStats({ entities }: Readonly<{ entities: EntityData[] }>) 
           <IconAlertCircle className="h-4 w-4 text-muted-foreground" />
         </CardHeader>
         <CardContent>
-          <div className="text-2xl font-bold">{stats.unmapped}</div>
+          <div className="text-2xl font-bold tracking-tight">{stats.unmapped}</div>
           <p className="text-xs text-muted-foreground">
             Need area assignment
           </p>
@@ -112,7 +112,7 @@ function DeviceMappingStats({ entities }: Readonly<{ entities: EntityData[] }>) 
           <IconDeviceGamepad className="h-4 w-4 text-muted-foreground" />
         </CardHeader>
         <CardContent>
-          <div className="text-2xl font-bold">{Object.keys(stats.bySourceType).length}</div>
+          <div className="text-2xl font-bold tracking-tight">{Object.keys(stats.bySourceType).length}</div>
           <p className="text-xs text-muted-foreground">
             Different source protocols
           </p>

--- a/frontend/src/pages/devices.tsx
+++ b/frontend/src/pages/devices.tsx
@@ -403,7 +403,7 @@ function DeviceDetailSheet({ entity, config, onClose }: IDeviceDetailSheetProps)
     )
   }
 
-  const controlsAreDisabled = controlsDisabled || control.isPending || powerState === null
+  const controlsAreDisabled = controlsDisabled || powerState === null
   const powerDisabledReason =
     powerState === null ? "Device has not reported a power state" : disabledReason
   const powerControl = (

--- a/frontend/src/pages/diagnostics.tsx
+++ b/frontend/src/pages/diagnostics.tsx
@@ -308,7 +308,7 @@ function HealthVerdictCard({
         <div className="flex items-baseline gap-3">
           <span
             className={cn(
-              "text-2xl font-semibold",
+              "text-2xl font-semibold tracking-tight",
               verdict.tone === "healthy" && "text-green-700 dark:text-green-400",
               verdict.tone === "warning" && "text-amber-700 dark:text-amber-400",
               verdict.tone === "critical" && "text-red-700 dark:text-red-400"

--- a/frontend/src/pages/home.tsx
+++ b/frontend/src/pages/home.tsx
@@ -410,7 +410,7 @@ export function ToggleDeviceRow({ entity, controlsDisabled, disabledReason, show
       )}
       <Switch
         checked={isOn}
-        disabled={rowDisabled || control.isPending}
+        disabled={rowDisabled}
         onCheckedChange={(checked) => sendCommand({ command: "set", state: checked })}
         aria-label={entity.name}
       />
@@ -445,7 +445,7 @@ export function ToggleDeviceRow({ entity, controlsDisabled, disabledReason, show
             value={[shownBrightness]}
             max={100}
             step={5}
-            disabled={rowDisabled || control.isPending}
+            disabled={rowDisabled}
             onValueChange={(value) => {
               const level = value[0]
               if (level !== undefined) setPendingBrightness(level)
@@ -521,13 +521,11 @@ function ZoneCard({ zone, controlsDisabled, disabledReason, showTimestamps }: Re
     )
   }
 
-  const allOffDisabled = controlsDisabled || bulkControl.isPending
-
   const allOffButton = (
     <Button
       variant="ghost"
       size="sm"
-      disabled={allOffDisabled}
+      disabled={controlsDisabled}
       onClick={handleAllOff}
       className="h-11 gap-1.5 px-2 text-muted-foreground"
       aria-label={`Turn all lights off in ${zone.displayName}`}
@@ -548,7 +546,7 @@ function ZoneCard({ zone, controlsDisabled, disabledReason, showTimestamps }: Re
             </Badge>
           )}
           {switchableIds.length > 0 &&
-            (allOffDisabled && controlsDisabled ? (
+            (controlsDisabled ? (
               <Tooltip>
                 <TooltipTrigger asChild>
                   <span>{allOffButton}</span>

--- a/frontend/src/pages/lights.tsx
+++ b/frontend/src/pages/lights.tsx
@@ -164,7 +164,7 @@ export function LightRow({
       )}
       <Switch
         checked={isOn}
-        disabled={rowDisabled || control.isPending}
+        disabled={rowDisabled}
         onCheckedChange={(checked) => sendCommand({ command: "set", state: checked })}
         aria-label={entity.name}
       />
@@ -199,7 +199,7 @@ export function LightRow({
             value={[shownBrightness]}
             max={100}
             step={5}
-            disabled={rowDisabled || control.isPending}
+            disabled={rowDisabled}
             onValueChange={(value) => {
               const level = value[0]
               if (level !== undefined) setPendingBrightness(level)
@@ -280,8 +280,7 @@ function ZoneLightsCard({
     )
   }
 
-  const zoneButtonsDisabled =
-    controlsDisabled || switchableIds.length === 0 || bulkControl.isPending
+  const zoneButtonsDisabled = controlsDisabled || switchableIds.length === 0
   const zoneButtonsReason = controlsDisabled
     ? disabledReason
     : "No lights in this zone are responding"
@@ -392,7 +391,7 @@ function MasterBar({ lights, controlsDisabled, disabledReason }: Readonly<IMaste
     )
   }
 
-  const masterDisabled = controlsDisabled || available.length === 0 || bulkControl.isPending
+  const masterDisabled = controlsDisabled || available.length === 0
   const masterReason = controlsDisabled ? disabledReason : "No lights are responding"
 
   const buttons = (

--- a/frontend/src/pages/network-map.tsx
+++ b/frontend/src/pages/network-map.tsx
@@ -101,25 +101,25 @@ function NetworkStatsSidebar({
         <CardContent className="space-y-4">
           <div className="grid grid-cols-2 gap-4">
             <div className="text-center">
-              <div className="text-2xl font-bold text-emerald-600">{stats.online}</div>
+              <div className="text-2xl font-bold tracking-tight text-emerald-600">{stats.online}</div>
               <div className="text-xs text-muted-foreground">Online</div>
             </div>
             <div className="text-center">
-              <div className="text-2xl font-bold text-gray-500">{stats.offline}</div>
+              <div className="text-2xl font-bold tracking-tight text-gray-500">{stats.offline}</div>
               <div className="text-xs text-muted-foreground">Offline</div>
             </div>
           </div>
 
           {stats.errors > 0 && (
             <div className="text-center">
-              <div className="text-2xl font-bold text-red-600">{stats.errors}</div>
+              <div className="text-2xl font-bold tracking-tight text-red-600">{stats.errors}</div>
               <div className="text-xs text-muted-foreground">Errors</div>
             </div>
           )}
 
           {availability && (stats.recent || 0) > 0 && (
             <div className="text-center">
-              <div className="text-2xl font-bold text-blue-600">{stats.recent}</div>
+              <div className="text-2xl font-bold tracking-tight text-blue-600">{stats.recent}</div>
               <div className="text-xs text-muted-foreground">Recent Activity</div>
             </div>
           )}
@@ -365,18 +365,18 @@ function MultiProtocolStats({ entities }: { entities: EntityData[] }) {
         <CardContent className="space-y-4">
           <div className="grid grid-cols-2 gap-4">
             <div className="text-center">
-              <div className="text-2xl font-bold text-emerald-600">{stats.online}</div>
+              <div className="text-2xl font-bold tracking-tight text-emerald-600">{stats.online}</div>
               <div className="text-xs text-muted-foreground">Online</div>
             </div>
             <div className="text-center">
-              <div className="text-2xl font-bold text-gray-500">{stats.offline}</div>
+              <div className="text-2xl font-bold tracking-tight text-gray-500">{stats.offline}</div>
               <div className="text-xs text-muted-foreground">Offline</div>
             </div>
           </div>
 
           {stats.errors > 0 && (
             <div className="text-center">
-              <div className="text-2xl font-bold text-red-600">{stats.errors}</div>
+              <div className="text-2xl font-bold tracking-tight text-red-600">{stats.errors}</div>
               <div className="text-xs text-muted-foreground">Errors</div>
             </div>
           )}
@@ -687,13 +687,13 @@ export default function NetworkMap() {
                         <div className="space-y-4">
                           <div className="grid grid-cols-2 gap-4">
                             <div className="text-center">
-                              <div className="text-2xl font-bold text-blue-600">
+                              <div className="text-2xl font-bold tracking-tight text-blue-600">
                                 {bridgeStatus.bridges_active || 0}
                               </div>
                               <div className="text-sm text-muted-foreground">Active Bridges</div>
                             </div>
                             <div className="text-center">
-                              <div className="text-2xl font-bold">
+                              <div className="text-2xl font-bold tracking-tight">
                                 {((bridgeStatus.health_score || 0) * 100).toFixed(0)}%
                               </div>
                               <div className="text-sm text-muted-foreground">Bridge Health</div>
@@ -808,7 +808,7 @@ export default function NetworkMap() {
                   <CardContent>
                     <div className="grid gap-4 md:grid-cols-3">
                       <div className="text-center">
-                        <div className="text-2xl font-bold text-green-600">
+                        <div className="text-2xl font-bold tracking-tight text-green-600">
                           {Math.round((allEntities.filter(e => {
                             const entity = e;
                             return entity.state === 'on' || entity.state === 'online';
@@ -817,13 +817,13 @@ export default function NetworkMap() {
                         <div className="text-sm text-muted-foreground">Connectivity</div>
                       </div>
                       <div className="text-center">
-                        <div className="text-2xl font-bold text-blue-600">
+                        <div className="text-2xl font-bold tracking-tight text-blue-600">
                           {Object.values(throughput || {}).reduce((a, b) => a + b, 0).toFixed(1)}
                         </div>
                         <div className="text-sm text-muted-foreground">Total msg/sec</div>
                       </div>
                       <div className="text-center">
-                        <div className="text-2xl font-bold text-purple-600">
+                        <div className="text-2xl font-bold tracking-tight text-purple-600">
                           {bridgeStatus ? ((bridgeStatus.health_score || 0) * 100).toFixed(0) : 0}%
                         </div>
                         <div className="text-sm text-muted-foreground">Bridge Health</div>

--- a/frontend/src/pages/power.tsx
+++ b/frontend/src/pages/power.tsx
@@ -37,6 +37,7 @@ import { Label } from "@/components/ui/label"
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
 import { toast } from "@/hooks/use-toast"
 import { entitiesQueryKeys, useEntities } from "@/hooks/useEntities"
+import { useOptimisticValue } from "@/hooks/useOptimisticValue"
 import { cn } from "@/lib/utils"
 
 const MODE_OPTIONS: {
@@ -164,6 +165,11 @@ export function InverterModeCard({ inverter, controlsDisabled }: Readonly<IContr
   const state = inverter?.state ?? {}
   const currentCode = num(state.mode)
   const modeAdjustable = num(state.mode_adjustable) !== 0
+  // Victron endpoints sit outside the entity command lifecycle, so echo the
+  // chosen mode locally until the Cerbo state round-trips.
+  const modeEcho = useOptimisticValue(
+    MODE_OPTIONS.find((option) => option.code === currentCode)?.mode ?? ""
+  )
 
   const mutation = useMutation({
     mutationFn: (mode: InverterMode) => setInverterMode(mode),
@@ -190,24 +196,24 @@ export function InverterModeCard({ inverter, controlsDisabled }: Readonly<IContr
       </CardHeader>
       <CardContent className="space-y-3">
         <RadioGroup
-          value={MODE_OPTIONS.find((option) => option.code === currentCode)?.mode ?? ""}
-          disabled={controlsDisabled || !modeAdjustable || mutation.isPending}
+          value={modeEcho.shown}
+          disabled={controlsDisabled || !modeAdjustable}
           onValueChange={(value) => {
             const option = MODE_OPTIONS.find((candidate) => candidate.mode === value)
-            if (option && option.code !== currentCode) setPendingMode(option)
+            if (option && option.mode !== modeEcho.shown) setPendingMode(option)
           }}
           className="grid grid-cols-2 gap-2"
           aria-label="Inverter charger mode"
         >
           {MODE_OPTIONS.map((option) => {
-            const isCurrent = currentCode === option.code
+            const isCurrent = modeEcho.shown === option.mode
             return (
               <RadioChoice
                 key={option.mode}
                 value={option.mode}
                 label={option.label}
                 selected={isCurrent}
-                disabled={controlsDisabled || !modeAdjustable || mutation.isPending}
+                disabled={controlsDisabled || !modeAdjustable}
               />
             )
           })}
@@ -235,7 +241,11 @@ export function InverterModeCard({ inverter, controlsDisabled }: Readonly<IContr
             </Button>
             <Button
               disabled={mutation.isPending}
-              onClick={() => pendingMode && mutation.mutate(pendingMode.mode)}
+              onClick={() => {
+                if (!pendingMode) return
+                modeEcho.setPending(pendingMode.mode)
+                mutation.mutate(pendingMode.mode, { onError: modeEcho.clearPending })
+              }}
             >
               {mutation.isPending ? "Sending…" : `Switch to ${pendingMode?.label}`}
             </Button>
@@ -253,6 +263,8 @@ export function ShoreLimitCard({ inverter, controlsDisabled }: Readonly<IControl
   const state = inverter?.state ?? {}
   const currentLimit = num(state.input_current_limit)
   const limitAdjustable = num(state.input_current_limit_adjustable) !== 0
+  // Same as the mode card: echo the chosen limit until the Cerbo reports it.
+  const limitEcho = useOptimisticValue(currentLimit)
 
   const mutation = useMutation({
     mutationFn: (amps: number) => setInputCurrentLimit(amps),
@@ -270,9 +282,14 @@ export function ShoreLimitCard({ inverter, controlsDisabled }: Readonly<IControl
     },
   })
 
-  const disabled = controlsDisabled || !limitAdjustable || mutation.isPending
+  const disabled = controlsDisabled || !limitAdjustable
   const customValue = Number(customAmps)
   const customValid = customAmps !== "" && Number.isFinite(customValue) && customValue >= 0
+
+  const applyLimit = (amps: number) => {
+    limitEcho.setPending(amps)
+    mutation.mutate(amps, { onError: limitEcho.clearPending })
+  }
 
   return (
     <Card>
@@ -280,7 +297,7 @@ export function ShoreLimitCard({ inverter, controlsDisabled }: Readonly<IControl
         <CardTitle className="flex items-center justify-between text-base">
           Shore input limit
           <Badge variant="secondary" className="tabular-nums">
-            {currentLimit === null ? "—" : `${currentLimit} A`}
+            {limitEcho.shown === null ? "—" : `${limitEcho.shown} A`}
           </Badge>
         </CardTitle>
       </CardHeader>
@@ -290,9 +307,9 @@ export function ShoreLimitCard({ inverter, controlsDisabled }: Readonly<IControl
           shore and make up the difference from the batteries.
         </p>
         <RadioGroup
-          value={LIMIT_PRESETS.includes(currentLimit ?? -1) ? String(currentLimit) : ""}
+          value={LIMIT_PRESETS.includes(limitEcho.shown ?? -1) ? String(limitEcho.shown) : ""}
           disabled={disabled}
-          onValueChange={(value) => mutation.mutate(Number(value))}
+          onValueChange={(value) => applyLimit(Number(value))}
           className="flex flex-wrap gap-2"
           aria-label="Shore input current limit presets"
         >
@@ -301,7 +318,7 @@ export function ShoreLimitCard({ inverter, controlsDisabled }: Readonly<IControl
               key={amps}
               value={String(amps)}
               label={`${amps} A`}
-              selected={currentLimit === amps}
+              selected={limitEcho.shown === amps}
               disabled={disabled}
             />
           ))}
@@ -321,7 +338,7 @@ export function ShoreLimitCard({ inverter, controlsDisabled }: Readonly<IControl
           <Button
             size="sm"
             disabled={disabled || !customValid}
-            onClick={() => mutation.mutate(customValue)}
+            onClick={() => applyLimit(customValue)}
           >
             Apply
           </Button>

--- a/frontend/src/pages/unknown-pgns.tsx
+++ b/frontend/src/pages/unknown-pgns.tsx
@@ -54,7 +54,7 @@ function UnknownPGNStats({ unknownPGNs }: { unknownPGNs: UnknownPGNEntry[] }) {
           <IconQuestionMark className="h-4 w-4 text-muted-foreground" />
         </CardHeader>
         <CardContent>
-          <div className="text-2xl font-bold">{stats.totalEntries}</div>
+          <div className="text-2xl font-bold tracking-tight">{stats.totalEntries}</div>
           <p className="text-xs text-muted-foreground">
             Distinct PGN identifiers
           </p>
@@ -67,7 +67,7 @@ function UnknownPGNStats({ unknownPGNs }: { unknownPGNs: UnknownPGNEntry[] }) {
           <IconAlertTriangle className="h-4 w-4 text-muted-foreground" />
         </CardHeader>
         <CardContent>
-          <div className="text-2xl font-bold">{stats.totalMessages.toLocaleString()}</div>
+          <div className="text-2xl font-bold tracking-tight">{stats.totalMessages.toLocaleString()}</div>
           <p className="text-xs text-muted-foreground">
             Avg {stats.avgCount} per PGN
           </p>
@@ -80,7 +80,7 @@ function UnknownPGNStats({ unknownPGNs }: { unknownPGNs: UnknownPGNEntry[] }) {
           <IconClock className="h-4 w-4 text-muted-foreground" />
         </CardHeader>
         <CardContent>
-          <div className="text-2xl font-bold">{stats.recentEntries}</div>
+          <div className="text-2xl font-bold tracking-tight">{stats.recentEntries}</div>
           <p className="text-xs text-muted-foreground">
             Seen in last 24 hours
           </p>
@@ -93,7 +93,7 @@ function UnknownPGNStats({ unknownPGNs }: { unknownPGNs: UnknownPGNEntry[] }) {
           <IconAlertTriangle className="h-4 w-4 text-muted-foreground" />
         </CardHeader>
         <CardContent>
-          <div className="text-2xl font-bold">{stats.highFrequency}</div>
+          <div className="text-2xl font-bold tracking-tight">{stats.highFrequency}</div>
           <p className="text-xs text-muted-foreground">
             Over 100 messages
           </p>

--- a/frontend/src/pages/unmapped-entries.tsx
+++ b/frontend/src/pages/unmapped-entries.tsx
@@ -67,7 +67,7 @@ function UnmappedEntriesStats({ unmappedEntries }: { unmappedEntries: UnmappedEn
           <IconCircuitSwitchOpen className="h-4 w-4 text-muted-foreground" />
         </CardHeader>
         <CardContent>
-          <div className="text-2xl font-bold">{stats.totalEntries}</div>
+          <div className="text-2xl font-bold tracking-tight">{stats.totalEntries}</div>
           <p className="text-xs text-muted-foreground">
             DGN/instance pairs
           </p>
@@ -80,7 +80,7 @@ function UnmappedEntriesStats({ unmappedEntries }: { unmappedEntries: UnmappedEn
           <IconMapPin className="h-4 w-4 text-muted-foreground" />
         </CardHeader>
         <CardContent>
-          <div className="text-2xl font-bold">{stats.withSuggestions}</div>
+          <div className="text-2xl font-bold tracking-tight">{stats.withSuggestions}</div>
           <p className="text-xs text-muted-foreground">
             {stats.totalEntries > 0
               ? Math.round((stats.withSuggestions / stats.totalEntries) * 100)
@@ -95,7 +95,7 @@ function UnmappedEntriesStats({ unmappedEntries }: { unmappedEntries: UnmappedEn
           <IconClock className="h-4 w-4 text-muted-foreground" />
         </CardHeader>
         <CardContent>
-          <div className="text-2xl font-bold">{stats.recentEntries}</div>
+          <div className="text-2xl font-bold tracking-tight">{stats.recentEntries}</div>
           <p className="text-xs text-muted-foreground">
             Seen in last 24 hours
           </p>
@@ -108,7 +108,7 @@ function UnmappedEntriesStats({ unmappedEntries }: { unmappedEntries: UnmappedEn
           <IconSettings className="h-4 w-4 text-muted-foreground" />
         </CardHeader>
         <CardContent>
-          <div className="text-2xl font-bold">{stats.uniqueDeviceTypes}</div>
+          <div className="text-2xl font-bold tracking-tight">{stats.uniqueDeviceTypes}</div>
           <p className="text-xs text-muted-foreground">
             Unique DGN types
           </p>


### PR DESCRIPTION
## Summary

Applies the apple-design (Designing Fluid Interfaces) guidance to the frontend in two pieces:

**Fluid polish**
- Switch thumb stretches toward the pressed direction on press (iOS switch affordance); trailing edge stays anchored when checked.
- App header divider is now a scroll edge effect — border + soft shadow appear only while content is scrolled under the chrome.
- Size-specific negative tracking (`tracking-tight`) on 2xl/3xl numerals and headings.

**Interruptibility — never lock out input during a transition**
- Removes `isPending` disables from owner-facing continuous controls (light switches/dimmers, bulk zone/master buttons, climate setpoint steppers, mode/fan selects, Aqua-Hot / AC-load toggles, device power switches). The entity command lifecycle already provides optimistic cache patches with rollback, so these lockouts added friction without feedback.
- SetpointStepper stays tappable mid-send; a tap re-enters the debounce and re-targets.
- Victron power controls (outside the entity lifecycle) get a new `useOptimisticValue` echo hook (clears on state catch-up, error, or settle timeout).
- Confirmation dialogs for consequential actions (generator, VE.Bus mode) intentionally keep their pending lockout.

## Testing
- 146/146 vitest (adds interruptibility contract test + 5 hook tests)
- Typecheck clean; eslint diff-clean vs baseline
- Verified in browser against a local backend (virtual CAN, Entegra coach model): pages render clean, Stale mode still disables controls

🤖 Generated with [Claude Code](https://claude.com/claude-code)