### PR TITLE
fix(can): honor configured bustype in message injector

### DIFF
--- a/backend/integrations/can/message_injector.py
+++ b/backend/integrations/can/message_injector.py
@@ -22,6 +22,7 @@ from typing import Any, Optional
 
 import can
 
+from backend.core.config import get_can_settings
 from backend.core.guardrail_interfaces import (
     CommandHaltAction,
     GuardrailParticipant,
@@ -343,7 +344,12 @@ class CANMessageInjector(GuardrailParticipant):
         """Get or create CAN bus for interface."""
         if interface not in self._buses:
             try:
-                self._buses[interface] = can.interface.Bus(interface, bustype="socketcan")
+                can_settings = get_can_settings()
+                self._buses[interface] = can.interface.Bus(
+                    channel=interface,
+                    bustype=can_settings.bustype,
+                    bitrate=can_settings.bitrate,
+                )
                 logger.info("Created CAN bus for interface: %s", interface)
             except Exception as e:
                 logger.error("Failed to create CAN bus %s: %s", interface, e)


### PR DESCRIPTION
## Summary
- `CANMessageInjector._get_or_create_bus` hardcoded `bustype="socketcan"`, ignoring `COACHIQ_CAN__BUSTYPE`. On macOS/virtual-CAN dev environments, `POST /api/can-tools/inject` failed with `[Errno 43] Protocol not supported` even though the rest of the backend ran fine on the virtual bus.
- Now resolves `bustype` and `bitrate` from `get_can_settings()`, matching how `MultiNetworkManager._initialize_network_bus` constructs buses.

## Verification
Started the backend with `COACHIQ_CAN__BUSTYPE=virtual COACHIQ_CAN__INTERFACES=virtual0 COACHIQ_AUTH__ENABLED=false` and POSTed `/api/can-tools/inject` with interface `virtual0`:

```json
{"success": true, "messages_sent": 1, "messages_failed": 0, "success_rate": 100.0}
```

`/api/can-tools/status` confirmed `total_injected: 1`, `active_interfaces: ["virtual0"]`. Injector-adjacent tests pass (`test_can_facade.py`, `test_can_facade_guardrails.py`, `test_composition_root_order.py` — 24 passed); no new ruff findings on changed lines and `ruff format` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)