### PR TITLE
fix(security): persist CAN injection audit records

### DIFF
--- a/backend/core/composition_root.py
+++ b/backend/core/composition_root.py
@@ -1099,7 +1099,7 @@ class CompositionRoot:
 
             async def audit_injection(request: Any, result: Any) -> None:
                 security_audit = self.get_optional_service("security_audit_service")
-                if security_audit and hasattr(security_audit, "log_injection"):
+                if security_audit:
                     await security_audit.log_injection(request, result)
 
             can_message_injector = CANMessageInjector(

--- a/backend/services/security/security_audit_service.py
+++ b/backend/services/security/security_audit_service.py
@@ -25,7 +25,7 @@ from collections import defaultdict, deque
 from datetime import UTC, datetime
 from enum import Enum
 from ipaddress import ip_address, ip_network
-from typing import Any, Dict, List, Optional, Set
+from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, Field
 
@@ -33,6 +33,9 @@ from backend.core.performance import PerformanceMonitor
 from backend.models.audit_events import AuditEventType as EnhancedAuditEventType
 from backend.models.audit_events import StructuredAuditEvent
 from backend.repositories.security_audit_repository import SecurityAuditRepository
+
+if TYPE_CHECKING:
+    from backend.integrations.can.message_injector import InjectionRequest, InjectionResult
 
 logger = logging.getLogger(__name__)
 
@@ -64,6 +67,9 @@ class SecurityEventType(str, Enum):
     ENTITY_CONTROL_FAILURE = "entity_control_failure"
     BULK_OPERATION_STARTED = "bulk_operation_started"
     BULK_OPERATION_COMPLETED = "bulk_operation_completed"
+
+    # CAN Bus Events
+    CAN_MESSAGE_INJECTION = "can_message_injection"
 
     # Security Threats
     RATE_LIMIT_EXCEEDED = "rate_limit_exceeded"
@@ -295,6 +301,47 @@ class SecurityAuditService:
 
         return event_id
 
+    async def log_injection(self, request: "InjectionRequest", result: "InjectionResult") -> str:
+        """
+        Log a CAN message injection audit event.
+
+        Invoked via CANMessageInjector's audit callback for every injection
+        attempt, including the synthetic record emitted on command halt.
+
+        Args:
+            request: The injection request that was executed
+            result: The outcome of the injection
+
+        Returns:
+            str: Event ID
+        """
+        severity = (
+            SecurityEventSeverity.MEDIUM
+            if result.success and not result.warnings
+            else SecurityEventSeverity.HIGH
+        )
+
+        return await self.log_security_event(
+            event_type=SecurityEventType.CAN_MESSAGE_INJECTION,
+            severity=severity,
+            user_id=request.user,
+            details={
+                "can_id": f"0x{request.can_id:X}",
+                "data": request.data.hex(),
+                "interface": request.interface,
+                "mode": request.mode.value,
+                "count": request.count,
+                "description": request.description,
+                "reason": request.reason,
+                "success": result.success,
+                "messages_sent": result.messages_sent,
+                "messages_failed": result.messages_failed,
+                "duration_seconds": result.duration,
+                "error": result.error,
+                "warnings": list(result.warnings),
+            },
+        )
+
     async def log_structured_event(self, event: StructuredAuditEvent) -> str:
         """
         Log a structured audit event following OWASP ASVS V7 guidelines.
@@ -377,6 +424,8 @@ class SecurityAuditService:
             return "critical_safety_action"
         if event_type == SecurityEventType.SAFETY_INTERLOCK_VIOLATED:
             return "safety_constraint_violated"
+        if event_type == SecurityEventType.CAN_MESSAGE_INJECTION:
+            return "direct_can_bus_write"
         if event_type in [
             SecurityEventType.ENTITY_CONTROL_SUCCESS,
             SecurityEventType.ENTITY_CONTROL_FAILURE,

--- a/scripts/ci-quality-gate.sh
+++ b/scripts/ci-quality-gate.sh
@@ -19,7 +19,7 @@ RESET="\033[0m"
 # gate's job is to stop the count from going UP (a ratchet); fixing actual
 # pyright errors lower the count and the script will print a green message
 # nudging you to update the baseline downward.
-EXPECTED_PYRIGHT_ERRORS=1204  # Ratcheted 2026-07-11: backend contract and realtime-state cleanup (1207 -> 1204; Linux CI verified).
+EXPECTED_PYRIGHT_ERRORS=1200  # Ratcheted 2026-07-12: security_audit_service unused-import cleanup (1204 -> 1200; verify against Linux CI's printed count).
 EXPECTED_FRONTEND_TS_ERRORS=0  # Ratcheted 2026-05-12 to 0 by PR #110 (DatabaseManagementTab + can-sniffer + useCANScanWebSocket generic). Any new TS error is a hard fail.
 EXPECTED_FRONTEND_ESLINT_ERRORS=216  # Ratcheted 2026-07-11: session cache cleanup lint fixes (219 -> 216).
 

--- a/tests/integrations/can/test_message_injector_audit.py
+++ b/tests/integrations/can/test_message_injector_audit.py
@@ -1,0 +1,156 @@
+"""Tests for CAN message injection audit logging.
+
+Regression coverage for the silent audit no-op: the composition root wires an
+async audit callback into CANMessageInjector, so the injector must await it,
+and SecurityAuditService must expose log_injection for the callback to call.
+"""
+
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from backend.integrations.can.message_injector import (
+    CANMessageInjector,
+    InjectionMode,
+    InjectionRequest,
+    InjectionResult,
+    SafetyLevel,
+)
+from backend.services.security.security_audit_service import (
+    SecurityAuditService,
+    SecurityEventSeverity,
+    SecurityEventType,
+)
+
+pytestmark = pytest.mark.can
+
+
+def _request(**overrides) -> InjectionRequest:
+    defaults = {
+        "can_id": 0x18FEF100,
+        "data": b"\x01\x02",
+        "interface": "can1",
+        "mode": InjectionMode.SINGLE,
+        "user": "test-user",
+        "reason": "unit test",
+    }
+    defaults.update(overrides)
+    return InjectionRequest(**defaults)
+
+
+class TestRunAuditCallback:
+    """The injector must await async callbacks (the composition root passes one)."""
+
+    @pytest.mark.asyncio
+    async def test_awaits_async_callback(self):
+        calls = []
+
+        async def audit_callback(request, result):
+            calls.append((request, result))
+
+        injector = CANMessageInjector(
+            safety_level=SafetyLevel.MODERATE, audit_callback=audit_callback
+        )
+        request = _request()
+        result = InjectionResult(success=True, messages_sent=1)
+
+        await injector._run_audit_callback(request, result)
+
+        assert calls == [(request, result)]
+
+    @pytest.mark.asyncio
+    async def test_supports_sync_callback(self):
+        callback = Mock(return_value=None)
+        injector = CANMessageInjector(safety_level=SafetyLevel.MODERATE, audit_callback=callback)
+        request = _request()
+        result = InjectionResult(success=True, messages_sent=1)
+
+        await injector._run_audit_callback(request, result)
+
+        callback.assert_called_once_with(request, result)
+
+    @pytest.mark.asyncio
+    async def test_callback_error_does_not_propagate(self):
+        async def audit_callback(request, result):
+            raise RuntimeError("audit store down")
+
+        injector = CANMessageInjector(
+            safety_level=SafetyLevel.MODERATE, audit_callback=audit_callback
+        )
+
+        await injector._run_audit_callback(_request(), InjectionResult(success=True))
+
+    @pytest.mark.asyncio
+    async def test_command_halt_emits_audit_record(self):
+        calls = []
+
+        async def audit_callback(request, result):
+            calls.append((request, result))
+
+        injector = CANMessageInjector(
+            safety_level=SafetyLevel.MODERATE, audit_callback=audit_callback
+        )
+
+        await injector.halt_command_emission("test halt")
+
+        assert len(calls) == 1
+        halt_request, halt_result = calls[0]
+        assert halt_request.user == "SYSTEM"
+        assert "COMMAND_HALT" in halt_request.reason
+        assert halt_result.success is True
+
+
+class TestLogInjection:
+    """SecurityAuditService.log_injection persists injection audit events."""
+
+    def _service(self) -> tuple[SecurityAuditService, AsyncMock]:
+        repository = AsyncMock()
+        monitor = Mock()
+        monitor.monitor_service_method.return_value = lambda func: func
+        service = SecurityAuditService(
+            security_audit_repository=repository, performance_monitor=monitor
+        )
+        return service, repository
+
+    @pytest.mark.asyncio
+    async def test_persists_audit_event(self):
+        service, repository = self._service()
+        request = _request()
+        result = InjectionResult(success=True, messages_sent=1)
+
+        event_id = await service.log_injection(request, result)
+
+        assert event_id
+        repository.store_audit_event.assert_awaited_once()
+        event = repository.store_audit_event.await_args.args[0]
+        assert event.event_type == SecurityEventType.CAN_MESSAGE_INJECTION
+        assert event.severity == SecurityEventSeverity.MEDIUM
+        assert event.user_id == "test-user"
+        assert event.safety_impact == "direct_can_bus_write"
+        assert event.details["can_id"] == "0x18FEF100"
+        assert event.details["data"] == "0102"
+        assert event.details["interface"] == "can1"
+        assert event.details["messages_sent"] == 1
+
+    @pytest.mark.asyncio
+    async def test_failed_injection_logged_high_severity(self):
+        service, repository = self._service()
+        result = InjectionResult(success=False, messages_failed=1, error="bus off")
+
+        await service.log_injection(_request(), result)
+
+        event = repository.store_audit_event.await_args.args[0]
+        assert event.severity == SecurityEventSeverity.HIGH
+        assert event.details["success"] is False
+        assert event.details["error"] == "bus off"
+
+    @pytest.mark.asyncio
+    async def test_injection_with_warnings_logged_high_severity(self):
+        service, repository = self._service()
+        result = InjectionResult(success=True, messages_sent=1, warnings=["dangerous message"])
+
+        await service.log_injection(_request(), result)
+
+        event = repository.store_audit_event.await_args.args[0]
+        assert event.severity == SecurityEventSeverity.HIGH
+        assert event.details["warnings"] == ["dangerous message"]


### PR DESCRIPTION
## Summary
- `SecurityAuditService.log_injection` never existed, so the composition root's `hasattr` guard silently dropped every CAN injection audit record — the callback was a permanent no-op. This implements the method and removes the guard.
- New `SecurityEventType.CAN_MESSAGE_INJECTION` event persists user, CAN ID, data hex, interface, mode, reason, sent/failed counts, duration, error, and warnings via the standard `log_security_event` path. Severity is MEDIUM for clean sends, HIGH for failures or injections that tripped safety warnings; safety impact tagged `direct_can_bus_write`.
- Complements #239 (which made the injector await async audit callbacks) — together the audit trail now actually records injections, including the synthetic command-halt record.
- Cleans four unused `typing` imports on the touched line and ratchets `EXPECTED_PYRIGHT_ERRORS` 1204 → 1200 (trust CI's printed count if it lands elsewhere).

## Test plan
- [x] New `tests/integrations/can/test_message_injector_audit.py` (7 tests, `pytest.mark.can`): async/sync callback handling, error containment, command-halt audit record, event persistence and severity mapping
- [x] Related suites pass with no new failures (facade guardrails, composition-root order, pin security — 13 pre-existing local-baseline errors reproduce identically on unmodified code)
- [x] Zero new ruff findings on changed lines; pyright errors on touched files 9 → 5, none introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)